### PR TITLE
Add success pages for Scan and Page requests

### DIFF
--- a/app/assets/stylesheets/modules/success.scss
+++ b/app/assets/stylesheets/modules/success.scss
@@ -1,0 +1,7 @@
+.success-page {
+  h1 {
+    .glyphicon-ok {
+      color: $dark-cyan;
+    }
+  }
+}

--- a/app/assets/stylesheets/sul-requests.scss
+++ b/app/assets/stylesheets/sul-requests.scss
@@ -9,5 +9,6 @@
 @import 'modules/forms';
 @import 'modules/home-page';
 @import 'modules/scan-or-deliver';
+@import 'modules/success';
 @import 'modules/sul-footer';
 @import 'modules/top-navbar';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,10 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user
 
+  def current_ability
+    @current_ability ||= Ability.new(current_user, params[:token])
+  end
+
   private
 
   def rescue_can_can(exception)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,8 +8,11 @@ class PagesController < RequestsController
 
   def create
     if @page.update(create_params_with_current_user)
-      flash[:success] = 'Request was successfully created.'
-      redirect_to root_path
+      if current_user.webauth_user?
+        redirect_to successfull_page_path(@page)
+      else
+        redirect_to successfull_page_path(@page, token: @page.encrypted_token)
+      end
     else
       flash[:error] = 'There was a problem creating your request.'
       render 'new'

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -8,9 +8,8 @@ class ScansController < RequestsController
   end
 
   def create
-    if @scan.update(create_params)
-      flash[:success] = 'Scan request was successfully created.'
-      redirect_to root_url
+    if @scan.update(create_params.merge(user_id: current_user.id))
+      redirect_to successfull_scan_path(@scan)
     else
       flash[:error] = 'There was a problem creating your scan request.'
       render 'new'

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -8,19 +8,27 @@ module RequestsHelper
     select_for_multiple_libraries(form, pickup_libraries) || single_library_markup(form, pickup_libraries.first)
   end
 
+  def label_for_pickup_libraries_dropdown(pickup_libraries)
+    if pickup_libraries.many?
+      'Deliver to'
+    else
+      'Must be used in'
+    end
+  end
+
   private
 
   def select_for_multiple_libraries(form, pickup_libraries)
     return unless pickup_libraries.keys.length > 1
     form.select :destination,
                 pickup_libraries_array(pickup_libraries),
-                label: 'Deliver to'
+                label: label_for_pickup_libraries_dropdown(pickup_libraries)
   end
 
   def single_library_markup(form, library)
     <<-HTML
       <div class='form-group'>
-        <div class='#{label_column_class} control-label'>Must be used in</div>
+        <div class='#{label_column_class} control-label'>#{label_for_pickup_libraries_dropdown([])}</div>
         <div class='#{content_column_class} input-like-text'>#{library.last}</div>
         #{form.hidden_field :destination, value: library.first}
       </div>

--- a/app/models/concerns/token_encryptable.rb
+++ b/app/models/concerns/token_encryptable.rb
@@ -1,0 +1,20 @@
+###
+#  Mixin to handle creating, encyrpting, and decrypting, and validating tokens for objects
+###
+module TokenEncryptable
+  def to_token
+    token_encryptor_attributes.join
+  end
+
+  def token_encryptor_attributes
+    [id, created_at]
+  end
+
+  def encrypted_token
+    @encrypted_token ||= SULRequests::TokenEncryptor.new(to_token).encrypt_and_sign
+  end
+
+  def valid_token?(token)
+    SULRequests::TokenEncryptor.new(token).decrypt_and_verify == to_token
+  end
+end

--- a/app/models/library_location.rb
+++ b/app/models/library_location.rb
@@ -18,6 +18,12 @@ class LibraryLocation
     end
   end
 
+  class << self
+    def library_name_by_code(code)
+      SULRequests::Application.config.libraries[code]
+    end
+  end
+
   private
 
   def all_libraries

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -31,10 +31,11 @@ class Request < ActiveRecord::Base
   # there already is one associated with that email address
   def autosave_associated_records_for_user
     return unless user
-    if (new_user = User.find_by_email(user.email))
-      self.user = new_user
+    if (existing_user = User.find_by_email(user.email))
+      self.user = existing_user
     else
       user.save!
+      self.user = user
     end
   end
 end

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -2,6 +2,12 @@
 #  Request class for making simple page requests
 ###
 class Page < Request
+  include TokenEncryptable
+
+  def token_encryptor_attributes
+    super << user.email
+  end
+
   def commentable?
     return super unless origin == 'SAL-NEWARK'
     true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,14 @@ class User < ActiveRecord::Base
 
   attr_writer :ldap_group_string
 
+  def to_email_string
+    if webauth_user?
+      "#{webauth}@stanford.edu"
+    else
+      "#{name} (#{email})"
+    end
+  end
+
   def webauth_user?
     webauth.present?
   end

--- a/app/views/pages/success.html.erb
+++ b/app/views/pages/success.html.erb
@@ -1,0 +1,15 @@
+<div class='<%= dialog_column_class %> success-page'>
+  <h1 id='dialogTitle'><span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Request complete</h1>
+  <dl class='dl-horizontal'>
+    <% if @page.commentable? && @page.data['comments'].present? %>
+      <dt>Item(s) requested</dt>
+      <dd><%= @page.data['comments'] %></dd>
+    <% end %>
+
+    <dt><%= label_for_pickup_libraries_dropdown(@page.library_location.pickup_libraries) %></dt>
+    <dd><%= LibraryLocation.library_name_by_code(@page.destination) %></dd>
+
+    <dt><span class='sr-only'>User</span></dt>
+    <dd><%= @page.user.to_email_string %></dd>
+  </dl>
+</div>

--- a/app/views/scans/success.html.erb
+++ b/app/views/scans/success.html.erb
@@ -1,0 +1,22 @@
+<div class='<%= dialog_column_class %> success-page'>
+  <h1 id='dialogTitle'><span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Request complete</h1>
+  <dl class='dl-horizontal'>
+    <% if @scan.data.present? %>
+      <% if (page_range = @scan.data['page_range']).present? %>
+        <dt>Page range</dt>
+        <dd><%= page_range %></dd>
+      <% end %>
+      <% if (section_title = @scan.data['section_title']).present? %>
+        <dt>Article title</dt>
+        <dd><%= section_title %></dd>
+      <% end %>
+      <% if (authors = @scan.data['authors']).present? %>
+        <dt>Author(s)</dt>
+        <dd><%= authors %></dd>
+      <% end %>
+    <% end %>
+
+    <dt><span class='sr-only'>User</span></dt>
+    <dd><%= @scan.user.to_email_string %></dd>
+  </dl>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module SULRequests
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Pacific Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module SULRequests
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    require 'token_encryptor'
     # Load all request types automatically
     config.autoload_paths += %W( #{config.root}/app/models/requests )
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,15 @@ Rails.application.routes.draw do
   get 'webauth/login' => 'authorization#login', as: :login
   get 'webauth/logout' => 'authorization#logout', as: :logout
 
+  concern :successable do
+    member do
+      get :success, as: :successfull
+    end
+  end
+
   resources :requests, only: :new
-  resources :pages
-  resources :scans
+  resources :pages, concerns: :successable
+  resources :scans, concerns: :successable
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,7 @@ destination_admin_groups:
   SPEC: []
 
 contact_email: 'someone@stanford.edu'
+
+token_encrypt:
+  secret: ''
+  salt: ''

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,4 @@
+# This is different on any server running under development
+token_encrypt:
+  secret: 'OpCeOjbiQUwyyzoMzjtHnGbgfOthajiUqwbQuXNZRitkkQpvMPHILfcmkvikFcaN'
+  salt: 'dcVNcekAYNIFtggdJXQpSkWHBpBVsVsPiRzCFpWbZGLrQtHKSdMBKIWKmYYIZnkbXuMisFlSkHbUmIimKMbjFMVDpfzyIRLvmLYBUparuPAaxYjPzdmFfRGBGgxfvwOR'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,3 +6,7 @@ origin_admin_groups:
 
 destination_admin_groups:
   FAKE-DESTINATION-LIBRARY: ['FAKE-DESTINATION-LIBRARY-TEST-LDAP-GROUP']
+
+token_encrypt:
+  secret: 'cphNKBJUCUlDeekeQGTmPkinkxAkJKxDsfHailJrKKIzxkSRFHbarXxjYRMdkyKW'
+  salt: 'dGcTBhXrQjsvQkbDQCkAIdogYjzOiIQpjToNLjqyzslKShfTvxIJHmMZhzdNjOqtDZKtxutyHBZmNHKOcGMfHzxwCFeOTBeEHYHNedtrmdfLzHMTRSDJCRMURaAjRrDq'

--- a/lib/token_encryptor.rb
+++ b/lib/token_encryptor.rb
@@ -1,0 +1,52 @@
+module SULRequests
+  ###
+  #  Class to encrypt and decrypt messages using ActiveSupport::MessageEncryptor
+  #  This class requires that a secret and a salt are configured. These two configured
+  #  strings should be of moderate complexity and randomness.
+  #  If these configured keys change they will break any existing tokens given out.
+  #
+  #  Simple Usage:
+  #  encrypted_token = SULRequests::TokenEncryptor.new('abc-123').encrypt_and_sign
+  #  SULRequests::TokenEncryptor.new(encrypted_token).decrypt_and_verify
+  #  => "abc-123"
+  ###
+  class TokenEncryptor
+    def initialize(token)
+      fail InvalidSecret unless secret.present?
+      fail InvalidSalt unless salt.present?
+      @token = token
+    end
+
+    def encrypt_and_sign
+      encryptor.encrypt_and_sign(@token)
+    end
+
+    def decrypt_and_verify
+      encryptor.decrypt_and_verify(@token)
+    end
+
+    private
+
+    def key
+      @key ||= ActiveSupport::KeyGenerator.new(secret).generate_key(salt)
+    end
+
+    def encryptor
+      @encryptor ||= ActiveSupport::MessageEncryptor.new(key)
+    end
+
+    def secret
+      Settings.token_encrypt['secret']
+    end
+
+    def salt
+      Settings.token_encrypt['salt']
+    end
+
+    class InvalidSecret < StandardError
+    end
+
+    class InvalidSalt < StandardError
+    end
+  end
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -30,21 +30,25 @@ describe PagesController do
           login_path(referrer: new_page_path(origin: 'GREEN'))
         )
       end
-      it 'should be allowed if user name and email is filled out' do
+      it 'should be allowed if user name and email is filled out (via token)' do
         put :create, page: {
+          item_id: '1234',
           origin: 'GREEN',
+          origin_location: 'STACKS',
           user_attributes: { name: 'Jane Stanford', email: 'jstanford@stanford.edu' }
         }
-        expect(response).to be_success
+
+        expect(response.location).to match(/#{successfull_page_url(Page.last)}\?token=/)
+        expect(Page.last.user).to eq User.last
       end
     end
     describe 'by webauth users' do
-      let(:user) { User.new(webauth: 'some-user') }
+      let(:user) { User.create(webauth: 'some-user') }
       it 'should be allowed' do
         put :create, page: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS' }
-        expect(flash[:success]).to eq 'Request was successfully created.'
-        expect(response).to redirect_to root_url
+        expect(response).to redirect_to successfull_page_path(Page.last)
         expect(Page.last.origin).to eq 'GREEN'
+        expect(Page.last.user).to eq user
       end
     end
     describe 'invalid requests' do

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -35,14 +35,17 @@ describe ScansController do
     end
     describe 'by non-webauth users' do
       let(:user) { User.new(name: 'Jane Stanford', email: 'jstanford@stanford.edu') }
+      it 'should raise an error' do
+        expect(-> { put(:create, scan: { origin: 'SAL3' }) }).to raise_error(CanCan::AccessDenied)
+      end
     end
     describe 'by webauth users' do
-      let(:user) { User.new(webauth: 'some-user') }
+      let(:user) { User.create(webauth: 'some-user') }
       it 'should be allowed' do
         put :create, scan: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS' }
-        expect(flash[:success]).to eq 'Scan request was successfully created.'
-        expect(response).to redirect_to root_url
+        expect(response).to redirect_to successfull_scan_path(Scan.last)
         expect(Scan.last.origin).to eq 'SAL3'
+        expect(Scan.last.user).to eq user
       end
     end
     describe 'invalid requests' do

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -11,7 +11,7 @@ describe 'Creating a page request' do
 
       click_button 'Send request'
 
-      expect(page).to have_css('.alert-success', text: /Request was successfully created/)
+      expect(page).to have_css('h1#dialogTitle', text: 'Request complete')
     end
   end
   describe 'by a webauth user' do
@@ -20,7 +20,8 @@ describe 'Creating a page request' do
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
       click_button 'Send request'
 
-      expect(page).to have_css('.alert-success', text: /Request was successfully created/)
+      expect(current_url).to eq successfull_page_url(Page.last)
+      expect(page).to have_css('h1#dialogTitle', text: 'Request complete')
     end
   end
   describe 'comments' do
@@ -33,7 +34,7 @@ describe 'Creating a page request' do
 
       click_button 'Send request'
 
-      expect(page).to have_css('.alert-success', text: /Request was successfully created/)
+      expect(page).to have_css('h1#dialogTitle', text: 'Request complete')
 
       expect(Page.last.data['comments']).to eq comment
     end

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -17,7 +17,7 @@ describe 'Create Scan Request' do
 
       click_button 'Send request'
 
-      expect(page).to have_css('.alert-success', text: 'Scan request was successfully created.')
+      expect(page).to have_css('h1#dialogTitle', 'Request complete')
 
       scan = Scan.last
       expect(scan.item_id).to eq '1234'

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -29,4 +29,12 @@ describe RequestsHelper do
       end
     end
   end
+  describe '#label_for_pickup_libraries_dropdown' do
+    it 'should be "Deliver to" when if there are mutliple possiblities' do
+      expect(label_for_pickup_libraries_dropdown(%w(GREEN MUSIC))).to eq 'Deliver to'
+    end
+    it 'should be "Must be used in" when there is only one possibility' do
+      expect(label_for_pickup_libraries_dropdown(['GREEN'])).to eq 'Must be used in'
+    end
+  end
 end

--- a/spec/lib/token_encryptor_spec.rb
+++ b/spec/lib/token_encryptor_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe SULRequests::TokenEncryptor do
+  let(:token) { 'token-123' }
+  let(:subject) { SULRequests::TokenEncryptor }
+  it 'should throw an error if there is no configured secret' do
+    allow_any_instance_of(subject).to receive(:secret).and_return('')
+    expect(-> { subject.new(token) }).to raise_error(SULRequests::TokenEncryptor::InvalidSecret)
+  end
+  it 'should throw an error if there is no configured salt' do
+    allow_any_instance_of(subject).to receive(:salt).and_return('')
+    expect(-> { subject.new(token) }).to raise_error(SULRequests::TokenEncryptor::InvalidSalt)
+  end
+  describe '#encrypt_and_sign' do
+    it 'should return an encyrpted and signed message' do
+      expect(subject.new(token).encrypt_and_sign).to include '==--'
+      expect(subject.new(token).encrypt_and_sign.length).to be > token.length
+    end
+  end
+  describe '#decrypt_and_verify' do
+    let(:encrypted_token) { subject.new(token).encrypt_and_sign }
+    it 'should decrypt and verify encrypted and signed messages' do
+      expect(subject.new(encrypted_token).decrypt_and_verify).to eq token
+    end
+    it 'should raise an error if the token is not valid' do
+      expect(
+        -> { subject.new("1#{encrypted_token}").decrypt_and_verify }
+      ).to raise_error(ActiveSupport::MessageVerifier::InvalidSignature)
+    end
+  end
+end

--- a/spec/models/concerns/token_encryptable_spec.rb
+++ b/spec/models/concerns/token_encryptable_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+###
+#  Simple test class for testing methods mixed-in by TokenEncryptable
+###
+class TestEncryptorClass
+  attr_accessor :id, :created_at, :new_attribute
+  include TokenEncryptable
+  def token_encryptor_attributes
+    super << new_attribute
+  end
+end
+
+describe TokenEncryptable do
+  let(:subject) { TestEncryptorClass.new }
+  before do
+    subject.id = '123'
+    subject.created_at = 'now'
+  end
+  describe 'to_token' do
+    it 'should include id and created_at by default' do
+      expect(subject.to_token).to eq '123now'
+    end
+    it 'shuold include attributes added by the class that is mixing in' do
+      subject.new_attribute = 'my_new_attr'
+      expect(subject.to_token).to eq '123nowmy_new_attr'
+    end
+  end
+  describe 'token encryption' do
+    let(:token) { subject.to_token }
+    let(:encrypted_token) { subject.encrypted_token }
+    describe 'encyrption' do
+      it 'should return an encrypted_token longer than the original' do
+        expect(encrypted_token.length).to be > token.length
+      end
+      it 'should be able to verify that a given encrypted token is valid' do
+        expect(subject).to be_valid_token(encrypted_token)
+      end
+      it 'should raise an error when passed an invalid encrypted token' do
+        expect(-> { subject.valid_token?(token) }).to raise_error(ActiveSupport::MessageVerifier::InvalidSignature)
+      end
+    end
+  end
+end

--- a/spec/models/library_location_spec.rb
+++ b/spec/models/library_location_spec.rb
@@ -19,4 +19,13 @@ describe LibraryLocation do
       expect(LibraryLocation.new(request).pickup_libraries).to eq('MUSIC' => 'Music Library')
     end
   end
+  describe '#library_name_by_code' do
+    it 'should return the configured library\'s name' do
+      expect(LibraryLocation.library_name_by_code('GREEN')).to eq 'Green Library'
+      expect(LibraryLocation.library_name_by_code('SAL3')).to eq 'SAL3 (off-campus storage)'
+    end
+    it 'should return nil when there is no configured library' do
+      expect(LibraryLocation.library_name_by_code('NOT-A-LIBRARY')).to be_nil
+    end
+  end
 end

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe Page do
+  describe 'TokenEncryptable' do
+    it 'should mixin TokenEncryptable' do
+      expect(subject).to be_kind_of TokenEncryptable
+    end
+    it 'should add the user email address to the token' do
+      subject.user = User.new(email: 'jstanford@stanford.edu')
+      expect(subject.to_token).to match(/jstanford@stanford.edu$/)
+    end
+  end
+
   describe '#commentable?' do
     it 'should be false if the library is not a commentable library' do
       expect(subject).to_not be_commentable

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,21 @@ describe User do
       ).to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+  describe '#to_email_string' do
+    describe 'for webauth users' do
+      it 'should be their Stanford email address' do
+        subject.webauth = 'jstanford'
+        expect(subject.to_email_string).to eq 'jstanford@stanford.edu'
+      end
+    end
+    describe 'for non-webauth users' do
+      it 'should be their name plus their email in parenthesis' do
+        subject.name = 'Jane Stanford'
+        subject.email = 'jstanford@stanford.edu'
+        expect(subject.to_email_string).to eq 'Jane Stanford (jstanford@stanford.edu)'
+      end
+    end
+  end
   describe '#webauth_user?' do
     it 'should return false when the user has no WebAuth attribute' do
       expect(subject).to_not be_webauth_user

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,5 +72,7 @@ RSpec.configure do |config|
 end
 
 def stub_current_user(user = 'some-user')
-  allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(User.new(webauth: user))
+  allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(
+    User.find_or_create_by(webauth: user)
+  )
 end

--- a/spec/views/pages/success.html.erb_spec.rb
+++ b/spec/views/pages/success.html.erb_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'pages/success.html.erb' do
+  let(:page) { Page.new }
+  let(:user) { User.new }
+  before do
+    assign(:page, page)
+    allow(page).to receive_messages(user: user)
+    allow(view).to receive_messages(current_user: user)
+  end
+  it 'should have an icon and h1 heading' do
+    render
+    expect(rendered).to have_css('.glyphicon.glyphicon-ok[aria-hidden="true"]')
+    expect(rendered).to have_css('h1', text: 'Request complete')
+  end
+  describe 'metadata' do
+    let(:page) { Page.new(origin: 'SAL-NEWARK', destination: 'GREEN', data: { 'comments' => 'I want this item!' }) }
+    before { render }
+    it 'should have the destination library' do
+      expect(rendered).to have_css('dt', text: 'Deliver to')
+      expect(rendered).to have_css('dd', text: 'Green Library')
+    end
+    it 'should have a comments section' do
+      expect(rendered).to have_css('dt', text: 'Item(s) requested')
+      expect(rendered).to have_css('dd', text: 'I want this item!')
+    end
+  end
+  describe 'user information' do
+    describe 'for webauth users' do
+      let(:user) { User.new(webauth: 'somebody') }
+      it 'should give their stanford-email address' do
+        render
+        expect(rendered).to have_css('dd', text: 'somebody@stanford.edu')
+      end
+    end
+    describe 'for non-webauth useres' do
+      let(:user) { User.new(name: 'Jane Stanford', email: 'jstanford@stanford.edu') }
+      it 'should give their name and email (in parens)' do
+        render
+        expect(rendered).to have_css('dd', text: 'Jane Stanford (jstanford@stanford.edu)')
+      end
+    end
+  end
+end

--- a/spec/views/scans/success.html.erb_spec.rb
+++ b/spec/views/scans/success.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe 'scans/success.html.erb' do
+  let(:scan) { Scan.new }
+  let(:user) { User.new }
+  before do
+    assign(:scan, scan)
+    allow(scan).to receive_messages(user: user)
+    allow(view).to receive_messages(current_user: user)
+  end
+  it 'should have an icon and h1 heading' do
+    render
+    expect(rendered).to have_css('.glyphicon.glyphicon-ok[aria-hidden="true"]')
+    expect(rendered).to have_css('h1', text: 'Request complete')
+  end
+  describe 'metadata' do
+    let(:scan) do
+      Scan.new(
+        data: { 'page_range' => 'Range-123', 'section_title' => 'Section-123', 'authors' => 'Author-123' }
+      )
+    end
+    before { render }
+    it 'should have the page range' do
+      expect(rendered).to have_css('dt', text: 'Page range')
+      expect(rendered).to have_css('dd', text: 'Range-123')
+    end
+    it 'should have a section title' do
+      expect(rendered).to have_css('dt', text: 'Article title')
+      expect(rendered).to have_css('dd', text: 'Section-123')
+    end
+    it 'should have a section title' do
+      expect(rendered).to have_css('dt', text: 'Author(s)')
+      expect(rendered).to have_css('dd', text: 'Author-123')
+    end
+  end
+  describe 'user information' do
+    describe 'for webauth users' do
+      let(:user) { User.new(webauth: 'somebody') }
+      it 'should give their stanford-email address' do
+        render
+        expect(rendered).to have_css('dd', text: 'somebody@stanford.edu')
+      end
+    end
+    describe 'for non-webauth useres' do
+      let(:user) { User.new(name: 'Jane Stanford', email: 'jstanford@stanford.edu') }
+      it 'should give their name and email (in parens)' do
+        render
+        expect(rendered).to have_css('dd', text: 'Jane Stanford (jstanford@stanford.edu)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #58 

This PR adds a token encryption/decryption method that we can also use for allowing users who supplied only a Library ID or Name/Email to view the request given a URL including the encrypted token.

## Scan Request
![webauth-scan](https://cloud.githubusercontent.com/assets/96776/7311315/bd0eab5a-e9ef-11e4-8b09-a20c1842d074.png)

## Page Request
![anon-page](https://cloud.githubusercontent.com/assets/96776/7311314/bd0e9cc8-e9ef-11e4-8b06-783cb38741ed.png)
