### PR TITLE
Allow scans and pages to create requests after a webauth login redirect.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -32,8 +32,8 @@ class PagesController < RequestsController
   protected
 
   def rescue_can_can(*)
-    if params[:action].to_sym == :create && !current_user.webauth_user?
-      redirect_to login_path(referrer: new_page_path(params[:page].except(:user_attributes)))
+    if !current_user.webauth_user? && create_via_post?
+      redirect_to login_path(referrer: create_pages_path(page: params[:page].except(:user_attributes)))
     else
       super
     end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -29,4 +29,8 @@ class RequestsController < ApplicationController
     request.item_id = params[:item_id]
     request.origin_location = params[:origin_location]
   end
+
+  def create_via_post?
+    params[:action].to_sym == :create && request.post?
+  end
 end

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -32,6 +32,14 @@ class ScansController < RequestsController
     fail UnscannableItemError unless @scan.scannable?
   end
 
+  def rescue_can_can(*)
+    if !current_user.webauth_user? && create_via_post?
+      redirect_to login_path(referrer: create_scans_path(scan: params[:scan].except(:user_attributes)))
+    else
+      super
+    end
+  end
+
   def create_params
     params.require(:scan).permit(:item_id,
                                  :origin,

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -31,11 +31,20 @@ class Request < ActiveRecord::Base
   # there already is one associated with that email address
   def autosave_associated_records_for_user
     return unless user
-    if (existing_user = User.find_by_email(user.email))
+    if (existing_user = find_existing_user)
       self.user = existing_user
     else
       user.save!
       self.user = user
+    end
+  end
+
+  def find_existing_user
+    return unless user
+    if user.webauth_user?
+      User.find_by_webauth(user.webauth)
+    elsif user.non_webauth_user?
+      User.find_by_email(user.email)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,12 @@ Rails.application.routes.draw do
   get 'webauth/login' => 'authorization#login', as: :login
   get 'webauth/logout' => 'authorization#logout', as: :logout
 
+  concern :creatable_via_get_redirect do
+    collection do
+      get 'create', as: :create
+    end
+  end
+
   concern :successable do
     member do
       get :success, as: :successfull
@@ -16,8 +22,8 @@ Rails.application.routes.draw do
   end
 
   resources :requests, only: :new
-  resources :pages, concerns: :successable
-  resources :scans, concerns: :successable
+  resources :pages, concerns: [:creatable_via_get_redirect, :successable]
+  resources :scans, concerns: [:creatable_via_get_redirect, :successable]
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -24,10 +24,14 @@ describe PagesController do
   describe 'create' do
     describe 'by anonymous users' do
       let(:user) { User.new }
-      it 'should redirect to login if no user information is filled out' do
-        put :create, page: { origin: 'GREEN' }
+      it 'should redirect to the login page passing a refferrer param to continue creating the page request' do
+        post :create, page: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS' }
         expect(response).to redirect_to(
-          login_path(referrer: new_page_path(origin: 'GREEN'))
+          login_path(
+            referrer: create_pages_path(
+              page: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS' }
+            )
+          )
         )
       end
       it 'should be allowed if user name and email is filled out (via token)' do
@@ -41,11 +45,18 @@ describe PagesController do
         expect(response.location).to match(/#{successfull_page_url(Page.last)}\?token=/)
         expect(Page.last.user).to eq User.last
       end
+      describe 'via get' do
+        it 'should raise an error' do
+          expect(
+            -> { get :create, page: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS' } }
+          ).to raise_error(CanCan::AccessDenied)
+        end
+      end
     end
     describe 'by webauth users' do
       let(:user) { User.create(webauth: 'some-user') }
       it 'should be allowed' do
-        put :create, page: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS' }
+        post :create, page: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS' }
         expect(response).to redirect_to successfull_page_path(Page.last)
         expect(Page.last.origin).to eq 'GREEN'
         expect(Page.last.user).to eq user
@@ -54,7 +65,7 @@ describe PagesController do
     describe 'invalid requests' do
       let(:user) { User.new(webauth: 'some-user') }
       it 'should return an error message to the user' do
-        put :create, page: { item_id: '1234' }
+        post :create, page: { item_id: '1234' }
         expect(flash[:error]).to eq 'There was a problem creating your request.'
         expect(response).to render_template 'new'
       end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -40,6 +40,17 @@ describe Request do
   end
   describe 'nested attributes for' do
     describe 'users' do
+      it 'should handle webauth users (w/o emails) correctly' do
+        User.create!(webauth: 'a-webauth-user')
+        webauth_user = User.new(webauth: 'current-webauth-user')
+        allow_any_instance_of(Request).to receive_messages(user: webauth_user)
+        Request.create!(
+          item_id: '1234',
+          origin: 'GREEN',
+          origin_location: 'STACKS'
+        )
+        expect(Request.last.user).to eq User.last
+      end
       it 'should create new users' do
         expect(User.find_by_email('jstanford@stanford.edu')).to be_nil
         Request.create(


### PR DESCRIPTION
Closes #56 

![submit-after-login](https://cloud.githubusercontent.com/assets/96776/7327528/aed27628-ea82-11e4-9997-f359c60b2f67.gif)
