### PR TITLE
Store and display the SearchWorks item's title

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -10,6 +10,10 @@ class Request < ActiveRecord::Base
   belongs_to :user, autosave: true
   accepts_nested_attributes_for :user
 
+  before_create do
+    self.item_title ||= searchworks_item.title
+  end
+
   def new_request?
     status.present?
   end

--- a/app/views/pages/_searchworks_item_information.html.erb
+++ b/app/views/pages/_searchworks_item_information.html.erb
@@ -1,0 +1,7 @@
+<h2>
+  <% if @page.persisted? %>
+    <%= @page.item_title %>
+  <% else %>
+    <%= @page.searchworks_item.title %>
+  <% end %>
+</h2>

--- a/app/views/pages/success.html.erb
+++ b/app/views/pages/success.html.erb
@@ -1,5 +1,6 @@
 <div class='<%= dialog_column_class %> success-page'>
   <h1 id='dialogTitle'><span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Request complete</h1>
+  <%= render 'searchworks_item_information' %>
   <dl class='dl-horizontal'>
     <% if @page.commentable? && @page.data['comments'].present? %>
       <dt>Item(s) requested</dt>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -1,5 +1,6 @@
 <div class='<%= dialog_column_class %>'>
   <%= render 'header' %>
   <%= render 'form_flashes' %>
+  <%= render 'searchworks_item_information' %>
   <%= render 'form' %>
 </div>

--- a/app/views/scans/_searchworks_item_information.html.erb
+++ b/app/views/scans/_searchworks_item_information.html.erb
@@ -1,0 +1,7 @@
+<h2>
+  <% if @scan.persisted? %>
+    <%= @scan.item_title %>
+  <% else %>
+    <%= @scan.searchworks_item.title %>
+  <% end %>
+</h2>

--- a/app/views/scans/success.html.erb
+++ b/app/views/scans/success.html.erb
@@ -1,5 +1,6 @@
 <div class='<%= dialog_column_class %> success-page'>
   <h1 id='dialogTitle'><span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Request complete</h1>
+  <%= render 'searchworks_item_information' %>
   <dl class='dl-horizontal'>
     <% if @scan.data.present? %>
       <% if (page_range = @scan.data['page_range']).present? %>

--- a/db/migrate/20150428230734_add_item_title_to_requests.rb
+++ b/db/migrate/20150428230734_add_item_title_to_requests.rb
@@ -1,0 +1,5 @@
+class AddItemTitleToRequests < ActiveRecord::Migration
+  def change
+    add_column :requests, :item_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150420165058) do
+ActiveRecord::Schema.define(version: 20150428230734) do
 
   create_table "requests", force: :cascade do |t|
     t.string   "type"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20150420165058) do
     t.string   "item_id"
     t.integer  "user_id"
     t.text     "data"
+    t.string   "item_title"
   end
 
   add_index "requests", ["user_id"], name: "index_requests_on_user_id"

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     item_id '1234'
     origin 'GREEN'
     origin_location 'STACKS'
+    item_title 'Title for Page 1234'
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     item_id '12345'
     origin 'BIOLOGY'
     origin_location 'STACKS'
+    item_title 'Title for Request 12345'
   end
 end

--- a/spec/factories/scans.rb
+++ b/spec/factories/scans.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     item_id '1234'
     origin 'SAL3'
     origin_location 'STACKS'
+    item_title 'Title for Scan 1234'
   end
 end

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 describe 'Creating a page request' do
   let(:user) { create(:webauth_user) }
+  describe 'item information' do
+    it 'should display the items title' do
+      visit new_page_path(item_id: '2824966', origin: 'GREEN', origin_location: 'STACKS')
+    end
+  end
   describe 'by an anonmyous user' do
     it 'should be possible if a name and email is filled out', js: true do
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -86,6 +86,16 @@ describe Request do
       end
     end
   end
+  describe 'item_title' do
+    it 'should fetch the item title on object creation' do
+      Request.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'STACKS')
+      expect(Request.last.item_title).to eq 'When do you need an antacid? : a burning question'
+    end
+    it 'should not fetch the title when it is already present' do
+      Request.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'STACKS', item_title: 'This title')
+      expect(Request.last.item_title).to eq 'This title'
+    end
+  end
   describe '#data' do
     it 'should be a serialized hash' do
       data_hash = { a: :a, b: :b }

--- a/spec/views/pages/_searchworks_item_informatin.html.erb_spec.rb
+++ b/spec/views/pages/_searchworks_item_informatin.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'pages/_searchworks_item_information.html.erb' do
+  before do
+    assign(:page, page)
+    render
+  end
+  describe 'persisted pages' do
+    let(:page) { create(:page) }
+    it 'should display the stored item title in an h2' do
+      expect(Capybara.string(rendered)).to have_css('h2', text: 'Title for Page 1234')
+    end
+  end
+  describe 'non-persisted pages' do
+    let(:page) { Page.new(item_id: '2824966') }
+    it 'should display the API fetched item title in an h2' do
+      expect(Capybara.string(rendered)).to have_css('h2', text: /When do you need an antacid\? : a burning question/)
+    end
+  end
+end

--- a/spec/views/pages/success.html.erb_spec.rb
+++ b/spec/views/pages/success.html.erb_spec.rb
@@ -12,6 +12,10 @@ describe 'pages/success.html.erb' do
     expect(rendered).to have_css('.glyphicon.glyphicon-ok[aria-hidden="true"]')
     expect(rendered).to have_css('h1', text: 'Request complete')
   end
+  it 'should have the title in an h2 heading' do
+    render
+    expect(rendered).to have_css('h2', text: 'Title for Page 1234')
+  end
   describe 'metadata' do
     let(:page) do
       create(

--- a/spec/views/scans/_searchworks_item_information.html.erb_spec.rb
+++ b/spec/views/scans/_searchworks_item_information.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'scans/_searchworks_item_information.html.erb' do
+  before do
+    assign(:scan, scan)
+    render
+  end
+  describe 'persisted scans' do
+    let(:scan) { create(:scan) }
+    it 'should display the stored item title in an h2' do
+      expect(rendered).to have_css('h2', text: 'Title for Scan 1234')
+    end
+  end
+  describe 'non-persisted scans' do
+    let(:scan) { Scan.new(item_id: '2824966') }
+    it 'should display the API fetched item title in an h2' do
+      expect(rendered).to have_css('h2', text: /When do you need an antacid\? : a burning question/)
+    end
+  end
+end

--- a/spec/views/scans/success.html.erb_spec.rb
+++ b/spec/views/scans/success.html.erb_spec.rb
@@ -12,6 +12,10 @@ describe 'scans/success.html.erb' do
     expect(rendered).to have_css('.glyphicon.glyphicon-ok[aria-hidden="true"]')
     expect(rendered).to have_css('h1', text: 'Request complete')
   end
+  it 'should have the title in an h2 heading' do
+    render
+    expect(rendered).to have_css('h2', text: 'Title for Scan 1234')
+  end
   describe 'metadata' do
     let(:scan) do
       create(


### PR DESCRIPTION
Closes #81 

We'll need to style these appropriately.  I have some questions around our global heading styling approach, but I think we can move forward and address the css later (as long as the html is correct).

![h2-item-title](https://cloud.githubusercontent.com/assets/96776/7382924/3ca96b5a-edcb-11e4-991f-805f941fd43f.png)
