### PR TITLE
Raise error when users attempt to go to a mediated page or page form...

### DIFF
--- a/app/controllers/mediated_pages_controller.rb
+++ b/app/controllers/mediated_pages_controller.rb
@@ -4,6 +4,7 @@
 class MediatedPagesController < RequestsController
   def new
     request_defaults(@mediated_page)
+    validate_mediated_pageable
   end
 
   def create
@@ -20,6 +21,10 @@ class MediatedPagesController < RequestsController
   end
 
   protected
+
+  def validate_mediated_pageable
+    fail UnmediateableItemError unless @mediated_page.mediateable?
+  end
 
   def rescue_can_can(*)
     if !current_user.webauth_user? && create_via_post?
@@ -41,5 +46,8 @@ class MediatedPagesController < RequestsController
                                           :needed_date,
                                           data: [:comments],
                                           user_attributes: [:name, :email])
+  end
+
+  class UnmediateableItemError < StandardError
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,7 @@
 class PagesController < RequestsController
   def new
     request_defaults(@page)
+    validate_pageable
   end
 
   def create
@@ -31,6 +32,10 @@ class PagesController < RequestsController
 
   protected
 
+  def validate_pageable
+    fail UnpageableItemError unless @page.pageable?
+  end
+
   def rescue_can_can(*)
     if !current_user.webauth_user? && create_via_post?
       redirect_to login_path(referrer: create_pages_path(page: params[:page].except(:user_attributes)))
@@ -50,5 +55,8 @@ class PagesController < RequestsController
 
   def update_params
     params.require(:page).permit(:needed_date)
+  end
+
+  class UnpageableItemError < StandardError
   end
 end

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -20,6 +20,13 @@ describe MediatedPagesController do
       expect(assigns[:mediated_page].origin_location).to eq 'STACKS'
       expect(assigns[:mediated_page].item_id).to eq '1234'
     end
+    it 'should raise an error if the item is unmediateable' do
+      expect(
+        lambda do
+          get :new, item_id: '1234', origin: 'GREEN', origin_location: 'STACKS'
+        end
+      ).to raise_error(MediatedPagesController::UnmediateableItemError)
+    end
   end
   describe 'create' do
     describe 'by anonymous users' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -20,6 +20,13 @@ describe PagesController do
       expect(assigns[:page].origin_location).to eq 'STACKS'
       expect(assigns[:page].item_id).to eq '1234'
     end
+    it 'should raise an error when the item is not pageable' do
+      expect(
+        lambda do
+          get :new, item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS'
+        end
+      ).to raise_error(PagesController::UnpageableItemError)
+    end
   end
   describe 'create' do
     describe 'by anonymous users' do

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -40,7 +40,7 @@ describe 'Creating a mediated page request' do
       expect(MediatedPage.last.data['comments']).to eq comment
     end
     it 'should not include a comments for requests that do not get them' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'HOOVER', origin_location: 'STACKS')
+      visit new_mediated_page_path(item_id: '1234', origin: 'HOOVER', origin_location: 'STACKS-30')
 
       expect(page).to_not have_field('Comments')
     end


### PR DESCRIPTION
...for an item of an incorrect type.