### PR TITLE
Add path helper to delegate requests and return their polymorphic path.

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -12,12 +12,17 @@ class RequestsController < ApplicationController
     if @request.scannable?
       render
     else
-      @request.delegate_request!
-      redirect_to new_polymorphic_path(@request.type.underscore, params.except(:controller, :action))
+      redirect_to delegated_new_request_path(@request)
     end
   end
 
   protected
+
+  def delegated_new_request_path(request)
+    request.delegate_request!
+    new_polymorphic_path(request.type.underscore, params.except(:controller, :action))
+  end
+  helper_method :delegated_new_request_path
 
   def validate_new_params
     params.require(:origin)

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -1,7 +1,7 @@
 <div id="scan-or-deliver">
   <div class="row">
     <div class="col-xs-12 col-sm-6 buttons">
-      <%= link_to('Deliver to campus library', new_page_path(@request, params.except(:controller, :action)), class: 'btn btn-beige', 'aria-describedby' => 'deliveryDescription') %>
+      <%= link_to('Deliver to campus library', delegated_new_request_path(@request), class: 'btn btn-beige', 'aria-describedby' => 'deliveryDescription') %>
     </div>
     <div class="col-xs-12 col-sm-6 content">
       <dl id="deliveryDescription">

--- a/app/views/scans/_request_buttons_for_anon.html.erb
+++ b/app/views/scans/_request_buttons_for_anon.html.erb
@@ -1,4 +1,4 @@
 <%= send_request_via_login_button %>
 <p>Don’t have a SUNet ID?</p>
 <p>If you don’t have a SUNet ID, we can’t scan this item for you, but we can deliver the physical volume to a campus library for you to pick up.</p>
-<%= link_to('Request the physical item', new_page_path(params.except(:action, :controller)), class: 'btn btn-beige col-xs-12') %>
+<%= link_to('Request the physical item', delegated_new_request_path(@scan), class: 'btn btn-beige col-xs-12') %>

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -18,6 +18,7 @@ describe RequestsController do
         expect(-> { get(:new, origin_location: 'STACKS') }).to raise_error(ActionController::ParameterMissing)
       end
     end
+
     describe 'defaults' do
       it 'should be set' do
         get :new, scannable_params
@@ -26,19 +27,56 @@ describe RequestsController do
         expect(assigns[:request].item_id).to eq '12345'
       end
     end
+
     describe 'scannable item' do
       it 'should display a page to choose to have an item scanned or delivered' do
         get :new, scannable_params
         expect(response).to render_template('new')
       end
     end
+
     describe 'unscannable item' do
-      it 'should redirect to the new page request form' do
+      it 'should redirect to the new mediated page request form' do
         get :new, mediated_page_params
         expect(response).to redirect_to new_mediated_page_path(mediated_page_params)
       end
     end
+
+    describe 'unmediateable item' do
+      it 'rediredcts to the new page form' do
+        get :new, unscannable_params
+        expect(response).to redirect_to new_page_path(unscannable_params)
+      end
+    end
   end
+
+  describe 'delegated_new_request_path' do
+    let(:path) { controller.send(:delegated_new_request_path, request) }
+    describe 'for pages' do
+      let(:request) { build(:request) }
+      it 'delegeates the request object' do
+        path
+        expect(request.type).to eq 'Page'
+      end
+
+      it 'returns the page path' do
+        expect(path).to eq new_page_path
+      end
+    end
+
+    describe 'for medated pages' do
+      let(:request) { create(:request, origin: 'SPEC-COLL') }
+      it 'delegeates the request object' do
+        path
+        expect(request.type).to eq 'MediatedPage'
+      end
+
+      it 'retruns the mediated page path' do
+        expect(path).to eq new_mediated_page_path
+      end
+    end
+  end
+
   describe 'modify_item_selector_checkboxes' do
     it 'should raise an error of the subclassing controller does not implement the local_object_param method' do
       expect(-> { controller.send(:modify_item_selector_checkboxes) }).to raise_error(NotImplementedError)


### PR DESCRIPTION
Closes #124 

We currently don't have a use-case where either of the links will take you anywhere besides a Page request (until Hold/Recall, maybe).  However; since this same helper is now being called in https://github.com/sul-dlss/sul-requests/commit/f93aff591a36872b8f83403d31d54eb6794d784d#diff-cd57d2a9133000ab8443d9eb0c8a78c9R15 we know that the delegation and path creation is happening correctly.