### PR TITLE
Restrict API calls by default in tests and require that they're…

### DIFF
--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -134,7 +134,7 @@ describe Request do
   end
 
   describe 'item_title' do
-    it 'should fetch the item title on object creation' do
+    it 'should fetch the item title on object creation', allow_apis: true do
       Request.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'STACKS')
       expect(Request.last.item_title).to eq 'When do you need an antacid? : a burning question'
     end

--- a/spec/models/searchworks_item_spec.rb
+++ b/spec/models/searchworks_item_spec.rb
@@ -12,9 +12,9 @@ describe SearchworksItem do
       expect(subject.send(:url)).to eq("#{Settings.searchworks_api}/view/123/availability")
     end
   end
-  describe '#json' do
+  describe '#json', allow_apis: true do
     let(:json) { subject.send(:json) }
-    it 'should return json as the body of the response object' do
+    it 'should return json as the body of the response object', allow_apis: true do
       expect(json).to be_a Hash
       expect(json).to have_key 'title'
       expect(json).to have_key 'holdings'
@@ -46,7 +46,7 @@ describe SearchworksItem do
       }
     end
     let(:empty_json) { {} }
-    describe 'for a connection failure' do
+    describe 'for a connection failure', allow_apis: true do
       before do
         allow(subject).to receive_messages(url: Settings.searchworks_api.gsub('searchworks', 'searchwroks'))
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,16 @@ Capybara.javascript_driver = :poltergeist
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Module that when included causes RSpec to
+# stup our API requests. We can then explicitly
+# allow them in tests that need them by adding
+# allow_apis: true to the tests themselves
+module DisallowAPIs
+  def self.included(host)
+    host.metadata[:allow_apis] = false
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -45,6 +55,11 @@ RSpec.configure do |config|
 
   config.before(:each) do
     DatabaseCleaner.strategy = :transaction
+  end
+
+  config.include DisallowAPIs
+  config.before(:each, allow_apis: false) do
+    stub_searchworks_api_json({})
   end
 
   config.before(:each, js: true) do

--- a/spec/views/shared/_searchworks_item_information.html.erb_spec.rb
+++ b/spec/views/shared/_searchworks_item_information.html.erb_spec.rb
@@ -13,7 +13,7 @@ describe 'shared/_searchworks_item_information.html.erb' do
   end
   describe 'non-persisted scans' do
     let(:request) { Scan.new(item_id: '2824966') }
-    it 'should display the API fetched item title in an h2' do
+    it 'should display the API fetched item title in an h2', allow_apis: true do
       expect(rendered).to have_css('h2', text: /When do you need an antacid\? : a burning question/)
     end
   end


### PR DESCRIPTION
…turned on per-group that needs them.

This is an attempt to speed up the tests and reduce the burden on the availability API (and will also allow us to use the same mechanism for the Hours API).

This will become particularly important once #139 is merged since it validates holdings on create, thus hitting the availability API every time any request is validated.

### Before
![before](https://cloud.githubusercontent.com/assets/96776/7664155/b32e1f34-fb2f-11e4-9666-ce9cebfa4679.png)

### After
![after](https://cloud.githubusercontent.com/assets/96776/7664154/b32c622a-fb2f-11e4-89ca-a619126391b6.png)
