### PR TITLE
Add kaminari pagination to mediated pages list

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import 'bootstrap-sprockets';
+@import 'variables';
 @import 'bootstrap';
 @import 'sul-requests-mixins';
 @import 'sul-requests';

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,4 +1,6 @@
 a {
+  border-bottom: 1px dotted $sul-link-border-color;
+
   &.disabled {
     color: $gray-ccc;
     cursor: not-allowed;

--- a/app/assets/stylesheets/sul-requests.scss
+++ b/app/assets/stylesheets/sul-requests.scss
@@ -1,5 +1,3 @@
-@import 'sul-variables';
-
 // Import all individual stylesheets here
 @import 'base';
 @import 'layout';

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,0 +1,7 @@
+@import 'sul-variables';
+
+$gray-base: #000;
+$gray-dark: lighten($gray-base, 20%);
+$link-color: $gray-dark;
+
+$brand-primary: $cardinal-red;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -5,3 +5,4 @@ $gray-dark: lighten($gray-base, 20%);
 $link-color: $gray-dark;
 
 $brand-primary: $cardinal-red;
+$pagination-active-bg: #696969;

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,6 +7,16 @@ class AdminController < ApplicationController
 
   def show
     authorize! :manage, Request.new(origin: params[:id]).library_location
-    @mediated_pages = MediatedPage.where(origin: params[:id]).order(:origin)
+    @mediated_pages = MediatedPage.where(origin: params[:id]).order(:origin).page(page).per(per)
+  end
+
+  private
+
+  def page
+    params[:page]
+  end
+
+  def per
+    params.fetch(:per_page, 100)
   end
 end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,4 +1,5 @@
 <h1>Request mediation</h1>
 <div class='admin-requests'>
   <%= render partial: 'library_table', locals: { origin: params[:id], collection: @mediated_pages } %>
+  <%= paginate @mediated_pages, theme: 'sul' %>
 </div>

--- a/app/views/kaminari/sul/_first_page.html.erb
+++ b/app/views/kaminari/sul/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'disabled' if current_page.first? %>">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote %>
+</li>

--- a/app/views/kaminari/sul/_gap.html.erb
+++ b/app/views/kaminari/sul/_gap.html.erb
@@ -1,0 +1,11 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="disabled">
+  <span><%= raw(t 'views.pagination.truncate') %></span>
+</li>
+

--- a/app/views/kaminari/sul/_last_page.html.erb
+++ b/app/views/kaminari/sul/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'disabled' if current_page.last? %>">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote %>
+</li>

--- a/app/views/kaminari/sul/_next_page.html.erb
+++ b/app/views/kaminari/sul/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'disabled' if current_page.last? %>">
+  <%= link_to raw(t 'views.pagination.next'), url, rel: 'next', remote: remote %>
+</li>

--- a/app/views/kaminari/sul/_page.html.erb
+++ b/app/views/kaminari/sul/_page.html.erb
@@ -1,0 +1,17 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'active' if page.current? %>">
+  <% if page.current? %>
+    <span><%= number_with_delimiter(page.to_s) %></span>
+  <% else %>
+    <%= link_to number_with_delimiter(page.to_s), url, opts = { remote: remote, rel: page.next? ? 'next' : page.prev? ? 'prev' : nil } %>
+  <% end %>
+</li>
+

--- a/app/views/kaminari/sul/_paginator.html.erb
+++ b/app/views/kaminari/sul/_paginator.html.erb
@@ -1,0 +1,37 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+-%>
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <% if current_page.first? %>
+      <li class="disabled"><span><%= I18n.t('views.pagination.previous').html_safe %></span></li>
+    <% else %>
+      <%= prev_page_tag %>
+    <% end %>
+
+    <% if current_page.last? %>
+      <li class="disabled"><span><%= I18n.t('views.pagination.next').html_safe %></span></li>
+    <% else %>
+      <%= next_page_tag %>
+    <% end %>
+
+    <% each_relevant_page do |page| -%>
+      <% if page.left_outer? ||  page.inside_window? -%>
+        <% if page == current_page %>
+          <li class="active"><span><%= page %></span></li>
+        <% else %>
+          <%= page_tag page %>
+        <% end %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+  </ul>
+<% end -%>

--- a/app/views/kaminari/sul/_prev_page.html.erb
+++ b/app/views/kaminari/sul/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'disabled' if current_page.first? %>">
+  <%= link_to raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote %>
+</li>

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -61,6 +61,16 @@ describe 'Viewing all requests' do
 
         expect(page).to have_css('table tbody tr', count: 1)
       end
+
+      it 'paginates the data' do
+        visit admin_path('SPEC-COLL', per_page: 1)
+
+        expect(page).to have_css('.pagination')
+
+        click_on 'Next ›'
+
+        expect(page).to have_selector('.pagination .disabled', text: 'Next ›')
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #83 

This PR also updates the link color to use the grey + under-dots link style from the design doc (although it turned out to be an unnecessary change for the kaminari pagination, which uses a different active background color) 

The default per page value is `100` (not `1`, as shown in the screenshot below).

![screen shot 2015-05-18 at 3 20 07 pm](https://cloud.githubusercontent.com/assets/111218/7691691/6f738bbe-fd71-11e4-900e-fb13cc0dae75.png)