### PR TITLE
Restrict scan requests to locations that include scannable item types.

### DIFF
--- a/app/models/concerns/scannable.rb
+++ b/app/models/concerns/scannable.rb
@@ -3,6 +3,24 @@
 ###
 module Scannable
   def scannable?
-    @library == 'SAL3' && @location == 'STACKS'
+    scannable_library? &&
+      scannable_location? &&
+      includes_scannable_item?
+  end
+
+  private
+
+  def scannable_library?
+    library == 'SAL3'
+  end
+
+  def scannable_location?
+    %w(BUS-STACKS STACKS).include?(location)
+  end
+
+  def includes_scannable_item?
+    request.holdings.any? do |item|
+      %w(BUS-STACKS STKS STKS-MONO STKS-PERI).include?(item.type)
+    end
   end
 end

--- a/app/models/library_location.rb
+++ b/app/models/library_location.rb
@@ -2,12 +2,13 @@
 #  Class to handle configuration and logic around library codes and labels
 ###
 class LibraryLocation
-  attr_reader :library, :location
+  attr_reader :request, :library, :location
 
   include Scannable
   include Mediateable
 
   def initialize(request)
+    @request = request
     @library = request.origin
     @location = request.origin_location
   end

--- a/app/models/searchworks_item.rb
+++ b/app/models/searchworks_item.rb
@@ -12,6 +12,10 @@ class SearchworksItem
     json['title'] || ''
   end
 
+  def format
+    json['format'] || []
+  end
+
   def holdings
     return [] unless json['holdings'].present?
     @holdings ||= JSON.parse(json['holdings'].to_json, object_class: OpenStruct)

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -29,6 +29,9 @@ describe RequestsController do
     end
 
     describe 'scannable item' do
+      before do
+        stub_searchworks_api_json(build(:sal3_holdings))
+      end
       it 'should display a page to choose to have an item scanned or delivered' do
         get :new, scannable_params
         expect(response).to render_template('new')

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 describe ScansController do
-  let(:scan) { create(:scan, origin: 'SAL3', origin_location: 'STACKS') }
+  before do
+    stub_searchworks_api_json(build(:sal3_holdings))
+  end
+  let(:scan) { create(:scan_with_holdings, origin: 'SAL3', origin_location: 'STACKS', barcodes: ['12345678']) }
   let(:scannable_params) do
     { item_id: '12345', origin: 'SAL3', origin_location: 'STACKS' }
   end
@@ -147,8 +150,8 @@ describe ScansController do
       let(:user) { create(:superadmin_user) }
       it 'should be allowed to modify page rqeuests' do
         put :update, id: scan[:id], scan: { needed_date: '2015-04-14' }
-        expect(flash[:success]).to eq 'Scan request was successfully updated.'
         expect(response).to redirect_to root_url
+        expect(flash[:success]).to eq 'Scan request was successfully updated.'
         expect(Scan.find(scan.id).needed_date.to_s).to eq '2015-04-14'
       end
     end

--- a/spec/factories/scans.rb
+++ b/spec/factories/scans.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :scan do
-    item_id '1234'
+    item_id '12345'
     origin 'SAL3'
     origin_location 'STACKS'
-    item_title 'Title for Scan 1234'
+    item_title 'Title for Scan 12345'
   end
 
   factory :scan_with_holdings, class: Scan do
@@ -11,8 +11,8 @@ FactoryGirl.define do
     origin 'SAL3'
     origin_location 'STACKS'
 
-    after(:build) do |page|
-      class << page
+    after(:build) do |scan|
+      class << scan
         def searchworks_item
           FactoryGirl.build(:sal3_stacks_multi_holdings_searchworks_item)
         end

--- a/spec/factories/searchworks_api_json.rb
+++ b/spec/factories/searchworks_api_json.rb
@@ -2,6 +2,8 @@ FactoryGirl.define do
   factory :multiple_holdings, class: Hash do
     title 'Item Title'
 
+    format ['Book']
+
     holdings [
       { 'code' => 'GREEN',
         'locations' => [
@@ -9,6 +11,7 @@ FactoryGirl.define do
             'items' => [
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -16,6 +19,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '87654321',
                 'callnumber' => 'ABC 321',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -23,6 +27,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '12345679',
                 'callnumber' => 'ABC 456',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -44,6 +49,8 @@ FactoryGirl.define do
   factory :single_holding, class: Hash do
     title 'Item Title'
 
+    format ['Book']
+
     holdings [
       { 'code' => 'GREEN',
         'locations' => [
@@ -51,6 +58,7 @@ FactoryGirl.define do
             'items' => [
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -72,6 +80,8 @@ FactoryGirl.define do
   factory :special_collections_holdings, class: Hash do
     title 'Special Collections Item Title'
 
+    format ['Book']
+
     holdings [
       { 'code' => 'SPEC-COLL',
         'locations' => [
@@ -79,6 +89,7 @@ FactoryGirl.define do
             'items' => [
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'page',
                   'status_text' => 'Page'
@@ -86,6 +97,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '87654321',
                 'callnumber' => 'ABC 321',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'page',
                   'status_text' => 'Page'
@@ -107,6 +119,8 @@ FactoryGirl.define do
   factory :sal3_holdings, class: Hash do
     title 'SAL3 Item Title'
 
+    format ['Book']
+
     holdings [
       { 'code' => 'SAL3',
         'locations' => [
@@ -114,6 +128,7 @@ FactoryGirl.define do
             'items' => [
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'page',
                   'status_text' => 'Page'
@@ -121,6 +136,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '87654321',
                 'callnumber' => 'ABC 321',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'page',
                   'status_text' => 'Page'
@@ -142,6 +158,8 @@ FactoryGirl.define do
   factory :many_holdings, class: Hash do
     title 'Item title'
 
+    format ['Book']
+
     holdings [
       { 'code' => 'GREEN',
         'locations' => [
@@ -149,6 +167,7 @@ FactoryGirl.define do
             'items' => [
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -156,6 +175,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '23456789',
                 'callnumber' => 'ABC 456',
+                'type' => 'SOMETHING-ELSE',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -163,6 +183,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '34567890',
                 'callnumber' => 'ABC 789',
+                'type' => 'STKS-MONO',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -170,6 +191,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '45678901',
                 'callnumber' => 'ABC 012',
+                'type' => 'STKS-PERI',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -177,6 +199,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '56789012',
                 'callnumber' => 'ABC 345',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -184,6 +207,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '67890123',
                 'callnumber' => 'ABC 678',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -205,6 +229,8 @@ FactoryGirl.define do
   factory :searchable_holdings, class: Hash do
     title 'Item Title'
 
+    format ['Book']
+
     holdings [
       { 'code' => 'SPEC-COLL',
         'locations' => [
@@ -212,6 +238,7 @@ FactoryGirl.define do
             'items' => [
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -219,6 +246,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '23456789',
                 'callnumber' => 'ABC 456',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -226,6 +254,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '34567890',
                 'callnumber' => 'ABC 789',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -233,6 +262,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '45678901',
                 'callnumber' => 'ABC 012',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -240,6 +270,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '56789012',
                 'callnumber' => 'ABC 345',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -247,6 +278,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '67890123',
                 'callnumber' => 'ABC 678',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -254,6 +286,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '78901234',
                 'callnumber' => 'ABC 901',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -261,6 +294,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '89012345',
                 'callnumber' => 'ABC 234',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -268,6 +302,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '90123456',
                 'callnumber' => 'ABC 567',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -275,6 +310,7 @@ FactoryGirl.define do
               },
               { 'barcode' => '01234567',
                 'callnumber' => 'ABC 890',
+                'type' => 'STKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Create Scan Request' do
   before do
     allow_any_instance_of(ScansController).to receive(:illiad_query).and_return('http://illiad.ill')
+    stub_searchworks_api_json(build(:sal3_holdings))
   end
   describe 'by a webauth user' do
     before do
@@ -49,6 +50,7 @@ describe 'Create Scan Request' do
       stub_current_user(create(:webauth_user))
       stub_searchworks_api_json(build(:sal3_holdings))
     end
+
     it 'should persist to the database and offer up an illiad url' do
       visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
 

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -18,6 +18,9 @@ describe 'Requests Delegation' do
     end
   end
   describe 'scannable materials' do
+    before do
+      stub_searchworks_api_json(build(:sal3_holdings))
+    end
     it 'should be given the opportunity to request a scan or delivery' do
       visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
 

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -18,7 +18,8 @@ describe 'Send Request Buttons' do
 
   describe 'Scans' do
     before do
-      visit new_scan_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      stub_searchworks_api_json(build(:sal3_holdings))
+      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
     end
     it 'only allows to send request via WebAuth login' do
       expect(page).to have_css('button', text: /Send request.*login with SUNet ID/)

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -20,7 +20,7 @@ describe ConfirmationMailer do
 
     describe 'subject' do
       describe 'for Scan requests' do
-        let(:request) { create(:scan, user: user) }
+        let(:request) { create(:scan_with_holdings, user: user) }
         it 'is custom' do
           expect(mail.subject).to eq "Scan to PDF requested (#{request.item_title})"
         end

--- a/spec/models/concerns/scannable_spec.rb
+++ b/spec/models/concerns/scannable_spec.rb
@@ -4,20 +4,66 @@ require 'rails_helper'
 #  Stub test class for inlcuding Scannable mixin
 ###
 class ScannableTestClass
-  attr_accessor :library, :location
+  attr_accessor :request, :library, :location
   include Scannable
 end
 
 describe Scannable do
+  let(:request) { build(:request) }
   let(:subject) { ScannableTestClass.new }
+  before do
+    subject.request = request
+  end
   describe '#scannable?' do
-    it 'should be false if the item does not have the scannable attributes' do
-      expect(subject).to_not be_scannable
+    describe 'library and location' do
+      before do
+        allow(subject).to receive_messages(includes_scannable_item?: true)
+      end
+
+      it 'is true when from SAL3 + STACKS' do
+        subject.library = 'SAL3'
+        subject.location = 'STACKS'
+        expect(subject).to be_scannable
+      end
+
+      it 'is true whe from SAL3 + BUS-STACKS' do
+        subject.library = 'SAL3'
+        subject.location = 'BUS-STACKS'
+        expect(subject).to be_scannable
+      end
+
+      it 'is false when library or location is not SAL3 or STACKS' do
+        subject.library = 'NOT-SAL3'
+        subject.location = 'STACKS'
+        expect(subject).to_not be_scannable
+        subject.library = 'SAL3'
+        subject.location = 'NOT-STACKS'
+        expect(subject).to_not be_scannable
+      end
     end
-    it 'should return true if the library is SAL3 and the location in STACKS' do
-      subject.library = 'SAL3'
-      subject.location = 'STACKS'
-      expect(subject).to be_scannable
+
+    describe 'holdings' do
+      let(:scannalbe_items) { [double(type: 'STKS')] }
+      let(:unscannable_items) { [double(type: 'NOT-STKS')] }
+      before do
+        allow(subject).to receive_messages(scannable_library?: true)
+        allow(subject).to receive_messages(scannable_location?: true)
+      end
+
+      it 'is true when there are scannable items in the location' do
+        subject.request = double('request', holdings: scannalbe_items)
+        expect(subject).to be_scannable
+      end
+
+      it 'is false when there are no scannable items in the location' do
+        subject.request = double('request', holdings: unscannable_items)
+        expect(subject).to_not be_scannable
+      end
+
+      it 'is true when there are mixed items in the location' do
+        subject.request = double('request', holdings: [scannalbe_items, unscannable_items].flatten)
+        expect(subject).to be_scannable
+      end
     end
   end
 end

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -20,7 +20,7 @@ describe Dashboard do
   describe 'metrics' do
     it 'should return an array of metrics whose count is over 0' do
       expect(subject.metrics).to eq [:mediated_pages, :pages]
-      create(:scan)
+      create(:scan_with_holdings)
       expect(subject.class.new.metrics).to eq [:mediated_pages, :pages, :scans]
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -33,18 +33,6 @@ describe Request do
     end
   end
 
-  describe '#scannable?' do
-    it 'should be scannable if it is a SAL3 item in the STACKS location' do
-      subject.origin = 'SAL3'
-      subject.origin_location = 'STACKS'
-      expect(subject).to be_scannable
-    end
-
-    it 'should not be scannable if it is not in the corect location and library' do
-      expect(subject).to_not be_scannable
-    end
-  end
-
   describe '#commentable?' do
     it 'should be false' do
       expect(subject).to_not be_commentable

--- a/spec/models/searchworks_item_spec.rb
+++ b/spec/models/searchworks_item_spec.rb
@@ -34,6 +34,7 @@ describe SearchworksItem do
     let(:standard_json) do
       {
         'title' => 'The title of the object',
+        'format' => %w(Format1 Format2),
         'holdings' => [
           { 'code' => 'GREEN',
             'name' => 'Green Library',
@@ -56,9 +57,10 @@ describe SearchworksItem do
       it 'should return blank json' do
         expect(subject.send(:json)).to eq({})
       end
-      it 'should handle title and holdings correctly' do
+      it 'should handle title, format, and holdings correctly' do
         expect(subject.title).to eq('')
         expect(subject.holdings).to eq([])
+        expect(subject.format).to eq([])
       end
     end
     describe 'for a standard response' do
@@ -67,6 +69,9 @@ describe SearchworksItem do
       end
       it 'should have a title string' do
         expect(subject.title).to eq('The title of the object')
+      end
+      it 'should have a format array' do
+        expect(subject.format).to eq %w(Format1 Format2)
       end
       it 'should have an array of nested OpenStruct objects describing the holdings' do
         expect(subject.holdings).to be_a Array

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -27,7 +27,7 @@ describe 'requests/status.html.erb' do
   describe 'for scans' do
     let(:request) do
       create(
-        :scan,
+        :scan_with_holdings,
         user: user,
         data: {
           'page_range' => 'Range of pages', 'section_title' => 'Title of section', 'authors' => 'The Author'

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -44,7 +44,7 @@ describe 'requests/success.html.erb' do
   describe 'for scans' do
     let(:request) do
       create(
-        :scan,
+        :scan_with_holdings,
         user: user,
         data: {
           'page_range' => 'Range of pages', 'section_title' => 'Title of section', 'authors' => 'The Author'

--- a/spec/views/shared/_searchworks_item_information.html.erb_spec.rb
+++ b/spec/views/shared/_searchworks_item_information.html.erb_spec.rb
@@ -6,9 +6,9 @@ describe 'shared/_searchworks_item_information.html.erb' do
     render
   end
   describe 'persisted objects' do
-    let(:request) { create(:scan) }
+    let(:request) { create(:scan_with_holdings) }
     it 'should display the stored item title in an h2' do
-      expect(rendered).to have_css('h2', text: 'Title for Scan 1234')
+      expect(rendered).to have_css('h2', text: 'SAL3 Item Title')
     end
   end
   describe 'non-persisted scans' do


### PR DESCRIPTION
Closes #65 

After this PR when requests are made from scannable library/locations they will also be checked to see if the requested location has any scannable holdings (based on item-type).