### PR TITLE
Make first form field have focus for pages and mediated pages

### DIFF
--- a/app/assets/javascripts/toggle_name_and_email_input.js
+++ b/app/assets/javascripts/toggle_name_and_email_input.js
@@ -1,21 +1,27 @@
 (function($) {
   $.fn.toggleNameAndEmailInputs = function() {
     this.each(function(){
-      $(this).on('click', function(){
+      var contentForm = $(this).closest('form');
+
+      $(this).on('click', function() {
         var target = $($(this).data('target'));
         var content = $($(this).data('content-target'));
         var link = $($(this).data('link'));
         var targetScope = $(this).data('target');
         var store = target.detach();
-        var form = $('form').last();
 
         content.append(link.show()).show();
-        content.appendTo(form);
-        store.appendTo(form).hide();
+        content.appendTo(contentForm);
+        store.appendTo(contentForm).hide();
 
         if ( targetScope === '[data-no-sunet-content]' )
         {
           link.hide();
+        }
+        else if ( targetScope === '[data-no-sunet-target]' )
+        {
+          $(contentForm).find('input[type=text]')
+            .filter(':visible:first').focus();
         }
       });
     });

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -7,9 +7,12 @@ describe 'Creating a mediated page request' do
       visit new_mediated_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS')
       click_link "I don't have a SUNet ID"
 
+      expect(page).to have_field('Library ID', type: 'text')
       expect(page).to have_field('Name', type: 'text')
       expect(page).to have_field('Email', type: 'email')
       expect(page).to have_css('a', text: '‹ Go back (show the login option)')
+      expect(page).to have_css('input#mediated_page_user_attributes_library_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'mediated_page_user_attributes_library_id'
 
       click_link '‹ Go back (show the login option)'
       expect(page).to have_css('a', text: "I don't have a SUNet ID")
@@ -29,6 +32,9 @@ describe 'Creating a mediated page request' do
     it 'should be possible if a library id is filled out', js: true do
       visit new_mediated_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS')
       click_link "I don't have a SUNet ID"
+
+      expect(page).to have_css('input#mediated_page_user_attributes_library_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'mediated_page_user_attributes_library_id'
 
       fill_in 'Library ID', with: '123456'
 

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -12,6 +12,9 @@ describe 'Creating a page request' do
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
       click_link "I don't have a SUNet ID"
 
+      expect(page).to have_css('input#page_user_attributes_library_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'page_user_attributes_library_id'
+
       fill_in 'Name', with: 'Jane Stanford'
       fill_in 'Email', with: 'jstanford@stanford.edu'
 
@@ -23,6 +26,9 @@ describe 'Creating a page request' do
     it 'should be possible if a library ID is filled out', js: true do
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
       click_link "I don't have a SUNet ID"
+
+      expect(page).to have_css('input#page_user_attributes_library_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'page_user_attributes_library_id'
 
       fill_in 'Library ID', with: '123456'
 


### PR DESCRIPTION
When you click 'I don't have a SUNet ID' the first form field should have focus. Also added tests for this in spec/features/.