### PR TITLE
Set checked state on item selector to handle Back-Forward Cache.

### DIFF
--- a/app/assets/javascripts/limit_selected_items.js
+++ b/app/assets/javascripts/limit_selected_items.js
@@ -6,8 +6,14 @@
       var counter = $(itemSelector.data('counter-target'));
       var checkboxSelector = 'input[type="checkbox"]';
       var checkboxes = $(checkboxSelector, itemSelector);
+      var initSelected = $(checkboxSelector + ':checked', itemSelector).length;
+
+      // Set initial states to handle Back-Forward Cache
+      updateSelectedItemsData(itemSelector, initSelected);
+      updateCounterText(counter, initSelected);
+
       checkboxes.on('change', function(e){
-        var numberOfSelectedCheckboxes = (itemSelector.data('selected-items') || 0);
+        var numberOfSelectedCheckboxes = itemSelector.data('selected-items');
         // We need to track if the check box is being checked or unchecked
         // individually since we can't depend on simply querying all
         // checked check boxes (search removes them from the DOM)
@@ -23,12 +29,21 @@
           numberOfSelectedCheckboxes -= 1;
         }
 
-        itemSelector.data('selected-items', numberOfSelectedCheckboxes);
-        counter.text(numberOfSelectedCheckboxes + ' items selected');
-
+        updateSelectedItemsData(itemSelector, numberOfSelectedCheckboxes);
+        updateCounterText(counter, numberOfSelectedCheckboxes);
       });
     });
   };
+
+  function updateSelectedItemsData(selector, number) {
+    selector.data('selected-items', number);
+  }
+
+  function updateCounterText(counter, number) {
+    counter.text(number + ' items selected');
+  }
+
+  return this;
 })(jQuery);
 
 $(document).on('ready page:load', function(){

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -130,4 +130,37 @@ describe 'Item Selector' do
       end
     end
   end
+
+  describe 'when viewed under Back-Forward Cache', js: true do
+    before do
+      stub_current_user(create(:webauth_user))
+      stub_searchworks_api_json(build(:searchable_holdings))
+    end
+    it 'still limits selections' do
+      visit new_mediated_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS')
+
+      within('#item-selector') do
+        check('ABC 123')
+        check('ABC 456')
+        check('ABC 789')
+        check('ABC 012')
+        check('ABC 345')
+      end
+
+      expect(page).to have_content('5 items selected')
+
+      click_button 'Send request'
+
+      expect(page).to have_content('Request complete')
+
+      page.evaluate_script('window.history.back()') # Mimics back-button click
+
+      expect(page).to have_content('5 items selected')
+
+      within('#item-selector') do
+        check('ABC 901')
+        expect(field_labeled('ABC 901')).to_not be_checked
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #152 

I don't believe that page-refresh is actually a problem (as it clears out the checkboxes) but clicking navigating forward/backward in browser history was the actual issue.  @jgreben perhaps you can confirm since you unearthed the bug.

### Before
![item-selector-before](https://cloud.githubusercontent.com/assets/96776/7825783/064463d8-03c6-11e5-85b4-556a07f74cf8.gif)

### After
![item-selector-after](https://cloud.githubusercontent.com/assets/96776/7825784/06450a72-03c6-11e5-91b4-56c8271b5b06.gif)
