### PR TITLE
Allow a request's holdings to be toggled into view in the mediation table

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -6,3 +6,6 @@ ruby:
 
 scss:
   config_file: .scss-lint.yml
+
+javascript:
+  ignore_file: .javascript_ignore

--- a/.javascript_ignore
+++ b/.javascript_ignore
@@ -1,0 +1,2 @@
+spec/javascripts/*
+vendor/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
     - 'spec/spec_helper.rb'
+    - 'spec/teaspoon_env.rb'
     - 'vendor/**/*'
   RunRailsCops: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,12 @@ group :development, :test do
   # Poltergeist is a capybara driver to run integration tests using PhantomJS
   gem 'poltergeist'
 
+  # Teaspoon-jasmine is a wrapper for the Jasmine javascript testing library
+  gem 'teaspoon-jasmine'
+
+  # Allows jQuery integration into the Jasmine javascript testing framework
+  gem 'jasmine-jquery-rails'
+
   # Database cleaner allows us to clean the entire database after certain tests
   gem 'database_cleaner'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    jasmine-jquery-rails (2.0.3)
     jbuilder (2.2.13)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -252,6 +253,10 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    teaspoon (1.0.2)
+      railties (>= 3.2.5, < 5)
+    teaspoon-jasmine (2.2.0)
+      teaspoon (>= 1.0.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     therubyracer (0.12.2)
@@ -299,6 +304,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl_rails
   faraday
+  jasmine-jquery-rails
   jbuilder (~> 2.0)
   jquery-rails
   kaminari
@@ -315,6 +321,7 @@ DEPENDENCIES
   scss-lint
   sdoc (~> 0.4.0)
   sqlite3
+  teaspoon-jasmine
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
 
-task default: [:rubocop, :scss_lint, :spec, :display_coveralls_coverage]
+task default: [:teaspoon, :rubocop, :scss_lint, :spec, :display_coveralls_coverage]

--- a/app/assets/javascripts/mediation_table.js
+++ b/app/assets/javascripts/mediation_table.js
@@ -30,42 +30,56 @@ var mediationTable = (function() {
       var _this = this;
       var toggle = _this.toggleHandle(row);
       toggle.on('click', function() {
-        if(_this.rowIsProcessed(row)) {
-          _this.toggleRow(row);
-        } else {
-          _this.addHoldings(row);
-          _this.setRowProcessed(row);
-        }
+        _this.toggleHoldings(row);
       });
     },
 
-    toggleRow: function(row) {
+    toggleHoldings: function(row) {
       if ( row.hasClass('expanded') ) {
-        row.removeClass('expanded');
-        row.next('tr').hide();
+        this.hideRow(row);
       } else {
-        row.addClass('expanded');
-        row.next('tr').show();
+        this.showRow(row);
       }
     },
 
+    showRow: function(row) {
+      this.addHoldings(row);
+      row.addClass('expanded');
+      this.holdingsRow(row).show();
+    },
+
+    hideRow: function(row) {
+      row.removeClass('expanded');
+      this.holdingsRow(row).hide();
+    },
+
     addHoldings: function(row) {
-      $.ajax(row.data('mediate-request')).done(function(data){
-        row.after('<tr><td colspan="5">' + data + '</td></tr>');
-        row.addClass('expanded');
-      });
+      var _this = this;
+      if ( !_this.rowIsProcessed(row) ) {
+        var holdingsRow = _this.createHoldingsRow(row);
+        $.ajax(row.data('mediate-request')).done(function(data){
+          holdingsRow.find('td').html(data);
+          row.addClass('expanded');
+        });
+      }
+    },
+
+    createHoldingsRow: function(row) {
+      var holdingsRow = $('<tr class="holdings"><td colspan="5"></td></tr>');
+      row.after(holdingsRow);
+      return holdingsRow;
     },
 
     toggleHandle: function(row) {
       return row.find('[data-behavior="mediate-toggle"]');
     },
 
-    setRowProcessed: function(row) {
-      row.data('holdings-processed', 'true');
+    holdingsRow: function(row) {
+      return row.next('tr.holdings');
     },
 
     rowIsProcessed: function(row) {
-      return row.data('holdings-processed') == 'true';
+      return this.holdingsRow(row).find('table').length > 0;
     }
   };
 

--- a/app/assets/javascripts/mediation_table.js
+++ b/app/assets/javascripts/mediation_table.js
@@ -1,0 +1,74 @@
+var mediationTable = (function() {
+  var defaultOptions = {
+    selector: '[data-mediate-request]'
+  };
+
+  return {
+    init: function(opts) {
+      var _this = this;
+      _this.options = $.extend(defaultOptions, opts);
+      $(document).on('ready page:load', function(){
+        _this.addToggleHoldingsBehavior();
+      });
+      return this;
+    },
+
+    options: {},
+
+    addToggleHoldingsBehavior: function() {
+      var _this = this;
+      _this.mediatableRows().each(function(){
+        _this.addToggleClick($(this));
+      });
+    },
+
+    mediatableRows: function() {
+      return $(this.options.selector);
+    },
+
+    addToggleClick: function(row) {
+      var _this = this;
+      var toggle = _this.toggleHandle(row);
+      toggle.on('click', function() {
+        if(_this.rowIsProcessed(row)) {
+          _this.toggleRow(row);
+        } else {
+          _this.addHoldings(row);
+          _this.setRowProcessed(row);
+        }
+      });
+    },
+
+    toggleRow: function(row) {
+      if ( row.hasClass('expanded') ) {
+        row.removeClass('expanded');
+        row.next('tr').hide();
+      } else {
+        row.addClass('expanded');
+        row.next('tr').show();
+      }
+    },
+
+    addHoldings: function(row) {
+      $.ajax(row.data('mediate-request')).done(function(data){
+        row.after('<tr><td colspan="4">' + data + '</td></tr>');
+        row.addClass('expanded');
+      });
+    },
+
+    toggleHandle: function(row) {
+      return row.find('[data-behavior="mediate-toggle"]');
+    },
+
+    setRowProcessed: function(row) {
+      row.data('holdings-processed', 'true');
+    },
+
+    rowIsProcessed: function(row) {
+      return row.data('holdings-processed') == 'true';
+    }
+  };
+
+})();
+
+mediationTable.init();

--- a/app/assets/javascripts/mediation_table.js
+++ b/app/assets/javascripts/mediation_table.js
@@ -51,7 +51,7 @@ var mediationTable = (function() {
 
     addHoldings: function(row) {
       $.ajax(row.data('mediate-request')).done(function(data){
-        row.after('<tr><td colspan="4">' + data + '</td></tr>');
+        row.after('<tr><td colspan="5">' + data + '</td></tr>');
         row.addClass('expanded');
       });
     },

--- a/app/assets/stylesheets/modules/mediation.scss
+++ b/app/assets/stylesheets/modules/mediation.scss
@@ -1,0 +1,19 @@
+.mediation-table {
+  .mediate-toggle {
+    border-bottom: 0;
+
+    i {
+      @extend .glyphicon-plus-sign;
+      color: $dark-cyan;
+    }
+  }
+
+  .expanded {
+    .mediate-toggle {
+      i {
+        @extend .glyphicon-minus-sign;
+        color: $cardinal-red;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/sul-requests.scss
+++ b/app/assets/stylesheets/sul-requests.scss
@@ -8,6 +8,7 @@
 @import 'modules/forms';
 @import 'modules/home-page';
 @import 'modules/item-selector';
+@import 'modules/mediation';
 @import 'modules/messages';
 @import 'modules/scan-or-deliver';
 @import 'modules/success';

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,6 +10,11 @@ class AdminController < ApplicationController
     @mediated_pages = MediatedPage.where(origin: params[:id]).order(:origin).page(page).per(per)
   end
 
+  def holdings
+    authorize! :manage, (@request = MediatedPage.find(params[:id]))
+    render layout: false
+  end
+
   private
 
   def page

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -1,21 +1,17 @@
 <% uniq_locations = collection.map { |h| h['origin_location'] }.uniq %>
 
 <h3><%= LibraryLocation.library_name_by_code(origin) %></h3>
-<h4>
-  Library=<%= origin %>
-  <% if uniq_locations.one? %>
-    &amp; location=<%= uniq_locations.first %>
-  <% end %>
-</h4>
 
-<table class="table table-striped">
+<table class="table table-striped mediation-table">
   <%= render 'table_header' %>
   <tbody>
     <% collection.each do |request| %>
-      <tr>
-        <td><%= request.type %></td>
-        <td><%= request.origin_location %></td>
-        <td><%= request.destination %></td>
+      <tr data-mediate-request='<%= holdings_admin_path(request) %>'>
+        <td>
+          <a class="mediate-toggle" data-behavior='mediate-toggle' href='javascript:;'>
+            <i class="glyphicon"></i>
+          </a>
+        </td>
         <td><%= searchworks_link(request.item_id, request.item_title) %></td>
         <td><%= requester_info(request.user) %></td>
         <td><%= format_date(request.created_at) %></td>

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -12,6 +12,7 @@
             <i class="glyphicon"></i>
           </a>
         </td>
+        <td><%= request.needed_date %></td>
         <td><%= searchworks_link(request.item_id, request.item_title) %></td>
         <td><%= requester_info(request.user) %></td>
         <td><%= format_date(request.created_at) %></td>

--- a/app/views/admin/_table_header.html.erb
+++ b/app/views/admin/_table_header.html.erb
@@ -1,6 +1,7 @@
 <thead>
   <tr>
     <th>Mediate</th>
+    <th>Needed on</th>
     <th>Title</th>
     <th>Requester</th>
     <th>Requested on</th>

--- a/app/views/admin/_table_header.html.erb
+++ b/app/views/admin/_table_header.html.erb
@@ -1,8 +1,6 @@
 <thead>
   <tr>
-    <th>Type</th>
-    <th>Location</th>
-    <th>Destination</th>
+    <th>Mediate</th>
     <th>Title</th>
     <th>Requester</th>
     <th>Requested on</th>

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -1,0 +1,25 @@
+<% if @request.data['comments'].present? %>
+  <p><%= @request.data['comments'] %></p>
+<% end %>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th class='col-xs-1'>Yes</th>
+      <th class='col-xs-1'>No</th>
+      <th class='col-xs-1'>Location</th>
+      <th class='col-xs-1'>Current</th>
+      <th>Call number / Container</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @request.holdings.each do |item| %>
+      <tr>
+        <td class='col-xs-1'><button class="disabled btn btn-xs btn-success">Approve</button></td>
+        <td class='col-xs-1'><button class="disabled btn btn-xs btn-danger">Deny</button></td>
+        <td class='col-xs-1'><%= item.home_location %></td>
+        <td class='col-xs-1'><%= item.current_location.code %></td>
+        <td><%= item.callnumber %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/mediated_pages/_form.html.erb
+++ b/app/views/mediated_pages/_form.html.erb
@@ -12,5 +12,7 @@
     <% end %>
   <% end %>
 
+  <%= f.date_field :needed_date, label: t('forms.labels.needed_date') %>
+
   <%= render partial: 'shared/send_request_buttons', locals: { f: f } %>
 <% end %>

--- a/app/views/shared/_request_status_information.html.erb
+++ b/app/views/shared/_request_status_information.html.erb
@@ -34,4 +34,9 @@
       <dd><%= authors %></dd>
     <% end %>
   <% end %>
+
+  <% if current_request.needed_date.present? %>
+    <dt><%= t('forms.labels.needed_date') %></dt>
+    <dd><%= current_request.needed_date %></dd>
+  <% end %>
 </dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
     labels:
       authors: 'Author(s)'
       comments: 'Comment'
+      needed_date: 'Needed on'
       page_range: 'Page range'
       section_title: 'Article title'
       holdings: 'Item(s) requested'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,11 @@ Rails.application.routes.draw do
   resources :scans, concerns: [:creatable_via_get_redirect, :successable, :statusable]
   resources :mediated_pages, concerns: [:creatable_via_get_redirect, :successable, :statusable]
 
-  resources :admin, only: [:index, :show]
+  resources :admin, only: [:index, :show] do
+    member do
+      get :holdings, as: :holdings
+    end
+  end
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AdminController do
   before do
-    allow(controller).to receive_messages(current_user: user)
+    stub_current_user(user)
   end
 
   describe 'index' do
@@ -84,6 +84,21 @@ describe AdminController do
       let(:user) { create(:anon_user) }
       it 'should not be accessible' do
         expect(-> { get :show, id: 'SPEC-COLL' }).to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+
+  describe 'holdings' do
+    describe 'for super admins' do
+      let(:user) { create(:superadmin_user) }
+      let(:mediated_page) do
+        create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+      end
+
+      it 'should return the holdings table markup' do
+        get :holdings, id: mediated_page.id
+        expect(response).to be_successful
+        expect(assigns(:request)).to be_a(MediatedPage)
       end
     end
   end

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -48,7 +48,7 @@ FactoryGirl.define do
     after(:build) do |request|
       class << request
         def searchworks_item
-          FactoryGirl.build(:sal3_stacks_multi_holdings_searchworks_item)
+          FactoryGirl.build(:spec_coll_stacks_multi_holdings_searchworks_item)
         end
       end
     end

--- a/spec/factories/searchworks_api_json.rb
+++ b/spec/factories/searchworks_api_json.rb
@@ -239,6 +239,10 @@ FactoryGirl.define do
               { 'barcode' => '12345678',
                 'callnumber' => 'ABC 123',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -247,6 +251,10 @@ FactoryGirl.define do
               { 'barcode' => '23456789',
                 'callnumber' => 'ABC 456',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -255,6 +263,10 @@ FactoryGirl.define do
               { 'barcode' => '34567890',
                 'callnumber' => 'ABC 789',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -263,6 +275,10 @@ FactoryGirl.define do
               { 'barcode' => '45678901',
                 'callnumber' => 'ABC 012',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -271,6 +287,10 @@ FactoryGirl.define do
               { 'barcode' => '56789012',
                 'callnumber' => 'ABC 345',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -279,6 +299,10 @@ FactoryGirl.define do
               { 'barcode' => '67890123',
                 'callnumber' => 'ABC 678',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -287,6 +311,10 @@ FactoryGirl.define do
               { 'barcode' => '78901234',
                 'callnumber' => 'ABC 901',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -295,6 +323,10 @@ FactoryGirl.define do
               { 'barcode' => '89012345',
                 'callnumber' => 'ABC 234',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -303,6 +335,10 @@ FactoryGirl.define do
               { 'barcode' => '90123456',
                 'callnumber' => 'ABC 567',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'
@@ -311,6 +347,10 @@ FactoryGirl.define do
               { 'barcode' => '01234567',
                 'callnumber' => 'ABC 890',
                 'type' => 'STKS',
+                'current_location' => {
+                  'code' => ''
+                },
+                'home_location' => 'STACKS',
                 'status' => {
                   'availability_class' => 'available',
                   'status_text' => 'Available'

--- a/spec/factories/searchworks_items.rb
+++ b/spec/factories/searchworks_items.rb
@@ -34,4 +34,16 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :spec_coll_stacks_multi_holdings_searchworks_item, class: SearchworksItem do
+    initialize_with { new(create(:request, origin: 'SPEC-COLL', origin_location: 'STACKS')) }
+
+    after(:build) do |item|
+      class << item
+        def json
+          FactoryGirl.build(:searchable_holdings)
+        end
+      end
+    end
+  end
 end

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -14,16 +14,13 @@ describe 'Viewing all requests' do
         visit admin_index_path
 
         expect(page).to have_css('h3', text: /Green Library/)
-        expect(page).to have_css('h4', text: /Library=GREEN & location=STACKS/)
         expect(page).to have_css('td a', text: 'Fourth symphony. [Op. 51].')
         expect(page).to have_css('td a[href="mailto:jstanford@stanford.edu"]', text: /jstanford@stanford.edu/)
 
         expect(page).to have_css('h3', text: /SAL Newark/)
-        expect(page).to have_css('h4', text: /Library=SAL-NEWARK & location=STACKS/)
         expect(page).to have_css('td a', text: 'An American in Paris')
         expect(page).to have_css('td a[href="mailto:joe@xyz.com"]', text: /Joe \(joe@xyz.com\)/)
 
-        expect(page).to have_selector('td', text: /^Page$/, count: 2)
         expect(page).to have_selector('table.table-striped', count: 2)
       end
     end

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe 'Mediation table' do
+  let(:top_level_columns) { 4 }
+  before do
+    stub_current_user(create(:superadmin_user))
+    stub_searchworks_api_json(build(:searchable_holdings))
+    create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+    create(
+      :mediated_page_with_holdings,
+      user: create(:non_webauth_user, name: 'Joe Doe ', email: 'joedoe@example.com'),
+      barcodes: %w(34567890 45678901)
+    )
+  end
+
+  it 'has toggleable rows that display holdings', js: true do
+    visit admin_path('SPEC-COLL')
+    expect(page).to have_css('[data-mediate-request]', count: 2)
+    expect(page).to have_css('tbody tr', count: 2)
+    within(first('[data-mediate-request]')) do
+      expect(page).to have_css('td', count: top_level_columns)
+      page.find('a.mediate-toggle').click
+    end
+    expect(page).to have_css("tbody td[colspan='#{top_level_columns}'] table")
+    within("tbody td[colspan='#{top_level_columns}'] table") do
+      expect(page).to have_css('td button', text: 'Approve', count: 2)
+      expect(page).to have_css('td button', text: 'Deny', count: 2)
+      expect(page).to have_css('td', text: 'STACKS', count: 2)
+      expect(page).to have_css('td', text: 'ABC 123')
+      expect(page).to have_css('td', text: 'ABC 456')
+    end
+  end
+end

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Mediation table' do
-  let(:top_level_columns) { 4 }
+  let(:top_level_columns) { 5 }
   before do
     stub_current_user(create(:superadmin_user))
     stub_searchworks_api_json(build(:searchable_holdings))

--- a/spec/javascripts/fixtures/mediation_table.html
+++ b/spec/javascripts/fixtures/mediation_table.html
@@ -1,0 +1,12 @@
+<table>
+  <tr data-mediate-request='/1'>
+    <td id='toggle-handle1' data-behavior='mediate-toggle'><td>
+  </tr>
+  <tr data-mediate-request='/2'>
+    <td id='toggle-handle2' data-behavior='mediate-toggle'><td>
+  </tr>
+  <tr data-mediate-request='/3' class='expanded'>
+    <td id='toggle-handle3' data-behavior='mediate-toggle'><td>
+  </tr>
+  <tr class='holdings'><td><table></table></td></tr>
+</table>

--- a/spec/javascripts/mediation_table_spec.js
+++ b/spec/javascripts/mediation_table_spec.js
@@ -1,0 +1,87 @@
+//= require mediation_table
+//= require jasmine-jquery
+fixture.preload('mediaton_table.html');
+describe('Mediation Table', function() {
+  beforeAll(function() {
+    this.fixtures = fixture.load('mediation_table.html');
+  });
+
+  describe('Rows', function(){
+    it('gets all the mediateable rows by selector', function(){
+      expect(mediationTable.mediatableRows().length).toBe(3);
+    });
+  });
+
+  describe('Row toggling', function(){
+    describe('showRow', function() {
+      it('adds the expanded class to the row', function() {
+        var lastRow = mediationTable.mediatableRows().last();
+        lastRow.removeClass('expanded');
+        expect(lastRow).not.toHaveClass('expanded');
+        mediationTable.showRow(lastRow);
+        expect(lastRow).toHaveClass('expanded');
+      });
+    });
+
+    describe('hideRow', function() {
+      it('removes the expanded class on the row', function() {
+        var lastRow = mediationTable.mediatableRows().last();
+        lastRow.addClass('expanded');
+        expect(lastRow).toHaveClass('expanded');
+        mediationTable.hideRow(lastRow);
+        expect(lastRow).not.toHaveClass('expanded');
+      });
+    });
+  });
+
+  describe('Toggle Handle', function() {
+    it('finds the handle in the row', function() {
+      var row = mediationTable.mediatableRows().first();
+      expect(mediationTable.toggleHandle(row).attr('id')).toBe('toggle-handle1');
+    });
+  });
+
+  describe('rowIsProcessed', function() {
+    it('is truthy when the next row is a populated holdings row', function() {
+      var lastRow = mediationTable.mediatableRows().last();
+      expect(mediationTable.rowIsProcessed(lastRow)).toBeTruthy();
+    });
+
+    it('is falsy when the next row is not a populated holdings row', function() {
+      var firstRow = mediationTable.mediatableRows().first();
+      expect(mediationTable.rowIsProcessed(firstRow)).toBeFalsy();
+    });
+  });
+
+  describe('holdingsRow', function() {
+    it('returns the row that will contain the holdings', function() {
+      var lastRow = mediationTable.mediatableRows().last();
+      expect(mediationTable.holdingsRow(lastRow).length).toBe(1);
+    });
+
+    it('returns nothing when not present', function() {
+      var firstRow = mediationTable.mediatableRows().first();
+      expect(mediationTable.holdingsRow(firstRow).length).toBe(0);
+    });
+  });
+
+  describe('createHoldingsRow', function() {
+    it('adds a row to place the holdings into', function() {
+      var firstRow = mediationTable.mediatableRows().first();
+      expect(firstRow.next('tr.holdings').length).toBe(0);
+      mediationTable.createHoldingsRow(firstRow);
+      expect(firstRow.next('tr.holdings').length).toBe(1);
+    });
+  });
+
+  describe('Options', function() {
+    it('has defaults', function() {
+      expect(mediationTable.options.selector).toBe('[data-mediate-request]');
+    });
+
+    it('extends default with passed in attributes', function() {
+      mediationTable.init({ selector: '.something-else' });
+      expect(mediationTable.options.selector).toBe('.something-else');
+    });
+  });
+});

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,0 +1,32 @@
+// Teaspoon includes some support files, but you can use anything from your own support path too.
+// require support/jasmine-jquery-1.7.0
+// require support/jasmine-jquery-2.0.0
+// require support/jasmine-jquery-2.1.0
+// require support/sinon
+// require support/your-support-file
+//
+// PhantomJS (Teaspoons default driver) doesn't have support for Function.prototype.bind, which has caused confusion.
+// Use this polyfill to avoid the confusion.
+//= require support/bind-poly
+//
+// You can require your own javascript files here. By default this will include everything in application, however you
+// may get better load performance if you require the specific files that are being used in the spec that tests them.
+//= require application
+//
+// Deferring execution
+// If you're using CommonJS, RequireJS or some other asynchronous library you can defer execution. Call
+// Teaspoon.execute() after everything has been loaded. Simple example of a timeout:
+//
+// Teaspoon.defer = true
+// setTimeout(Teaspoon.execute, 1000)
+//
+// Matching files
+// By default Teaspoon will look for files that match _spec.{js,js.coffee,.coffee}. Add a filename_spec.js file in your
+// spec path and it'll be included in the default suite automatically. If you want to customize suites, check out the
+// configuration in teaspoon_env.rb
+//
+// Manifest
+// If you'd rather require your spec files manually (to control order for instance) you can disable the suite matcher in
+// the configuration and use this file as a manifest.
+//
+// For more information: http://github.com/modeset/teaspoon

--- a/spec/routing/admin_routing_spec.rb
+++ b/spec/routing/admin_routing_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe AdminController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/admin').to route_to('admin#index')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/admin/SPEC-COLL').to route_to('admin#show', id: 'SPEC-COLL')
+    end
+
+    it 'routes to #holdings' do
+      expect(get: '/admin/1/holdings').to route_to('admin#holdings', id: '1')
+    end
+  end
+end

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -1,0 +1,178 @@
+Teaspoon.configure do |config|
+  # Determines where the Teaspoon routes will be mounted. Changing this to "/jasmine" would allow you to browse to
+  # `http://localhost:3000/jasmine` to run your tests.
+  config.mount_at = "/teaspoon"
+
+  # Specifies the root where Teaspoon will look for files. If you're testing an engine using a dummy application it can
+  # be useful to set this to your engines root (e.g. `Teaspoon::Engine.root`).
+  # Note: Defaults to `Rails.root` if nil.
+  config.root = nil
+
+  # Paths that will be appended to the Rails assets paths
+  # Note: Relative to `config.root`.
+  config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
+
+  # Fixtures are rendered through a controller, which allows using HAML, RABL/JBuilder, etc. Files in these paths will
+  # be rendered as fixtures.
+  config.fixture_paths = ["spec/javascripts/fixtures"]
+
+  # SUITES
+  #
+  # You can modify the default suite configuration and create new suites here. Suites are isolated from one another.
+  #
+  # When defining a suite you can provide a name and a block. If the name is left blank, :default is assumed. You can
+  # omit various directives and the ones defined in the default suite will be used.
+  #
+  # To run a specific suite
+  # - in the browser: http://localhost/teaspoon/[suite_name]
+  # - with the rake task: rake teaspoon suite=[suite_name]
+  # - with the cli: teaspoon --suite=[suite_name]
+  config.suite do |suite|
+    # Specify the framework you would like to use. This allows you to select versions, and will do some basic setup for
+    # you -- which you can override with the directives below. This should be specified first, as it can override other
+    # directives.
+    # Note: If no version is specified, the latest is assumed.
+    #
+    # Versions: 1.3.1, 2.0.3, 2.1.3, 2.2.0
+    suite.use_framework :jasmine, "2.2.0"
+
+    # Specify a file matcher as a regular expression and all matching files will be loaded when the suite is run. These
+    # files need to be within an asset path. You can add asset paths using the `config.asset_paths`.
+    suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
+
+    # Load additional JS files, but requiring them in your spec helper is the preferred way to do this.
+    #suite.javascripts = []
+
+    # You can include your own stylesheets if you want to change how Teaspoon looks.
+    # Note: Spec related CSS can and should be loaded using fixtures.
+    #suite.stylesheets = ["teaspoon"]
+
+    # This suites spec helper, which can require additional support files. This file is loaded before any of your test
+    # files are loaded.
+    suite.helper = "spec_helper"
+
+    # Partial to be rendered in the head tag of the runner. You can use the provided ones or define your own by creating
+    # a `_boot.html.erb` in your fixtures path, and adjust the config to `"/boot"` for instance.
+    #
+    # Available: boot, boot_require_js
+    suite.boot_partial = "boot"
+
+    # Partial to be rendered in the body tag of the runner. You can define your own to create a custom body structure.
+    suite.body_partial = "body"
+
+    # Hooks allow you to use `Teaspoon.hook("fixtures")` before, after, or during your spec run. This will make a
+    # synchronous Ajax request to the server that will call all of the blocks you've defined for that hook name.
+    #suite.hook :fixtures, &proc{}
+
+    # Determine whether specs loaded into the test harness should be embedded as individual script tags or concatenated
+    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default, 
+    # Teaspoon expands all assets to provide more valuable stack traces that reference individual source files.
+    #suite.expand_assets = true
+  end
+
+  # Example suite. Since we're just filtering to files already within the root test/javascripts, these files will also
+  # be run in the default suite -- but can be focused into a more specific suite.
+  #config.suite :targeted do |suite|
+  #  suite.matcher = "spec/javascripts/targeted/*_spec.{js,js.coffee,coffee}"
+  #end
+
+  # CONSOLE RUNNER SPECIFIC
+  #
+  # These configuration directives are applicable only when running via the rake task or command line interface. These
+  # directives can be overridden using the command line interface arguments or with ENV variables when using the rake
+  # task.
+  #
+  # Command Line Interface:
+  # teaspoon --driver=phantomjs --server-port=31337 --fail-fast=true --format=junit --suite=my_suite /spec/file_spec.js
+  #
+  # Rake:
+  # teaspoon DRIVER=phantomjs SERVER_PORT=31337 FAIL_FAST=true FORMATTERS=junit suite=my_suite
+
+  # Specify which headless driver to use. Supports PhantomJS and Selenium Webdriver.
+  #
+  # Available: :phantomjs, :selenium, :capybara_webkit
+  # PhantomJS: https://github.com/modeset/teaspoon/wiki/Using-PhantomJS
+  # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
+  # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
+  #config.driver = :phantomjs
+
+  # Specify additional options for the driver.
+  #
+  # PhantomJS: https://github.com/modeset/teaspoon/wiki/Using-PhantomJS
+  # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
+  # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
+  #config.driver_options = nil
+
+  # Specify the timeout for the driver. Specs are expected to complete within this time frame or the run will be
+  # considered a failure. This is to avoid issues that can arise where tests stall.
+  #config.driver_timeout = 180
+
+  # Specify a server to use with Rack (e.g. thin, mongrel). If nil is provided Rack::Server is used.
+  #config.server = nil
+
+  # Specify a port to run on a specific port, otherwise Teaspoon will use a random available port.
+  #config.server_port = nil
+
+  # Timeout for starting the server in seconds. If your server is slow to start you may have to bump this, or you may
+  # want to lower this if you know it shouldn't take long to start.
+  #config.server_timeout = 20
+
+  # Force Teaspoon to fail immediately after a failing suite. Can be useful to make Teaspoon fail early if you have
+  # several suites, but in environments like CI this may not be desirable.
+  #config.fail_fast = true
+
+  # Specify the formatters to use when outputting the results.
+  # Note: Output files can be specified by using `"junit>/path/to/output.xml"`.
+  #
+  # Available: :dot, :clean, :documentation, :json, :junit, :pride, :rspec_html, :snowday, :swayze_or_oprah, :tap, :tap_y, :teamcity
+  #config.formatters = [:dot]
+
+  # Specify if you want color output from the formatters.
+  #config.color = true
+
+  # Teaspoon pipes all console[log/debug/error] to $stdout. This is useful to catch places where you've forgotten to
+  # remove them, but in verbose applications this may not be desirable.
+  #config.suppress_log = false
+
+  # COVERAGE REPORTS / THRESHOLD ASSERTIONS
+  #
+  # Coverage reports requires Istanbul (https://github.com/gotwarlost/istanbul) to add instrumentation to your code and
+  # display coverage statistics.
+  #
+  # Coverage configurations are similar to suites. You can define several, and use different ones under different
+  # conditions.
+  #
+  # To run with a specific coverage configuration
+  # - with the rake task: rake teaspoon USE_COVERAGE=[coverage_name]
+  # - with the cli: teaspoon --coverage=[coverage_name]
+
+  # Specify that you always want a coverage configuration to be used. Otherwise, specify that you want coverage
+  # on the CLI.
+  # Set this to "true" or the name of your coverage config.
+  #config.use_coverage = nil
+
+  # You can have multiple coverage configs by passing a name to config.coverage.
+  # e.g. config.coverage :ci do |coverage|
+  # The default coverage config name is :default.
+  config.coverage do |coverage|
+    # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.
+    #
+    # Available: text-summary, text, html, lcov, lcovonly, cobertura, teamcity
+    #coverage.reports = ["text-summary", "html"]
+
+    # The path that the coverage should be written to - when there's an artifact to write to disk.
+    # Note: Relative to `config.root`.
+    #coverage.output_path = "coverage"
+
+    # Assets to be ignored when generating coverage reports. Accepts an array of filenames or regular expressions. The
+    # default excludes assets from vendor, gems and support libraries.
+    #coverage.ignore = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
+
+    # Various thresholds requirements can be defined, and those thresholds will be checked at the end of a run. If any
+    # aren't met the run will fail with a message. Thresholds can be defined as a percentage (0-100), or nil.
+    #coverage.statements = nil
+    #coverage.functions = nil
+    #coverage.branches = nil
+    #coverage.lines = nil
+  end
+end

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -57,12 +57,12 @@ describe 'requests/status.html.erb' do
 
   describe 'for medidated pages' do
     describe 'selected items' do
-      let(:request) { create(:mediated_page_with_holdings, user: user, barcodes: %w(12345678 87654321)) }
+      let(:request) { create(:mediated_page_with_holdings, user: user, barcodes: %w(12345678 23456789)) }
       before { render }
       it 'are displayed when there are multiple selected' do
         expect(rendered).to have_css('dt', text: 'Item(s) requested')
         expect(rendered).to have_css('dd', text: 'ABC 123')
-        expect(rendered).to have_css('dd', text: 'ABC 321')
+        expect(rendered).to have_css('dd', text: 'ABC 456')
       end
     end
   end

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -24,6 +24,13 @@ describe 'requests/status.html.erb' do
     expect(rendered).to have_css('dd', text: 'Green Library')
   end
 
+  it 'has the needed date' do
+    request.needed_date = Time.zone.today
+    render
+    expect(rendered).to have_css('dt', text: 'Needed on')
+    expect(rendered).to have_css('dd', text: Time.zone.today)
+  end
+
   describe 'for scans' do
     let(:request) do
       create(

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -24,6 +24,13 @@ describe 'requests/success.html.erb' do
     expect(rendered).to have_css('dd', text: 'Green Library')
   end
 
+  it 'has the needed date' do
+    request.needed_date = Time.zone.today
+    render
+    expect(rendered).to have_css('dt', text: 'Needed on')
+    expect(rendered).to have_css('dd', text: Time.zone.today)
+  end
+
   describe 'user information' do
     describe 'for webauth users' do
       let(:user) { create(:webauth_user) }

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -74,12 +74,12 @@ describe 'requests/success.html.erb' do
 
   describe 'for medidated pages' do
     describe 'selected items' do
-      let(:request) { create(:mediated_page_with_holdings, user: user, barcodes: %w(12345678 87654321)) }
+      let(:request) { create(:mediated_page_with_holdings, user: user, barcodes: %w(12345678 23456789)) }
       before { render }
       it 'are displayed when there are multiple selected' do
         expect(rendered).to have_css('dt', text: 'Item(s) requested')
         expect(rendered).to have_css('dd', text: 'ABC 123')
-        expect(rendered).to have_css('dd', text: 'ABC 321')
+        expect(rendered).to have_css('dd', text: 'ABC 456')
       end
     end
   end


### PR DESCRIPTION
Closes #141 
This PR also adds the ability to do javascript unit testing using [Teaspoon](https://github.com/modeset/teaspoon) and [Jasmine](http://jasmine.github.io/).  Check it out!

![mediation-table](https://cloud.githubusercontent.com/assets/96776/7891023/c648976e-05fe-11e5-8820-54531913f0e4.gif)
