### PR TITLE
Changed the illiad base url to fix the export of requests to ILLiad.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,5 +19,5 @@ token_encrypt:
 mailer_host: 'example.com'
 searchworks_api: 'http://searchworks-test.stanford.edu/api-test'
 searchworks_link: 'http://searchworks.stanford.edu/view'
-sul_illiad: 'https://sulils-test.stanford.edu/illiad.dll/OpenURL?'
+sul_illiad: 'https://sulils-test.stanford.edu/illiad.dll?'
 GOOGLE_ANALYTICS_ID: ''

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -93,7 +93,7 @@ describe ScansController do
 
       it 'should construct an illiad query url' do
         illiad_response = controller.send(:illiad_query, create(:scan_with_holdings, barcodes: ['12345678']))
-        expect(illiad_response).to include('illiad.dll/OpenURL?')
+        expect(illiad_response).to include('illiad.dll?')
         expect(illiad_response).to include('Action=10&Form=30')
         expect(illiad_response).to include('&rft.genre=scananddeliverArticle')
         expect(illiad_response).to include('&rft.jtitle=SAL3+Item+Title')


### PR DESCRIPTION
After upgrading to illiad version 8.6 it appears that the 'OpenURL' path directive is no longer used when submitting an OpenURL request. We just need to reference the illiad.dll file and then the query string.