### PR TITLE
Changed ILLiad OpenURL params to correctly place item information in ILLiad

### DIFF
--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -33,17 +33,30 @@ class ScansController < RequestsController
 
   protected
 
+  def illiad_page
+    @illiad_page = { 'Action': '10', 'Form': '30', 'rft.genre': 'scananddeliverArticle' }
+  end
+
+  def illiad_item_data(scan)
+    @illiad_item_data = { 'rft.location': scan.origin,
+                          'rft.callnum': scan.holdings.first.callnumber,
+                          'rft.item': scan.holdings.first.barcode }
+  end
+
+  def illiad_citation(scan)
+    @illiad_params = { 'rft.jtitle': scan.item_title,
+                       'rft.au': scan.data[:authors],
+                       'rft.pages': scan.data[:page_range],
+                       'rft.atitle': scan.data[:section_title] }
+  end
+
+  def illiad_callback(scan)
+    @illiad_callback = { 'scan_referrer': successful_scan_url(scan) }
+  end
+
   def illiad_query(scan)
-    illiad_params = {
-      'Action': '10', 'Form': '30', 'rft.genre': 'scananddeliverArticle',
-      'rft.jtitle': scan.item_title,
-      'rft.au': scan.data[:authors],
-      'rft.pages': scan.data[:page_range],
-      'rft.atitle': scan.data[:section_title],
-      'rft.volume': scan.holdings.first.callnumber,
-      'scan_referrer': successful_scan_url(scan)
-    }
-    Settings.sul_illiad + "#{illiad_params.to_query}"
+    illiad_qy = [illiad_page, illiad_item_data(scan), illiad_citation(scan), illiad_callback(scan)].reduce(:merge)
+    Settings.sul_illiad + "#{illiad_qy.to_query}"
   end
 
   def validate_scannable

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -97,7 +97,9 @@ describe ScansController do
         expect(illiad_response).to include('Action=10&Form=30')
         expect(illiad_response).to include('&rft.genre=scananddeliverArticle')
         expect(illiad_response).to include('&rft.jtitle=SAL3+Item+Title')
-        expect(illiad_response).to include('&rft.volume=ABC+123')
+        expect(illiad_response).to include('&rft.callnum=ABC+123')
+        expect(illiad_response).to include('&rft.item=12345678')
+        expect(illiad_response).to include('&rft.location=SAL3')
       end
 
       it 'sends an confirmation email' do


### PR DESCRIPTION
Changed ILLiad OpenURL params to correctly place item information in illiad client and to comply with rubocop's demands.