### PR TITLE
Allow for ad-hoc-items to be added to some requests

### DIFF
--- a/app/assets/javascripts/item_selector.js
+++ b/app/assets/javascripts/item_selector.js
@@ -17,9 +17,11 @@ var itemSelector = (function() {
       _this.checkboxes().each(function() {
         $(this).on('change', function() {
           if ( $(this).is(':checked') ) {
-            $(this).trigger('item-selector:selected');
+            _this.selectorElement()
+                 .trigger('item-selector:selected', [$(this)]);
           } else {
-            $(this).trigger('item-selector:deselected');
+            _this.selectorElement()
+                 .trigger('item-selector:deselected', [$(this)]);
           }
         });
       });

--- a/app/assets/javascripts/item_selector/item_selector_ad_hoc_items.js
+++ b/app/assets/javascripts/item_selector/item_selector_ad_hoc_items.js
@@ -1,0 +1,103 @@
+var itemSelectorAdHocItems = (function() {
+  var defaultOptions = {
+    selector: '[data-behavior="ad-hoc-items"]'
+  };
+
+  var santizeCallnumber = function(callnumber) {
+    return callnumber.replace(/\W+/g, '');
+  };
+
+  var adHocItemTemplate = function(value) {
+    return $(
+      '<span data-barcode="' +
+        santizeCallnumber(value) +
+      '" data-callnumber="' +
+        value +
+      '"></span>'
+    );
+  };
+
+  var adHochiddenFieldTemplate = function(item, fieldName) {
+    return $(
+      '<input id="hidden-' + item.data('barcode') + '" ' +
+      'type="hidden" ' +
+      'name="' + fieldName + '" ' +
+      'value="' + item.data('callnumber') + '" />'
+    );
+  };
+
+  return $.extend(itemSelector, {
+    init: function(opts) {
+      var _this = this;
+      _this.adHocOptions = $.extend(defaultOptions, opts);
+      $(document).on('ready page:load', function(){
+        _this.addItemsBehavior();
+        _this.enableAddButtonOnDeselect();
+        _this.disableAddButtonOnMaxItems();
+      });
+    },
+
+    adHocOptions: {},
+
+    addItemsBehavior: function() {
+      var _this = this;
+      _this.addItemsButton().on('click', function() {
+        var value = _this.addItemsInput().val();
+        if ( value !== '') {
+          var item = adHocItemTemplate(value);
+          _this.selectorElement()
+               .trigger('item-selector:selected', [item]);
+          _this.addHiddenAdHocField(item);
+          _this.addAdditionalRemoveBreadcrumbBehavior(item);
+          _this.addItemsInput().val('');
+        }
+      });
+    },
+
+    addAdditionalRemoveBreadcrumbBehavior: function(item) {
+      var barcode = item.data('barcode');
+      $('#breadcrumb-' + barcode)
+        .find('.close').on('click', function() {
+          $('#hidden-' + barcode).remove();
+      });
+    },
+
+    addHiddenAdHocField: function(item) {
+      var _this = this;
+      _this.breadcrumbContainer().append(
+        adHochiddenFieldTemplate(item, _this.hiddenFieldName())
+      );
+    },
+
+    disableAddButtonOnMaxItems: function() {
+      var _this = this;
+      _this.selectorElement()
+           .on('item-selector:max-selected-reached', function() {
+             _this.addItemsButton().addClass('disabled');
+           });
+    },
+
+    enableAddButtonOnDeselect: function() {
+      var _this = this;
+      _this.selectorElement().on('item-selector:deselected', function() {
+        _this.addItemsButton().removeClass('disabled');
+      });
+    },
+
+    addItemsInput: function() {
+      return $(this.adHocOptions.selector).find('input[type="text"]');
+    },
+
+    hiddenFieldName: function() {
+      return $(this.adHocOptions.selector).data('hidden-field-name');
+    },
+
+    addItemsButton: function() {
+      return $(this.adHocOptions.selector).find(
+        '[data-behavior="submit-ad-hoc-items"]'
+      );
+    }
+  });
+})();
+
+itemSelectorAdHocItems.init();

--- a/app/assets/javascripts/item_selector/item_selector_breadcrumbs.js
+++ b/app/assets/javascripts/item_selector/item_selector_breadcrumbs.js
@@ -19,8 +19,18 @@ var itemSelectorBreadcrumbs = (function() {
     init: function() {
       var _this = this;
       $(document).on('ready page:load', function(){
+        _this.setupDefaultBreadcrumbs();
         _this.addBreadcrumbBehavior();
       });
+    },
+
+    setupDefaultBreadcrumbs: function() {
+      var _this = this;
+      _this.checkboxes()
+           .filter(':checked')
+           .each(function() {
+             _this.addBreadcrumb($(this));
+           });
     },
 
     addBreadcrumbBehavior: function() {

--- a/app/assets/javascripts/item_selector/item_selector_breadcrumbs.js
+++ b/app/assets/javascripts/item_selector/item_selector_breadcrumbs.js
@@ -25,14 +25,14 @@ var itemSelectorBreadcrumbs = (function() {
 
     addBreadcrumbBehavior: function() {
       var _this = this;
-      _this.checkboxes().each(function() {
-        $(this).on('item-selector:selected', function() {
-          _this.addBreadcrumb($(this));
-        });
+      _this.selectorElement()
+           .on('item-selector:selected', function(event, item) {
+             _this.addBreadcrumb(item);
+      });
 
-        $(this).on('item-selector:deselected', function() {
-          _this.removeBreadcrumb($(this));
-        });
+      _this.selectorElement()
+           .on('item-selector:deselected', function(event, item) {
+             _this.removeBreadcrumb(item);
       });
     },
 
@@ -49,9 +49,11 @@ var itemSelectorBreadcrumbs = (function() {
     },
 
     addBreadcrumbRemoveBehavior: function(pill, item) {
+      var _this = this;
       pill.find('.close').on('click', function() {
-        item.prop('checked', false)
-            .trigger('item-selector:deselected');
+        item.prop('checked', false);
+        _this.selectorElement()
+             .trigger('item-selector:deselected', [item]);
       });
     },
 

--- a/app/assets/javascripts/item_selector/item_selector_incrementor.js
+++ b/app/assets/javascripts/item_selector/item_selector_incrementor.js
@@ -10,14 +10,12 @@ var itemSelectorIncrementor = (function() {
 
     addIncrementBehavior: function() {
       var _this = this;
-      _this.checkboxes().each(function() {
-        $(this).on('item-selector:selected', function() {
-          _this.increaseSelectedItemCount();
-        });
+      _this.selectorElement().on('item-selector:selected', function() {
+        _this.increaseSelectedItemCount();
+      });
 
-        $(this).on('item-selector:deselected', function() {
-          _this.decreaseSelectedItemCount();
-        });
+      _this.selectorElement().on('item-selector:deselected', function() {
+        _this.decreaseSelectedItemCount();
       });
     },
 

--- a/app/assets/javascripts/item_selector/item_selector_limit.js
+++ b/app/assets/javascripts/item_selector/item_selector_limit.js
@@ -23,15 +23,13 @@ var itemSelectorLimit = (function() {
 
     setupEventListeners: function() {
       var _this = this;
-      _this.checkboxes().each(function() {
-        $(this).on('item-selector:selected', function() {
-          _this.increaseSelectedNumber();
-          _this.enforceSelectedItemLimit($(this));
-        });
+      _this.selectorElement().on('item-selector:selected', function(_, item) {
+        _this.increaseSelectedNumber();
+        _this.enforceSelectedItemLimit(item);
+      });
 
-        $(this).on('item-selector:deselected', function() {
-          _this.decreaseSelectedNumber();
-        });
+      _this.selectorElement().on('item-selector:deselected', function() {
+        _this.decreaseSelectedNumber();
       });
     },
 
@@ -40,8 +38,9 @@ var itemSelectorLimit = (function() {
       var limit = selectorLimit(_this);
       if ( limit ) {
         if ( _this.numberOfSelectedCheckboxes() > limit ) {
-          checkbox.prop('checked', false)
-                  .trigger('item-selector:deselected');
+          checkbox.prop('checked', false);
+          _this.selectorElement()
+               .trigger('item-selector:deselected', [checkbox]);
         }
 
         if ( _this.numberOfSelectedCheckboxes() >= limit ) {

--- a/app/assets/javascripts/item_selector/item_selector_limit_message.js
+++ b/app/assets/javascripts/item_selector/item_selector_limit_message.js
@@ -11,7 +11,7 @@ var itemSelectorLimitMessage = (function() {
 
     setupDeselectedListener: function() {
       var _this = this;
-      _this.checkboxes().on('item-selector:deselected', function() {
+      _this.selectorElement().on('item-selector:deselected', function() {
         _this.removeMessage();
       });
     },

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -93,6 +93,7 @@ class RequestsController < ApplicationController
                                     :authors, :page_range, :section_title, # scans
                                     :proxy,
                                     barcodes: [],
+                                    ad_hoc_items: [],
                                     user_attributes: [:name, :email, :library_id])
   end
 

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -2,6 +2,13 @@
 #  Mixin to define commentable behavior in request objects
 ###
 module Commentable
+  # Used for adding ad-hoc items that are not listed in the holdings
+  def ad_hoc_item_commentable?
+    false
+  end
+
+  # Currently used to comment which items you would like if the
+  # location you're requesting from does not have any barcoded items
   def item_commentable?
     false
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -16,7 +16,9 @@ class Request < ActiveRecord::Base
   validate :requested_holdings_exist
 
   # Serialzed data hash
-  store :data, accessors: [:item_comment, :request_comment, :authors, :page_range, :section_title, :proxy], coder: JSON
+  store :data, accessors: [
+    :ad_hoc_items, :item_comment, :request_comment, :authors, :page_range, :section_title, :proxy
+  ], coder: JSON
   serialize :barcodes, Array
 
   belongs_to :user, autosave: true

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -12,6 +12,11 @@ class MediatedPage < Request
     super << user.email
   end
 
+  def ad_hoc_item_commentable?
+    return false unless origin == 'SPEC-COLL'
+    true
+  end
+
   def request_commentable?
     commentable_library_whitelist.include?(origin)
   end

--- a/app/models/searchworks_item.rb
+++ b/app/models/searchworks_item.rb
@@ -57,8 +57,6 @@ class SearchworksItem
   #  holdings to just what was requested by the user
   ###
   class RequestedHoldings
-    delegate :mhld, to: :location
-
     def initialize(searchworks_item)
       @searchworks_item = searchworks_item
     end
@@ -80,6 +78,11 @@ class SearchworksItem
       @barcoded_holdings ||= all.select do |item|
         item.barcode.match(barcode_pattern)
       end
+    end
+
+    def mhld
+      return [] unless location.present? && location.mhld.present?
+      location.mhld
     end
 
     private

--- a/app/views/confirmation_mailer/request_confirmation.text.erb
+++ b/app/views/confirmation_mailer/request_confirmation.text.erb
@@ -4,6 +4,7 @@ On <%= l @request.created_at.to_date, format: :long %>, you requested the follow
 
 Item(s) requested:
   <%= @request.holdings.map(&:callnumber).join("\n  ") %>
+  <%= @request.ad_hoc_items.join("\n  ") if @request.ad_hoc_items.present? %>
 
 <%= @request.data_to_email_s %>
 

--- a/app/views/shared/_item_selector.html.erb
+++ b/app/views/shared/_item_selector.html.erb
@@ -37,6 +37,16 @@
           </div>
         </div>
       </div>
+      <% if current_request.ad_hoc_item_commentable? %>
+        <div class='form-group'>
+          <div class='col-xs-6 form-inline' data-behavior='ad-hoc-items' data-hidden-field-name="<%= "#{f.object_name}[ad_hoc_items][]" %>">
+            <p>Refer to the collection finding aid to identify the items you need.</p>
+            <%= text_field_tag :ad_hoc_items, '', class: 'form-control' %>
+            <%= link_to 'Add', 'javascript:;', class: 'btn btn-default', data: { behavior: 'submit-ad-hoc-items' } %>
+            <p class='help-block'>Example: Series 1, Box 1</p>
+          </div>
+        </div>
+      <% end %>
       <p data-items-counter='true'><span data-count='true'>0</span> items selected</p>
       <div data-behavior='breadcrumb-container'></div>
       <div data-behavior='max-items-message'></div>

--- a/app/views/shared/_request_status_information.html.erb
+++ b/app/views/shared/_request_status_information.html.erb
@@ -6,6 +6,13 @@
     <% end  %>
   <% end %>
 
+  <% if current_request.ad_hoc_items.present? %>
+    <dt><%= current_request.class.human_attribute_name(:ad_hoc_items) %></dt>
+    <% current_request.ad_hoc_items.each do |item| %>
+      <dd><%= item %></dd>
+    <% end %>
+  <% end %>
+
   <% if current_request.destination.present? %>
     <dt>
       <%= label_for_pickup_libraries_dropdown(current_request.library_location.pickup_libraries) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
         needed_date: 'Needed on'
         request_comment: 'Comment'
         item_comment: 'Item(s) requested'
+        ad_hoc_items: 'Additional item(s)'
       hold_recall:
         <<: *request_anchor
         needed_date: 'Cancel request after'

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -179,6 +179,8 @@ describe 'Item Selector' do
 
       expect(page).to have_content('5 items selected')
 
+      expect(page).to have_css('.breadcrumb-pill', count: 5)
+
       within('#item-selector') do
         check('ABC 901')
         expect(field_labeled('ABC 901')).to_not be_checked

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -223,4 +223,81 @@ describe 'Item Selector' do
       expect(page).to_not have_css('#breadcrumb-23456789', text: 'ABC 456')
     end
   end
+
+  describe 'ad-hoc items', js: true do
+    before do
+      stub_current_user(create(:webauth_user))
+      stub_searchworks_api_json(build(:searchable_holdings))
+      visit new_mediated_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS')
+    end
+
+    it 'are addable and removable' do
+      expect(page).to_not have_css('#breadcrumb-CUSTOMCALLNUMBER', text: 'CUSTOM .CALLNUMBER')
+
+      fill_in 'ad_hoc_items', with: 'CUSTOM .CALLNUMBER'
+      click_link 'Add'
+
+      expect(page).to have_css('#breadcrumb-CUSTOMCALLNUMBER', text: 'CUSTOM .CALLNUMBER')
+
+      # Click the close button on the breadcrumb pill
+      find('#breadcrumb-CUSTOMCALLNUMBER .close').click
+
+      expect(page).to_not have_css('#breadcrumb-CUSTOMCALLNUMBER', text: 'CUSTOM .CALLNUMBER')
+    end
+
+    it 'are not addable when the max-threshold has been reached' do
+      expect(page).to_not have_css('[data-behavior="ad-hoc-items"] a.btn.disabled')
+      within('#item-selector') do
+        check('ABC 123')
+        check('ABC 456')
+        check('ABC 789')
+        check('ABC 012')
+        check('ABC 345')
+      end
+
+      expect(page).to have_css('.breadcrumb-pill', count: 5)
+      expect(page).to have_css('[data-behavior="ad-hoc-items"] a.btn.disabled')
+
+      within('#item-selector') do
+        uncheck('ABC 123')
+      end
+
+      expect(page).to have_css('.breadcrumb-pill', count: 4)
+      expect(page).to_not have_css('[data-behavior="ad-hoc-items"] a.btn.disabled')
+    end
+
+    it 'adds/removes a hidden field' do
+      expect(page).to_not have_css('input[type="hidden"]#hidden-ZZZ123', visible: false)
+
+      fill_in 'ad_hoc_items', with: 'ZZZ 123'
+      click_link 'Add'
+
+      expect(page).to have_css('input[type="hidden"]#hidden-ZZZ123', visible: false)
+
+      # Click the close button on the ad-hoc-item's pill
+      find('#breadcrumb-ZZZ123 .close').click
+
+      expect(page).to_not have_css('input[type="hidden"]#hidden-ZZZ123', visible: false)
+    end
+
+    it 'are persisted' do
+      fill_in 'ad_hoc_items', with: 'ZZZ 321'
+      click_link 'Add'
+      fill_in 'ad_hoc_items', with: 'ZZZ 456'
+      click_link 'Add'
+      fill_in 'ad_hoc_items', with: 'ZZZ 999'
+      click_link 'Add'
+
+      # Click the close button on the last ad-hoc-item's pill
+      find('#breadcrumb-ZZZ999 .close').click
+
+      click_button 'Send request'
+
+      expect(page).to have_css('dt', text: /additional item\(s\)/i)
+      expect(page).to have_css('dd', text: 'ZZZ 321')
+      expect(page).to have_css('dd', text: 'ZZZ 456')
+      expect(page).to_not have_css('dd', text: 'ZZZ 999')
+      expect(Request.last.ad_hoc_items).to eq(['ZZZ 321', 'ZZZ 456'])
+    end
+  end
 end

--- a/spec/javascripts/fixtures/ad_hoc_items_item_selector.html
+++ b/spec/javascripts/fixtures/ad_hoc_items_item_selector.html
@@ -1,0 +1,20 @@
+<div data-behavior='item-selector' data-filter-selected-items='true'>
+  <div data-counter-target="[data-items-counter='true']">
+    <input type='checkbox' data-barcode='123' data-callnumber='ABC 123' />
+    <input type='checkbox' data-barcode='234' data-callnumber='ABC 234' />
+    <input type='checkbox' data-barcode='345' data-callnumber='ABC 345' />
+    <input type='checkbox' data-barcode='456' data-callnumber='ABC 456' />
+    <input type='checkbox' data-barcode='567' data-callnumber='ABC 567' />
+    <input type='checkbox' data-barcode='678' data-callnumber='ABC 678' />
+    <input type='checkbox' data-barcode='789' data-callnumber='ABC 789' />
+    <input type='checkbox' data-barcode='890' data-callnumber='ABC 890' />
+    <input type='checkbox' data-barcode='901' data-callnumber='ABC 901' />
+  </div>
+</div>
+<div data-behavior='ad-hoc-items'>
+  <input type='text' id='ad_hoc_items' />
+  <a href='javascript:;' data-behavior='submit-ad-hoc-items'>Add</a>
+</div>
+
+<div data-items-counter='true'><span data-count='true'>0</span> items selected</div>
+<div data-behavior='breadcrumb-container'></div>

--- a/spec/javascripts/item_selector_ad_hoc_items_spec.js
+++ b/spec/javascripts/item_selector_ad_hoc_items_spec.js
@@ -1,0 +1,52 @@
+//= require item_selector/item_selector_ad_hoc_items
+//= require jasmine-jquery
+
+fixture.preload('ad_hoc_items_item_selector.html');
+
+describe('Item Selector Ad-Hoc Items', function(){
+  beforeAll(function() {
+    this.fixtures = fixture.load('ad_hoc_items_item_selector.html');
+  });
+
+  describe('addItemsInput()', function() {
+    it('is present', function() {
+      expect(itemSelectorAdHocItems.addItemsInput().length).toBe(1);
+    });
+  });
+
+  describe('addItemsButton()', function() {
+    it('is present', function() {
+      expect(itemSelectorAdHocItems.addItemsButton().length).toBe(1);
+    });
+  });
+
+  describe('disableAddButtonOnMaxItems()', function() {
+    it('disables the Add link when max items is reached', function() {
+      expect(
+        itemSelectorAdHocItems.addItemsButton().attr('class')
+      ).not.toMatch('disabled');
+
+      itemSelectorAdHocItems.disableAddButtonOnMaxItems();
+      itemSelectorAdHocItems.selectorElement()
+                            .trigger('item-selector:max-selected-reached');
+
+      expect(
+        itemSelectorAdHocItems.addItemsButton().attr('class')
+      ).toMatch('disabled');
+    });
+  });
+
+  describe('enableAddButtonOnDeselect()', function() {
+    it('enables the Add link when an item is deselected', function() {
+      itemSelectorAdHocItems.enableAddButtonOnDeselect();
+
+      itemSelectorAdHocItems.addItemsButton().addClass('disabled');
+      itemSelectorAdHocItems.selectorElement()
+                            .trigger('item-selector:deselected');
+
+      expect(
+        itemSelectorAdHocItems.addItemsButton().attr('class')
+      ).not.toMatch('disabled');
+    });
+  });
+});

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -34,7 +34,7 @@ describe ConfirmationMailer do
     end
 
     describe 'body' do
-      let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user: user) }
+      let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], ad_hoc_items: ['ZZZ 123'], user: user) }
       let(:body) { mail.body.to_s }
       it 'has the date' do
         expect(body).to match(/On #{request.created_at.strftime('%A, %b %-d %Y')}, you requested the following:/)
@@ -47,6 +47,10 @@ describe ConfirmationMailer do
       it 'has holdings information' do
         expect(body).to include('Item(s) requested:')
         expect(body).to include('ABC 123')
+      end
+
+      it 'has ad hoc items' do
+        expect(body).to include('ZZZ 123')
       end
 
       it 'has a link to the status page' do

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -21,6 +21,17 @@ describe MediatedPage do
     end
   end
 
+  describe '#ad_hoc_item_commentable?' do
+    it 'is true when the library is SPEC-COLL' do
+      subject.origin = 'SPEC-COLL'
+      expect(subject).to be_ad_hoc_item_commentable
+    end
+
+    it 'is false when the library is not SPEC-COLL' do
+      expect(subject).not_to be_ad_hoc_item_commentable
+    end
+  end
+
   describe '#request_commentable?' do
     it 'is true when the library is SPEC-COLL' do
       subject.origin = 'SPEC-COLL'

--- a/spec/models/searchworks_item_spec.rb
+++ b/spec/models/searchworks_item_spec.rb
@@ -135,6 +135,15 @@ describe SearchworksItem do
       end
     end
 
+    describe 'mhld' do
+      describe 'when not present' do
+        let(:item) { build(:green_stacks_searchworks_item) }
+        it 'returns an empty array' do
+          expect(subject.mhld).to eq []
+        end
+      end
+    end
+
     describe 'by_barcode' do
       let(:item) { build(:green_stacks_multi_holdings_searchworks_item) }
       it 'should return the items given an array of barcodes' do

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -62,6 +62,16 @@ describe 'requests/status.html.erb' do
   end
 
   describe 'for medidated pages' do
+    describe 'ad-hoc items' do
+      let(:request) { create(:mediated_page_with_holdings, user: user, ad_hoc_items: ['ZZZ 123', 'ZZZ 321']) }
+      before { render }
+      it 'are displayed when they are present' do
+        expect(rendered).to have_css('dt', text: 'Additional item(s)')
+        expect(rendered).to have_css('dd', text: 'ZZZ 123')
+        expect(rendered).to have_css('dd', text: 'ZZZ 321')
+      end
+    end
+
     describe 'selected items' do
       let(:request) { create(:mediated_page_with_holdings, user: user, barcodes: %w(12345678 23456789)) }
       before { render }

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -80,6 +80,16 @@ describe 'requests/success.html.erb' do
   end
 
   describe 'for medidated pages' do
+    describe 'ad-hoc items' do
+      let(:request) { create(:mediated_page_with_holdings, user: user, ad_hoc_items: ['ZZZ 123', 'ZZZ 321']) }
+      before { render }
+      it 'are displayed when they are present' do
+        expect(rendered).to have_css('dt', text: 'Additional item(s)')
+        expect(rendered).to have_css('dd', text: 'ZZZ 123')
+        expect(rendered).to have_css('dd', text: 'ZZZ 321')
+      end
+    end
+
     describe 'selected items' do
       let(:request) { create(:mediated_page_with_holdings, user: user, barcodes: %w(12345678 23456789)) }
       before { render }


### PR DESCRIPTION
Closes #171 

There is a small refactor in this PR to move the select/deselect events up from the checkbox to the item-selector element itself so that non-checkbox elements can exhibit selected/deselected behaviors.

![ad-hoc-items](https://cloud.githubusercontent.com/assets/96776/8258507/52ed3ab4-166a-11e5-97ff-254dba277fcb.gif)

![success](https://cloud.githubusercontent.com/assets/96776/8258502/49c8106c-166a-11e5-9b22-355f52116f86.png)