### PR TITLE
Allow breadcrumb pills to be inline and move max-items message location.

### DIFF
--- a/app/assets/stylesheets/modules/breadcrumb-pills.scss
+++ b/app/assets/stylesheets/modules/breadcrumb-pills.scss
@@ -2,8 +2,9 @@
   background-color: $white;
   border: 1px solid $breadcrumb-pill-border-color;
   border-radius: 10px;
-  display: table;
+  display: inline-block;
   margin-bottom: 5px;
+  margin-right: 5px;
   padding: 4px;
 
   .pill-addon {

--- a/app/views/shared/_item_selector.html.erb
+++ b/app/views/shared/_item_selector.html.erb
@@ -45,6 +45,7 @@
           </div>
         </div>
       </div>
+      <div data-behavior='max-items-message'></div>
       <% if current_request.ad_hoc_item_commentable? %>
         <div class='form-group'>
           <span class='control-label <%= label_column_class %>'>Add unlisted items</span>
@@ -66,7 +67,6 @@
         </span>
         <div class='<%= content_column_class %>'>
           <div data-behavior='breadcrumb-container'></div>
-          <div data-behavior='max-items-message'></div>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Closes #229 
Closes #230 

<img width="617" alt="item-selector-improvements" src="https://cloud.githubusercontent.com/assets/96776/8755945/78ef6230-2c83-11e5-986b-91d0e6d6cb27.png">
