### PR TITLE
Fix heading on Hold/Recall form and expand definition of…

### DIFF
--- a/app/models/concerns/hold_recallable.rb
+++ b/app/models/concerns/hold_recallable.rb
@@ -3,6 +3,28 @@
 ###
 module HoldRecallable
   def hold_recallable?
+    barcode_present? || on_order? || in_process?
+  end
+
+  private
+
+  def barcode_present?
     @request.requested_barcode.present?
+  end
+
+  def on_order?
+    [current_location, origin_location].include?('ON-ORDER')
+  end
+
+  def in_process?
+    [current_location, origin_location].include?('INPROCESS')
+  end
+
+  def current_location
+    @request.holdings.first.try(:current_location).try(:code)
+  end
+
+  def origin_location
+    @request.origin_location
   end
 end

--- a/app/models/library_location.rb
+++ b/app/models/library_location.rb
@@ -15,7 +15,7 @@ class LibraryLocation
   end
 
   def pageable?
-    !mediateable?
+    !mediateable? && !hold_recallable?
   end
 
   def pickup_libraries

--- a/app/views/hold_recalls/_header.html.erb
+++ b/app/views/hold_recalls/_header.html.erb
@@ -1,1 +1,3 @@
-<h1 id='dialogTitle'><%= t("headers.mediated_page.#{current_request.holdings.first.try(:current_location).try(:code)}", default: t('headers.mediated_page.default')) %></h1>
+<h1 id='dialogTitle'>
+  <%= t("headers.mediated_page.#{current_request.holdings.first.try(:current_location).try(:code) || 'default'}", default: t('headers.mediated_page.default')) %>
+</h1>

--- a/spec/models/concerns/hold_recallable_spec.rb
+++ b/spec/models/concerns/hold_recallable_spec.rb
@@ -15,13 +15,45 @@ describe HoldRecallable do
     subject.request = request
   end
   describe '#HoldRecallable?' do
-    it 'is true when a requested barcode is present' do
-      request.requested_barcode = '3610512345'
-      expect(subject).to be_hold_recallable
+    it 'is false by default' do
+      expect(subject).not_to be_hold_recallable
     end
 
-    it 'is false when a requested barcode is not present' do
-      expect(subject).not_to be_hold_recallable
+    describe 'when a barcode is provided' do
+      it 'is true' do
+        request.requested_barcode = '3610512345'
+        expect(subject).to be_hold_recallable
+      end
+    end
+
+    describe 'when INPROCESS' do
+      it 'is true when the origin_location is INPROCESS' do
+        request.origin_location = 'INPROCESS'
+        expect(request).to be_hold_recallable
+      end
+
+      it 'is true when the current location is INPROCESS' do
+        allow(request).to receive_messages(holdings: [
+          double('holding', current_location: double('location', code: 'INPROCESS'))
+        ])
+
+        expect(request).to be_hold_recallable
+      end
+    end
+
+    describe 'when ON-ORDER' do
+      it 'is true when the origin_location is ON-ORDER' do
+        request.origin_location = 'ON-ORDER'
+        expect(request).to be_hold_recallable
+      end
+
+      it 'is true when the current location is ON-ORDER' do
+        allow(request).to receive_messages(holdings: [
+          double('holding', current_location: double('location', code: 'ON-ORDER'))
+        ])
+
+        expect(request).to be_hold_recallable
+      end
     end
   end
 end

--- a/spec/models/library_location_spec.rb
+++ b/spec/models/library_location_spec.rb
@@ -12,11 +12,17 @@ describe LibraryLocation do
     expect(request.library_location).to be_a HoldRecallable
   end
   describe '#pageable?' do
-    it 'should be true if the LibraryLocation is not mediatable' do
+    it 'should be true if the LibraryLocation is not mediatable or hold recallable' do
       request.origin = 'GREEN'
       request.origin_location = 'STACKS'
       expect(request.library_location).to be_pageable
     end
+
+    it 'is false when the LibraryLocation is hold recallable' do
+      request.requested_barcode = '3610512345678'
+      expect(request.library_location).to_not be_pageable
+    end
+
     it 'should be false if the LibraryLocation is mediatable' do
       request.origin = 'SPEC-COLL'
       request.origin_location = 'STACKS'

--- a/spec/views/hold_recalls/_header.html.erb_spec.rb
+++ b/spec/views/hold_recalls/_header.html.erb_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'hold_recalls/_header.html.erb' do
+  let(:current_request) { double('request') }
+  before do
+    allow(view).to receive_messages(current_request: current_request)
+  end
+  describe 'ON-ORDER' do
+    before do
+      allow(current_request).to receive_messages(holdings: [
+        double('holding', current_location: double('location', code: 'ON-ORDER'))
+      ])
+    end
+    it 'has the correct header' do
+      render
+      expect(rendered).to have_css('h1', text: 'Request on-order item')
+    end
+  end
+
+  describe 'INPROCESS' do
+    before do
+      allow(current_request).to receive_messages(holdings: [
+        double('holding', current_location: double('location', code: 'INPROCESS'))
+      ])
+    end
+    it 'has the correct header' do
+      render
+      expect(rendered).to have_css('h1', text: 'Request in-process item')
+    end
+  end
+
+  describe 'checked out' do
+    before do
+      allow(current_request).to receive_messages(holdings: [
+        double('holding', current_location: double('location', code: 'CHECKEDOUT'))
+      ])
+    end
+    it 'has the correct header' do
+      render
+      expect(rendered).to have_css('h1', text: 'Request checked-out item')
+    end
+  end
+
+  describe 'default' do
+    it 'falls back to the default title when there is no location' do
+      allow(current_request).to receive_messages(holdings: [])
+      render
+      expect(rendered).to have_css('h1', text: 'Request item')
+    end
+
+    it 'falls back to the default title for other locations' do
+      allow(current_request).to receive_messages(holdings: [
+        double('holding', current_location: double('location', code: 'SOMETHING-ELSE'))
+      ])
+      render
+      expect(rendered).to have_css('h1', text: 'Request item')
+    end
+  end
+end


### PR DESCRIPTION
…hold-recallable.

This was caused by a current location that did not exist in the translation table (which we now properly fallback to a default title).

This PR also updates the hold-recallable definition so hopefully people will not get to the hold recall form for items that are not hold-recallable (which was the cause of this particular issue).

### Before
![before](https://cloud.githubusercontent.com/assets/96776/8789266/e8507fe6-2ef5-11e5-9c07-199e1d710a3b.png)

### After
![after](https://cloud.githubusercontent.com/assets/96776/8789265/e83edc8c-2ef5-11e5-9f9d-778bb49ad868.png)
