### PR TITLE
Add customizations to html5 date field for mediated pages

### DIFF
--- a/app/assets/javascripts/date_selector.js
+++ b/app/assets/javascripts/date_selector.js
@@ -1,0 +1,72 @@
+var dateSelector = (function() {
+  var defaultOptions = {
+    mediatedPageFieldSelector: 'input[data-request-type="mediated_page"]'
+  };
+
+  return {
+    init: function(opts) {
+      var _this = this;
+      _this.options = $.extend(defaultOptions, opts);
+      $(document).on('ready page:load', function(){
+        _this.setupListeners();
+      });
+    },
+
+    options: {},
+
+    setupListeners: function() {
+      var _this = this;
+      if ( _this.mediatedDateField().length > 0 ) {
+        pagingScheduleUpdater
+          .schedulerText()
+          .on('paging-schedule:updated', function(_, data) {
+            _this.setMinDate(data.date);
+            _this.restrictToOpenDates(
+              data.destination_business_days
+            );
+        });
+      }
+    },
+
+    setMinDate: function(date) {
+      if (date) {
+        this.mediatedDateField().prop('min', date);
+      }
+    },
+
+    restrictToOpenDates: function(openDates) {
+      var _this = this;
+      _this.mediatedDateField().on('change', function() {
+        if ( openDates.indexOf(_this.selectedDate()) > -1 ) {
+          _this.setDateFieldAsValid();
+        } else {
+          _this.setDateFieldAsInvalid();
+        }
+      });
+    },
+
+    selectedDate: function() {
+      return new Date(
+        this.mediatedDateField().val()
+      ).toISOString().slice(0, 10);
+    },
+
+    setDateFieldAsValid: function() {
+      this.mediatedDateField().closest('.form-group').removeClass('has-error');
+      this.mediatedDateField()[0].setCustomValidity('');
+    },
+
+    setDateFieldAsInvalid: function() {
+      this.mediatedDateField().closest('.form-group').addClass('has-error');
+      this.mediatedDateField()[0].setCustomValidity(
+        'The destination library is not open on ' + this.selectedDate()
+      );
+    },
+
+    mediatedDateField: function() {
+      return $(this.options.mediatedPageFieldSelector);
+    }
+  };
+})();
+
+dateSelector.init();

--- a/app/assets/javascripts/paging_schedule_updater.js
+++ b/app/assets/javascripts/paging_schedule_updater.js
@@ -55,6 +55,7 @@ var pagingScheduleUpdater = (function() {
       if(_this.schedulerText().text() != data.text) {
         _this.schedulerText().text(data.text);
         _this.schedulerText().addClass('highlighted');
+        _this.schedulerText().trigger('paging-schedule:updated', [data]);
         setTimeout(function(){
           _this.schedulerText().removeClass('highlighted');
         }, 1500);

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -12,7 +12,7 @@
   <%= render partial: 'destination_selector', locals: { f: f } %>
 
   <% if current_request.requires_needed_date? %>
-    <%= f.date_field :needed_date %>
+    <%= f.date_field :needed_date, data: { request_type: current_request.type.underscore } %>
   <% end %>
 
   <% if current_request.request_commentable? %>

--- a/spec/javascripts/date_selector_spec.js
+++ b/spec/javascripts/date_selector_spec.js
@@ -1,0 +1,74 @@
+//= require date_selector
+//= require jasmine-jquery
+
+fixture.preload('date_selector.html');
+
+describe('Date Selector', function() {
+  beforeAll(function() {
+    this.fixtures = fixture.load('date_selector.html');
+  });
+
+  describe('setDateFieldAsValid()', function() {
+    it('it removes the error class from the parent form-group', function() {
+      var formGroup = dateSelector.mediatedDateField().closest('.form-group');
+      formGroup.addClass('has-error');
+      expect(formGroup).toHaveClass('has-error');
+      dateSelector.setDateFieldAsValid();
+      expect(formGroup).not.toHaveClass('has-error');
+    });
+  });
+
+  describe('setDateFieldAsInvalid()', function() {
+    it('it adds the error class from the parent form-group', function() {
+      dateSelector.mediatedDateField().val('2016-01-01');
+      var formGroup = dateSelector.mediatedDateField().closest('.form-group');
+      expect(formGroup).not.toHaveClass('has-error');
+      dateSelector.setDateFieldAsInvalid();
+      expect(formGroup).toHaveClass('has-error');
+    });
+  });
+
+  describe('restrictToOpenDates()', function() {
+    it('is invalid when the date is not in the given dates', function() {
+      var formGroup = dateSelector.mediatedDateField().closest('.form-group');
+      dateSelector.restrictToOpenDates(
+        ['2016-01-01', '2016-01-02', '2016-01-03']
+      );
+      expect(formGroup).not.toHaveClass('has-error');
+      dateSelector.mediatedDateField().val('2016-01-04').trigger('change');
+      expect(formGroup).toHaveClass('has-error');
+    });
+
+    it('is valid when the date is in the given dates', function() {
+      var formGroup = dateSelector.mediatedDateField().closest('.form-group');
+      formGroup.addClass('has-error');
+      dateSelector.restrictToOpenDates(
+        ['2016-01-01', '2016-01-02', '2016-01-03']
+      );
+      expect(formGroup).toHaveClass('has-error');
+      dateSelector.mediatedDateField().val('2016-01-03').trigger('change');
+      expect(formGroup).not.toHaveClass('has-error');
+    });
+  });
+
+  describe('setMinDate()', function() {
+    it('sets the min attribute of the input', function() {
+      expect(dateSelector.mediatedDateField().attr('min')).toBeUndefined();
+      dateSelector.setMinDate('2016-01-01');
+      expect(dateSelector.mediatedDateField().attr('min')).toBe('2016-01-01');
+    });
+  });
+
+  describe('selectedDate()', function() {
+    it('gets the value of the date field', function() {
+      dateSelector.mediatedDateField().val('2015-01-01');
+      expect(dateSelector.selectedDate()).toBe('2015-01-01');
+    });
+  });
+
+  describe('mediatedDateField()', function() {
+    it('exists', function() {
+      expect(dateSelector.mediatedDateField()).toExist();
+    });
+  });
+});

--- a/spec/javascripts/fixtures/date_selector.html
+++ b/spec/javascripts/fixtures/date_selector.html
@@ -1,0 +1,5 @@
+<span data-scheduler-text='true'></span>
+
+<div class='form-group'>
+  <input type="date" data-request-type="mediated_page" />
+</div>

--- a/spec/javascripts/item_selector_active_spec.js
+++ b/spec/javascripts/item_selector_active_spec.js
@@ -27,9 +27,9 @@ describe('Item Selector Active Behavior', function() {
       expect(
         firstCheckbox.closest('.input-group.active').length
       ).toBe(1);
-  
+
       itemSelectorBreadcrumbs.removeActive(firstCheckbox);
-      
+
       expect(
         firstCheckbox.closest('.input-group.active').length
       ).toBe(0);

--- a/spec/models/paging_schedule_spec.rb
+++ b/spec/models/paging_schedule_spec.rb
@@ -118,16 +118,18 @@ describe PagingSchedule do
     end
 
     describe 'attributes' do
+      let(:business_days) { ((Time.zone.today + 2.days)...(Time.zone.today + 5.days)).to_a }
       before do
         expect(business_day_double).to receive(:next_business_day).with(
           Time.zone.today + 4.days
         ).at_least(:once).and_return(
           Time.zone.today + 5.days
         )
+        allow(business_day_double).to receive(:business_days).and_return(business_days)
         expect(LibraryHours).to receive(:new).with('SAL3').at_least(:once).and_return(
           double(
             next_business_day: Time.zone.today + 2.days,
-            business_days: ((Time.zone.today + 2.days)...(Time.zone.today + 5.days)).to_a
+            business_days: business_days
           )
         )
       end
@@ -149,6 +151,10 @@ describe PagingSchedule do
 
         it 'includes the text representation' do
           expect(json[:text]).to eq("#{I18n.l(Time.zone.today + 5.days, format: :long)}, before 12n")
+        end
+
+        it 'includes the destination\'s business days' do
+          expect(json[:destination_business_days]).to eq business_days
         end
       end
 


### PR DESCRIPTION
Closes #90 (I think)

- [x] Set min date to the earliest paging estimate
- [x] Set date field as invalid when a date the destination library is not open is selected