### PR TITLE
Explicitly require the needed_date field

### DIFF
--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -12,7 +12,7 @@
   <%= render partial: 'destination_selector', locals: { f: f } %>
 
   <% if current_request.requires_needed_date? %>
-    <%= f.date_field :needed_date, data: { request_type: current_request.type.underscore } %>
+    <%= f.date_field :needed_date, required: true, data: { request_type: current_request.type.underscore } %>
   <% end %>
 
   <% if current_request.request_commentable? %>


### PR DESCRIPTION
Dunno why I thought this was working before (or why rails_bootstrap_form doesn't provide it..) but here we go.