### PR TITLE
Add library instruction notes below the destination library.

### DIFF
--- a/app/models/searchworks_item.rb
+++ b/app/models/searchworks_item.rb
@@ -85,7 +85,16 @@ class SearchworksItem
       location.mhld
     end
 
+    def library_instructions
+      return library.library_instructions if library && library.library_instructions.present?
+      { text: location.name } if location && location_specific_pickup_libraries.keys.include?(location.code)
+    end
+
     private
+
+    def location_specific_pickup_libraries
+      SULRequests::Application.config.location_specific_pickup_libraries
+    end
 
     def barcode_pattern
       /^36105/

--- a/app/views/requests/_destination_selector.html.erb
+++ b/app/views/requests/_destination_selector.html.erb
@@ -1,3 +1,5 @@
 <%= select_for_pickup_libraries(f).html_safe %>
 
+<%= render 'library_instructions' %>
+
 <%= render 'scheduler_text' %>

--- a/app/views/requests/_library_instructions.html.erb
+++ b/app/views/requests/_library_instructions.html.erb
@@ -1,0 +1,8 @@
+<% if current_request.holdings_object.library_instructions.present? %>
+  <div class='alert alert-info <%= "#{label_column_offset_class} #{content_column_class}" %>'>
+    <% if current_request.holdings_object.library_instructions[:heading] %>
+      <h4><%= current_request.holdings_object.library_instructions[:heading] %></h4>
+    <% end %>
+    <%= current_request.holdings_object.library_instructions[:text] %>
+  </div>
+<% end %>

--- a/spec/factories/searchworks_api_json.rb
+++ b/spec/factories/searchworks_api_json.rb
@@ -434,4 +434,39 @@ FactoryGirl.define do
       end.to_h
     end
   end
+
+  factory :library_instructions_holdings, class: Hash do
+    title 'Item Title'
+
+    format ['Book']
+
+    holdings [
+      { 'code' => 'SPEC-COLL',
+        'library_instructions' => {
+          'heading' => 'Instruction Heading',
+          'text' => 'This is the library instruction'
+        },
+        'locations' => [
+          { 'code' => 'STACKS',
+            'items' => [
+              { 'barcode' => '12345678',
+                'callnumber' => 'ABC 123',
+                'type' => 'STKS',
+                'status' => {
+                  'availability_class' => 'available',
+                  'status_text' => 'Available'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+    initialize_with do
+      attributes.map do |k, h|
+        [k.to_s, h]
+      end.to_h
+    end
+  end
 end

--- a/spec/factories/searchworks_items.rb
+++ b/spec/factories/searchworks_items.rb
@@ -58,4 +58,16 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :library_instructions_searchworks_item, class: SearchworksItem do
+    initialize_with { new(create(:request, origin: 'SPEC-COLL', origin_location: 'STACKS')) }
+
+    after(:build) do |item|
+      class << item
+        def json
+          FactoryGirl.build(:library_instructions_holdings)
+        end
+      end
+    end
+  end
 end

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'Library Instructions' do
+  before { stub_searchworks_api_json(build(:library_instructions_holdings)) }
+  it 'returns the library instructions from the API' do
+    visit new_request_path(item_id: '12345', origin: 'SPEC-COLL', origin_location: 'STACKS')
+
+    within('.alert.alert-info') do
+      expect(page).to have_css('h4', text: 'Instruction Heading')
+      expect(page).to have_content('This is the library instruction')
+    end
+  end
+end

--- a/spec/models/searchworks_item_spec.rb
+++ b/spec/models/searchworks_item_spec.rb
@@ -127,6 +127,34 @@ describe SearchworksItem do
       end
     end
 
+    describe '#library_instructions' do
+      let(:item) { build(:green_stacks_searchworks_item) }
+      describe 'when not present' do
+        it 'is nil' do
+          expect(subject.library_instructions).to be_nil
+        end
+      end
+
+      describe 'when present in the SearchWorks API response' do
+        let(:item) { build(:library_instructions_searchworks_item) }
+        it 'returns the library instructions from the API response' do
+          expect(subject.library_instructions[:heading]).to eq 'Instruction Heading'
+          expect(subject.library_instructions[:text]).to eq 'This is the library instruction'
+        end
+      end
+
+      describe 'when the origin location has location specific pickup libraries' do
+        let(:item) { build(:page_mp_mediated_page).searchworks_item }
+        it 'returns the location name as the text' do
+          allow(subject).to receive_messages(location: double(
+            code: 'PAGE-MP',
+            name: 'Paging restricted to Branner'
+          ))
+          expect(subject.library_instructions[:text]).to eq 'Paging restricted to Branner'
+        end
+      end
+    end
+
     describe 'barcoded holdings' do
       let(:item) { build(:green_stacks_multi_holdings_searchworks_item) }
       it 'should only return holdings that have the properly formatted barcode' do


### PR DESCRIPTION
Closes #217 

### Library Note
<img width="585" alt="library-note" src="https://cloud.githubusercontent.com/assets/96776/9017990/80382da8-378f-11e5-884b-995f03251071.png">

### Location Note
<img width="576" alt="location-note" src="https://cloud.githubusercontent.com/assets/96776/9017991/80397c94-378f-11e5-9ad3-9add8635a0a8.png">
