### PR TITLE
Remove form-group class from item selector but use bottom-margin.

### DIFF
--- a/app/assets/stylesheets/modules/item-selector.scss
+++ b/app/assets/stylesheets/modules/item-selector.scss
@@ -36,6 +36,7 @@
 
 .item-selector {
   border: 1px solid $item-selector-border-color;
+  margin-bottom: $form-group-margin-bottom;
   max-height: 300px;
   overflow: auto;
 

--- a/app/views/shared/_item_selector.html.erb
+++ b/app/views/shared/_item_selector.html.erb
@@ -11,7 +11,7 @@
       </div>
       <%= barcode.hidden_field nil, value: f.object.holdings.first.barcode %>
     <% elsif f.object.holdings.many? %>
-      <div id='selected-items-filter' class="form-group" data-behavior='item-selector' data-limit-reached-message="<%= t('sul_requests.limit_reached_message', limit: f.object.item_limit) %>">
+      <div id='selected-items-filter' data-behavior='item-selector' data-limit-reached-message="<%= t('sul_requests.limit_reached_message', limit: f.object.item_limit) %>">
         <% if f.object.holdings.length >= 10 %>
           <div class='form-group'>
             <label class='control-label <%= label_column_class %>' for='item-selector-search'>Search item list</label>


### PR DESCRIPTION
Closes #255 

### Before
<img width="626" alt="before" src="https://cloud.githubusercontent.com/assets/96776/9019036/0057abde-379b-11e5-9c21-adcc05d76299.png">

### After
<img width="624" alt="after" src="https://cloud.githubusercontent.com/assets/96776/9019037/0058cef6-379b-11e5-80da-5c8fd7bd752d.png">
