### PR TITLE
Add estimated delivery date for a page on Scan/Delivery choice form.

### DIFF
--- a/app/views/requests/_form_choice.html.erb
+++ b/app/views/requests/_form_choice.html.erb
@@ -1,12 +1,14 @@
 <div id="scan-or-deliver">
   <div class="row">
     <div class="col-xs-12 col-sm-6 buttons">
-      <%= link_to('Deliver to campus library', delegated_new_request_path(@request), class: 'btn btn-md btn-default', 'aria-describedby' => 'deliveryDescription') %>
+      <%= link_to('Deliver to campus library', delegated_new_request_path(current_request), class: 'btn btn-md btn-default', 'aria-describedby' => 'deliveryDescription') %>
     </div>
-    <div class="col-xs-12 col-sm-6 content">
+    <div class="col-xs-12 col-sm-6 content" data-scheduler-lookup-url='<%= paging_schedule_path(origin: current_request.origin) %>'>
       <dl id="deliveryDescription">
         <dt>Earliest delivery</dt>
-        <dd>Unknown</dd>
+        <dd data-single-library-value='<%= SULRequests::Application.config.default_pickup_library %>'>
+          <span id='scheduler-text' data-scheduler-text='true' aria-live='polite'></span>
+        </dd>
       </dl>
     </div>
   </div>
@@ -15,7 +17,7 @@
   </div>
   <div class="row scan-to-pdf">
     <div class="col-xs-12 col-sm-6 buttons">
-      <%= link_to('Scan to PDF<span class="btn-sub-text">requires SUNet login</span>'.html_safe, new_scan_path(@request, params.except(:controller, :action)), class: 'btn btn-md btn-scan', 'aria-describedby' => 'scanDescription') %>
+      <%= link_to('Scan to PDF<span class="btn-sub-text">requires SUNet login</span>'.html_safe, new_scan_path(current_request, params.except(:controller, :action)), class: 'btn btn-md btn-scan', 'aria-describedby' => 'scanDescription') %>
     </div>
     <div class="col-xs-12 col-sm-6 content">
       <dl id="scanDescription">

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -36,4 +36,14 @@ describe 'Paging Schedule' do
       expect(page).to have_css('#scheduler-text', text: /, (before|after)/, visible: true)
     end
   end
+
+  describe 'form choice page', js: true do
+    before { stub_searchworks_api_json(build(:sal3_holdings)) }
+    it 'shows the estimated delivery for Green Library' do
+      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      within('#deliveryDescription') do
+        expect(page).to have_css('#scheduler-text', text: /, (before|after)/, visible: true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #260 

<img width="530" alt="estimated-delivery-date" src="https://cloud.githubusercontent.com/assets/96776/9142607/b5215cd6-3cf5-11e5-8c66-0a77424ab992.png">

(**note:** the estimated delivery date is Saturday because we don't have SAL3 hours yet)