### PR TITLE
Allow for origin and location specific contact information in emails …

### DIFF
--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -5,6 +5,7 @@ class ConfirmationMailer < ApplicationMailer
   def request_confirmation(request)
     @request = request
     @status_url = success_url
+    @contact_info = formatted_contact_info
     mail(
       to: request.notification_email_address,
       from: from_address,
@@ -15,10 +16,7 @@ class ConfirmationMailer < ApplicationMailer
   private
 
   def from_address
-    I18n.t(
-      "confirmation_email.#{@request.origin.underscore}.from",
-      default: I18n.t('confirmation_email.default.from')
-    )
+    contact_info[:email]
   end
 
   def subject
@@ -27,6 +25,20 @@ class ConfirmationMailer < ApplicationMailer
       title: @request.item_title,
       default: I18n.t('confirmation_email.request.subject')
     )
+  end
+
+  def contact_info
+    contact_info_config[@request.origin_location] ||
+      contact_info_config[@request.origin] ||
+      contact_info_config['default']
+  end
+
+  def contact_info_config
+    SULRequests::Application.config.contact_info
+  end
+
+  def formatted_contact_info
+    "  #{contact_info[:phone]}\n  #{contact_info[:email]}"
   end
 
   def success_url

--- a/app/views/confirmation_mailer/request_confirmation.text.erb
+++ b/app/views/confirmation_mailer/request_confirmation.text.erb
@@ -13,4 +13,4 @@ Check the status of your request at <%= @status_url %>
 
 Questions about your request?
 Contact:
-<%= t("confirmation_email.contact.#{@request.origin.underscore}", default: t('confirmation_email.contact.default')) %>
+<%= @contact_info %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -121,6 +121,33 @@ module SULRequests
       'PAGE-SP' => ['SPEC-COLL']
     }
 
+    config.contact_info = {
+      'HOOVER' => {
+        phone: '(650) 723-2058',
+        email: 'hoovercirc@stanford.edu'
+      },
+      'HV-ARCHIVE' => {
+        phone: '(650) 723-3563',
+        email: 'archives@hoover.stanford.edu'
+      },
+      'HOPKINS' => {
+        phone: '(831) 655-6229',
+        email: 'HMS-Library@lists.stanford.edu'
+      },
+      'PAGE-MP' => {
+        phone: '(650) 723-2746',
+        email: 'brannerlibrary@stanford.edu'
+      },
+      'SPEC-COLL' => {
+        phone: '(650) 725-1022',
+        email: 'specialcollections@stanford.edu'
+      },
+      'default' => {
+        phone: '(650) 723-1493',
+        email: 'greencirc@stanford.edu'
+      }
+    }
+
     config.hours_api_location_map = {
       'ARS' => { library_slug: 'ars', location_slug: 'archive-recorded-sound' },
       'ART' => { library_slug: 'art', location_slug: 'library-circulation' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,10 +52,6 @@ en:
       pages: 'Pages'
       scans: 'Scan requests'
   confirmation_email:
-    contact:
-      default: "  (650) 723-1493\n  greencirc@stanford.edu"
-    default:
-      from: 'greencirc@stanford.edu'
     request:
       subject: 'Item(s) requested (%{title})'
     scan:

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -13,8 +13,24 @@ describe ConfirmationMailer do
     end
 
     describe 'from' do
-      it 'is the default' do
-        expect(mail.from).to eq ['greencirc@stanford.edu']
+      describe 'default' do
+        it 'is the configured default' do
+          expect(mail.from).to eq ['greencirc@stanford.edu']
+        end
+      end
+
+      describe 'origin specific' do
+        let(:request) { create(:mediated_page, user: user) }
+        it 'is the configured from address for the origin' do
+          expect(mail.from).to eq ['specialcollections@stanford.edu']
+        end
+      end
+
+      describe 'location specific' do
+        let(:request) { create(:page_mp_mediated_page, user: user) }
+        it 'is the configured from address for the origin' do
+          expect(mail.from).to eq ['brannerlibrary@stanford.edu']
+        end
       end
     end
 
@@ -56,12 +72,32 @@ describe ConfirmationMailer do
       it 'has a link to the status page' do
         expect(body).to match(%r{Check the status of your request at .*\/pages\/#{request.id}\/status\?token})
       end
+    end
 
-      it 'has contact information' do
-        expect(body).to include('Questions about your request?')
-        expect(body).to include('Contact:')
-        expect(body).to match(/\(\d{3}\) \d{3}-\d{4}/)
-        expect(body).to include('greencirc@stanford.edu')
+    describe 'contact info' do
+      let(:body) { mail.body.to_s }
+      describe 'default' do
+        let(:request) { create(:page_with_holdings, user: user) }
+        it 'includes the configured contact information' do
+          expect(body).to include('Questions about your request?')
+          expect(body).to include('Contact:')
+          expect(body).to match(/\(\d{3}\) \d{3}-\d{4}/)
+          expect(body).to include('greencirc@stanford.edu')
+        end
+      end
+
+      describe 'origin specific' do
+        let(:request) { create(:mediated_page, user: user) }
+        it 'includes the configured contact information' do
+          expect(body).to include('specialcollections@stanford.edu')
+        end
+      end
+
+      describe 'location specific' do
+        let(:request) { create(:page_mp_mediated_page, user: user) }
+        it 'includes the configured contact information' do
+          expect(body).to include('brannerlibrary@stanford.edu')
+        end
       end
     end
   end


### PR DESCRIPTION
…with a default fallback.

Closes #224 