### PR TITLE
Add a (visually) hidden honey-pot email field to catch spammers.

### DIFF
--- a/app/controllers/concerns/request_strong_params.rb
+++ b/app/controllers/concerns/request_strong_params.rb
@@ -12,9 +12,9 @@ module RequestStrongParams
   end
 
   def create_params
+    params.permit(:email)
     params.permit(:modal)
-    params.require(:request).permit(:destination,
-                                    :item_id, :origin, :origin_location,
+    params.require(:request).permit(:item_id, :origin, :origin_location, :destination,
                                     :needed_date,
                                     :item_comment, :request_comment,
                                     :authors, :page_range, :section_title, # scans
@@ -25,6 +25,7 @@ module RequestStrongParams
   end
 
   def update_params
+    params.permit(:email)
     params.permit(:modal)
     params.require(:request).permit(:needed_date)
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -6,6 +6,7 @@ class RequestsController < ApplicationController
   include RequestStrongParams
   include ModalLayout
 
+  before_action :capture_email_field
   before_action :modify_item_selector_checkboxes, only: :create
   before_action :modify_item_proxy_status, only: :create
 
@@ -110,5 +111,12 @@ class RequestsController < ApplicationController
     options[:modal] = params[:modal]
 
     redirect_to polymorphic_path([:successful, current_request], options)
+  end
+
+  def capture_email_field
+    fail HoneyPotFieldError if params[:email].present?
+  end
+
+  class HoneyPotFieldError < StandardError
   end
 end

--- a/app/views/requests/_hidden_form_fields.html.erb
+++ b/app/views/requests/_hidden_form_fields.html.erb
@@ -2,3 +2,7 @@
 <%= f.hidden_field :origin %>
 <%= f.hidden_field :origin_location %>
 <%= hidden_field_tag(:modal, params[:modal]) if params[:modal] %>
+<div style='display:none; visibility:hidden;'>
+  <%= label_tag(:email, 'Ignore this email field. It is used to detect spammers. If you enter anything into this field your message will not be sent.') %>
+  <%= email_field_tag(:email) %>
+</div>

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -155,6 +155,24 @@ describe PagesController do
           end
         ).to change { ConfirmationMailer.deliveries.count }.by(1)
       end
+
+      context 'create/update' do
+        it 'raises an error when the honey-pot email field is filled in on create' do
+          expect(
+            lambda do
+              post :create, request: normal_params, email: 'something'
+            end
+          ).to raise_error(RequestsController::HoneyPotFieldError)
+        end
+
+        it 'raises an error when the honey-pot email field is filled in on update' do
+          expect(
+            lambda do
+              put :update, id: page[:id], email: 'something'
+            end
+          ).to raise_error(RequestsController::HoneyPotFieldError)
+        end
+      end
     end
     describe 'invalid requests' do
       let(:user) { create(:webauth_user) }

--- a/spec/features/honey_pot_field_spec.rb
+++ b/spec/features/honey_pot_field_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe 'Honey Pot Fields' do
+  let(:user) { create(:webauth_user) }
+  before { stub_current_user(user) }
+  context 'Email field' do
+    it 'raises an error if the field has been filled out' do
+      visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
+
+      hidden_field = find('#email', visible: false)
+      hidden_field.set('some-email')
+
+      expect(
+        -> { click_button 'Send request' }
+      ).to raise_error(RequestsController::HoneyPotFieldError)
+    end
+  end
+end


### PR DESCRIPTION
Closes #235 