### PR TITLE
Re-styled broadcast messages

### DIFF
--- a/app/assets/stylesheets/modules/messages.scss
+++ b/app/assets/stylesheets/modules/messages.scss
@@ -23,3 +23,33 @@
     }
   }
 }
+
+.messages {
+  margin-left: 2em;
+
+  h2 {
+    color: $black;
+    float: left;
+    font-size: 1.2em;
+    font-weight: normal;
+  }
+
+  .message {
+    clear: both;
+  }
+
+  .status {
+    color: $cardinal-red;
+  }
+
+  .active {
+    color: $green;
+    font-weight: bold;
+  }
+
+  .edit-message {
+    left: 14px;
+    position: relative;
+    top: 14px;
+  }
+}

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -7,6 +7,7 @@ $gray: #3f3c30;
 $gray-ccc: #ccc;
 $gray-41-percent: #696969;
 $grayish-yellow: #d5d5d3;
+$green: #008000;
 $light-grayish-orange: #f0eeea;
 $light-grayish-yellow: #f7f7f4;
 $lighter-grayish-yellow: #fbfbf9;

--- a/app/views/messages/_messages_for_library.html.erb
+++ b/app/views/messages/_messages_for_library.html.erb
@@ -1,24 +1,48 @@
 <div class="messages">
-<% messages = @messages.select { |m| m.library == library_code && m.request_type == request_type } %>
-<% messages.each do |message| %>
-  <div class="message">
-      <% if message.scheduled? %>
-      <div class="status <%= 'active' if message.active? %>">
-        <% if message.active? %>
-          Active <%= time_tag message.start_at.to_date, :short %> through <%= time_tag message.end_at.to_date, :short %>
-        <% else %>
-          Inactive (was <%= time_tag message.start_at.to_date, :short %> through <%= time_tag message.end_at.to_date, :short %>)
-        <% end %>
-      </div>
-      <% end %>
 
-      <div class="text well-sm">
+  <% messages = @messages.select { |m| m.library == library_code && m.request_type == request_type } %>
+
+  <% if library_code == 'SAL' %>
+    <% library_code = "SAL1&2" %>
+  <% elsif library_code == "SAL-NEWARK"%>
+    <% library_code = "SAL Newark" %>
+  <% end %>
+
+  <h2><%= request_type.titleize + " from " + library_code if messages.none? %></h2>
+  <%= link_to " Add message", new_message_path(library: library_code, request_type: request_type), class: 'btn btn-sm btn-default edit-message glyphicon glyphicon-pencil' if messages.none? %>
+
+  <% messages.each do |message| %>
+  <h2><%= request_type.titleize + " from " + library_code %></h2>
+  <% if message.text.length > 0 %>
+    <%= link_to [:edit, message], class: 'btn btn-sm btn-default edit-message' do %>
+      <i class="glyphicon glyphicon-pencil"> Edit message</i>
+    <% end %>
+  <% else %>
+    <%= link_to new_message_path(library: library_code, request_type: request_type), class: 'btn btn-sm btn-default edit-message' do %>
+      <i class="glyphicon glyphicon-pencil"> Add message</i>
+    <% end %>
+  <% end %>
+
+  <div class="message">
+    <% if message.scheduled? %>
+    <div class="status <%= 'active' if message.active? %>">
+      <% if message.active? %>
+      Active <%= time_tag message.start_at.to_date, :short %> through <%= time_tag message.end_at.to_date, :short %>
+      <% else %>
+      Inactive (was <%= time_tag message.start_at.to_date, :short %> through <%= time_tag message.end_at.to_date, :short %>)
+      <% end %>
+    </div>
+    <% end %>
+
+    <% if message.text.length > 0 %>
+      <div class="text alert alert-warning">
         <%= render message %>
       </div>
+    <% end %>
 
-      <%= link_to "Edit message", [:edit, message] %>
   </div>
-<% end %>
+  <% end %>
 
-<%= link_to "Add message", new_message_path(library: library_code, request_type: request_type) if messages.none? %>
+  <div style="clear: both" ></div>
+
 </div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,18 +1,15 @@
 <h1>Broadcast messages for request forms</h1>
 
 <div>
-  <h2>Page from anywhere</h2>
   <%= render partial: 'messages_for_library', locals: { library_code: 'anywhere', request_type: 'page'} %>
 </div>
 
 <% LibraryLocation.pageable_libraries.each do |library_code, library_name| %>
   <div class="library-page-<%= library_code %>">
-    <h2>Page from <%= library_name %></h2>
-    <%= render partial: 'messages_for_library', locals: { library_code: library_code, request_type: 'page'} %>
+    <%= render partial: 'messages_for_library', locals: { library_name: library_name, library_code: library_code, request_type: 'page'} %>
   </div>
 <% end %>
 
 <div>
-  <h2>Scan from anywhere</h2>
   <%= render partial: 'messages_for_library', locals: { library_code: 'anywhere', request_type: 'scan' } %>
 </div>

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -9,7 +9,6 @@ describe 'Viewing all requests' do
       it 'should list data in tables' do
         visit messages_path
 
-        expect(page).to have_css('h1', text: 'Broadcast messages for request forms')
         expect(page).to have_css('h2', text: /Page from anywhere/)
         expect(page).to have_css('h2', text: /Page from SAL1&2/)
         expect(page).to have_css('h2', text: /Page from SAL3/)


### PR DESCRIPTION
Re-styled broadcast messages view to include buttonized links, alert-style message box, styled active/inactive notes, and the button link moved next to the heading.

Ps. the branch name should have been "206-..." not "260-..."