### PR TITLE
Re-styled broadcast messages

### DIFF
--- a/app/assets/stylesheets/modules/messages.scss
+++ b/app/assets/stylesheets/modules/messages.scss
@@ -23,3 +23,33 @@
     }
   }
 }
+
+.messages {
+  margin-bottom: 26px;
+  margin-left: 2em;
+
+  h2 {
+    color: $black;
+    display: inline;
+    font-size: 1.2em;
+    font-weight: normal;
+  }
+
+  .message {
+    clear: both;
+  }
+
+  .status {
+    color: $cardinal-red;
+  }
+
+  .active {
+    color: $green;
+    font-weight: bold;
+  }
+
+  .edit-message {
+    margin-bottom: 7px;
+    word-spacing: -7px;
+  }
+}

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -7,6 +7,7 @@ $gray: #3f3c30;
 $gray-ccc: #ccc;
 $gray-41-percent: #696969;
 $grayish-yellow: #d5d5d3;
+$green: #008000;
 $light-grayish-orange: #f0eeea;
 $light-grayish-yellow: #f7f7f4;
 $lighter-grayish-yellow: #fbfbf9;

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,26 @@
+###
+#  Helper module for broadcast message related markup
+###
+module MessagesHelper
+  def link_to_edit_message(message)
+    link_to ' Edit message',
+            [:edit, message],
+            class: 'btn
+                    btn-sm
+                    btn-default
+                    edit-message
+                    glyphicon
+                    glyphicon-pencil'
+  end
+
+  def link_to_add_message(library_code, request_type)
+    link_to ' Add message',
+            new_message_path(library: library_code,
+                             request_type: request_type),
+            class: 'btn
+                    btn-sm
+                    btn-default
+                    edit-message
+                    glyphicon glyphicon-pencil'
+  end
+end

--- a/app/views/messages/_messages_for_library.html.erb
+++ b/app/views/messages/_messages_for_library.html.erb
@@ -1,24 +1,41 @@
 <div class="messages">
-<% messages = @messages.select { |m| m.library == library_code && m.request_type == request_type } %>
-<% messages.each do |message| %>
-  <div class="message">
+
+  <% messages = @messages.select { |m| m.library == library_code && m.request_type == request_type } %>
+  <% library = LibraryLocation.library_name_by_code(library_code).to_s %>
+
+  <% if messages.none? %>
+    <h2><%= request_type.titleize + " from #{library.presence || 'anywhere'}" %></h2>
+    <%= link_to_add_message(library_code, request_type) %>
+  <% end %>
+
+  <% messages.each do |message| %>
+    <h2><%= message.title %></h2>
+    <% if message.text.length > 0 %>
+      <%= link_to_edit_message(message) %>
+    <% else %>
+      <%= link_to_add_message(library_code, request_type) %>
+    <% end %>
+
+    <div class="message">
       <% if message.scheduled? %>
-      <div class="status <%= 'active' if message.active? %>">
+        <div class="status <%= 'active' if message.active? %>">
         <% if message.active? %>
           Active <%= time_tag message.start_at.to_date, :short %> through <%= time_tag message.end_at.to_date, :short %>
         <% else %>
           Inactive (was <%= time_tag message.start_at.to_date, :short %> through <%= time_tag message.end_at.to_date, :short %>)
-        <% end %>
-      </div>
       <% end %>
+    </div>
+  <% end %>
 
-      <div class="text well-sm">
-        <%= render message %>
-      </div>
+  <% if message.text.length > 0 %>
+    <div class="text alert alert-warning">
+      <%= render message %>
+    </div>
+  <% end %>
 
-      <%= link_to "Edit message", [:edit, message] %>
   </div>
-<% end %>
+  <% end %>
 
-<%= link_to "Add message", new_message_path(library: library_code, request_type: request_type) if messages.none? %>
+  <div style="clear: both" ></div>
+
 </div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,18 +1,15 @@
 <h1>Broadcast messages for request forms</h1>
 
 <div>
-  <h2>Page from anywhere</h2>
   <%= render partial: 'messages_for_library', locals: { library_code: 'anywhere', request_type: 'page'} %>
 </div>
 
 <% LibraryLocation.pageable_libraries.each do |library_code, library_name| %>
   <div class="library-page-<%= library_code %>">
-    <h2>Page from <%= library_name %></h2>
-    <%= render partial: 'messages_for_library', locals: { library_code: library_code, request_type: 'page'} %>
+    <%= render partial: 'messages_for_library', locals: { library_name: library_name, library_code: library_code, request_type: 'page'} %>
   </div>
 <% end %>
 
 <div>
-  <h2>Scan from anywhere</h2>
   <%= render partial: 'messages_for_library', locals: { library_code: 'anywhere', request_type: 'scan' } %>
 </div>

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -8,7 +8,6 @@ describe 'Viewing all requests' do
       end
       it 'should list data in tables' do
         visit messages_path
-
         expect(page).to have_css('h1', text: 'Broadcast messages for request forms')
         expect(page).to have_css('h2', text: /Page from anywhere/)
         expect(page).to have_css('h2', text: /Page from SAL1&2/)


### PR DESCRIPTION
Re-styled broadcast messages view including re-styled headings, buttonized links next to the heading, and alert-styled message box.

Renamed branch to match issue 206 and committed some changes that @jkeck suggested in closed PR #285.