### PR TITLE
Add text notifying users other than proxies and sponsors that an…

### DIFF
--- a/app/views/requests/success.html.erb
+++ b/app/views/requests/success.html.erb
@@ -14,12 +14,16 @@
     <% if current_request.proxy? %>
       <dd>
         <p>Shared with your proxy group</p>
-        <p class='help-block'>(We've sent a copy of this request to your email and to the designated notification address.)</p>
+        <p class='help-block'><%= t('.email_notification.proxy') %></p>
       </dd>
     <% elsif current_user.sponsor? %>
       <dd>
         <p>Individual Request</p>
-        <p class='help-block'>(We've sent a copy of this request to your email.)</p>
+        <p class='help-block'><%= t('.email_notification.default') %></p>
+      </dd>
+    <% elsif current_request.notification_email_address.present? %>
+      <dd>
+        <p class='help-block'><%= t('.email_notification.default') %></p>
       </dd>
     <% end %>
   </dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,11 @@ en:
       message:
         create: 'Save'
         update: 'Save'
+  requests:
+    success:
+      email_notification:
+        proxy: "(We've sent a copy of this request to your email and to the designated notification address.)"
+        default: "(We've sent a copy of this request to your email.)"
   status_text:
     paged: Paged
     hold: Item is on-site - hold for patron

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -61,7 +61,7 @@ describe 'requests/success.html.erb' do
       it 'is displayed as an individual request' do
         render
         expect(rendered).to include 'Individual Request'
-        expect(rendered).to include "We've sent a copy of this request to your email."
+        expect(rendered).to include 'We&#39;ve sent a copy of this request to your email.'
       end
     end
 
@@ -76,8 +76,28 @@ describe 'requests/success.html.erb' do
         render
         expect(rendered).to include 'Shared with your proxy group'
         expect(rendered).to include <<-EOS.strip
-          We've sent a copy of this request to your email and to the designated notification address.
+          We&#39;ve sent a copy of this request to your email and to the designated notification address.
         EOS
+      end
+    end
+
+    context 'for webauth users' do
+      let(:user) { create(:webauth_user) }
+
+      it 'indicates an email was sent' do
+        render
+        expect(rendered).to include user.to_email_string
+        expect(rendered).to include 'We&#39;ve sent a copy of this request to your email.'
+      end
+    end
+
+    context 'for name + email users' do
+      let(:user) { create(:non_webauth_user) }
+
+      it 'indicates an email was sent' do
+        render
+        expect(rendered).to include user.to_email_string
+        expect(rendered).to include 'We&#39;ve sent a copy of this request to your email.'
       end
     end
   end


### PR DESCRIPTION
…email was sent on the success page.

Closes #291 

## Before
<img width="545" alt="success-before" src="https://cloud.githubusercontent.com/assets/96776/9282198/87a40800-427f-11e5-973d-0b392b977889.png">

## After
<img width="539" alt="success-after" src="https://cloud.githubusercontent.com/assets/96776/9282199/87a5f5de-427f-11e5-9ea7-e87266f58138.png">

