### PR TITLE
[PROPOSAL] Style the destination field to not have the required label…

### DIFF
--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -18,7 +18,7 @@
     width: 3em;
   }
 
-  .required {
+  .required:not([for='request_destination']) {
     &:after {
       @extend .label;
       @extend .label-warning;


### PR DESCRIPTION
… (since it can't be blank).

This is just a proposal, I'm not sure if there's a better way to handle this.  The `required` label is there because we validate the presence of the destination in the model level.

Closes #284 

<img width="577" alt="destination-no-require" src="https://cloud.githubusercontent.com/assets/96776/9286642/7164151c-42ac-11e5-97a6-d968a744e6af.png">
