### PR TITLE
Only show the 'MyAccount' link in the request confirmation email if the request is likely to appear

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -119,6 +119,10 @@ class Request < ActiveRecord::Base
     SubmitSymphonyRequestJob.perform_now(self, options)
   end
 
+  def appears_in_myaccount?
+    user.webauth_user?
+  end
+
   class << self
     # The mediateable_oirgins will make multiple (efficient) database requests
     # in order to return the array of locations that are both configured as mediateable and have existing requests.

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -13,6 +13,10 @@ class Scan < Request
     1
   end
 
+  def appears_in_myaccount?
+    false
+  end
+
   private
 
   def scannable_validator

--- a/app/views/confirmation_mailer/request_confirmation.text.erb
+++ b/app/views/confirmation_mailer/request_confirmation.text.erb
@@ -9,7 +9,7 @@ Item(s) requested:
 <%= @request.data_to_email_s %>
 
 Check the status of your request at <%= @status_url %>
-<% if @request.user.webauth_user? %>You can also see the status at http://library.stanford.edu/myaccount<% end %>
+<% if @request.appears_in_myaccount? %>You can also see the status at http://library.stanford.edu/myaccount<% end %>
 
 Questions about your request?
 Contact:

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -72,6 +72,22 @@ describe ConfirmationMailer do
       it 'has a link to the status page' do
         expect(body).to match(%r{Check the status of your request at .*\/pages\/#{request.id}\/status\?token})
       end
+
+      context 'with a webauth user' do
+        let(:user) { build(:webauth_user) }
+
+        it 'has a link to myaccount' do
+          expect(body).to include 'You can also see the status at http://library.stanford.edu/myaccount'
+        end
+
+        context 'for a scan request' do
+          let(:request) { create(:scan_with_holdings, user: user) }
+
+          it 'excludes the myaccount link for a scan request' do
+            expect(body).not_to include 'You can also see the status at http://library.stanford.edu/myaccount'
+          end
+        end
+      end
     end
 
     describe 'contact info' do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -352,4 +352,19 @@ describe Request do
       subject.send_to_symphony! a: 1
     end
   end
+  describe '#appears_in_myaccount?' do
+    context 'with non-webauth users' do
+      it 'is disabled' do
+        subject.user = create(:library_id_user)
+        expect(subject.appears_in_myaccount?).to be false
+      end
+    end
+
+    context 'for webauth users' do
+      it 'is enabled' do
+        subject.user = create(:webauth_user)
+        expect(subject.appears_in_myaccount?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -26,4 +26,10 @@ describe Scan do
       expect(subject.item_limit).to eq 1
     end
   end
+
+  describe '#appears_in_myaccount?' do
+    it 'is disabled' do
+      expect(subject.appears_in_myaccount?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Fixes #348