### PR TITLE
When displaying status text, use the current location information before checking the home location

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -30,10 +30,10 @@ module RequestsHelper
     case
     when item.is_a?(String) # ad-hoc-item
       t('status_text.unlisted')
-    when item.home_location.ends_with?('-30')
-      t('status_text.paged')
     when item.current_location.try(:code) && item.current_location.code.ends_with?('-LOAN')
       t('status_text.hold')
+    when item.home_location.ends_with?('-30')
+      t('status_text.paged')
     else
       t('status_text.other')
     end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -82,7 +82,7 @@ describe RequestsHelper do
     let(:current_location_loan) do
       double(
         'holding',
-        home_location: 'STACKS',
+        home_location: 'MSS-30',
         current_location: double('location', code: 'GREEN-LOAN')
       )
     end


### PR DESCRIPTION
Fixes #335 