### PR TITLE
Remove leading space in 'Required' label.

### DIFF
--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -23,7 +23,7 @@
     &:after {
       @extend .label;
       @extend .label-warning;
-      content: ' Required';
+      content: 'Required';
       margin-left: 5px;
     }
   }


### PR DESCRIPTION
Closes #339 

### In Firefox
<img width="449" alt="required-label" src="https://cloud.githubusercontent.com/assets/96776/9645008/0ae9105e-517e-11e5-85d9-5da1d97cfdd1.png">
