### PR TITLE
Make SPEC and SAL-NEWARK item commentable and allow ad-hoc items…

### DIFF
--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -4,13 +4,15 @@
 module Commentable
   # Used for adding ad-hoc items that are not listed in the holdings
   def ad_hoc_item_commentable?
-    false
+    SULRequests::Application.config.ad_hoc_item_commentable_libraries.include?(origin)
   end
 
   # Currently used to comment which items you would like if the
   # location you're requesting from is configured as item commentable
   def item_commentable?
-    SULRequests::Application.config.item_commentable_libraries.include?(origin)
+    SULRequests::Application.config.item_commentable_libraries.include?(origin) &&
+      holdings.one? &&
+      holdings_object.mhld.present?
   end
 
   def request_commentable?

--- a/app/models/concerns/request_validations.rb
+++ b/app/models/concerns/request_validations.rb
@@ -6,6 +6,7 @@ module RequestValidations
 
   included do
     validates :item_id, :origin, :origin_location, presence: true
+    validates :item_comment, presence: true, if: :item_commentable?
     validate :requested_holdings_exist
     validate :needed_date_is_not_in_the_past, on: :create
   end

--- a/app/models/requests/hold_recall.rb
+++ b/app/models/requests/hold_recall.rb
@@ -14,4 +14,12 @@ class HoldRecall < Request
   def requires_needed_date?
     true
   end
+
+  def item_commentable?
+    false
+  end
+
+  def ad_hoc_item_commentable?
+    false
+  end
 end

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -17,13 +17,12 @@ class MediatedPage < Request
     super << user.email
   end
 
-  def ad_hoc_item_commentable?
-    return false unless origin == 'SPEC-COLL'
-    true
-  end
-
   def request_commentable?
     commentable_library_whitelist.include?(origin)
+  end
+
+  def item_commentable?
+    false
   end
 
   def requestable_by_all?

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -17,6 +17,14 @@ class Scan < Request
     false
   end
 
+  def item_commentable?
+    false
+  end
+
+  def ad_hoc_item_commentable?
+    false
+  end
+
   private
 
   def scannable_validator

--- a/app/views/shared/_item_comment.html.erb
+++ b/app/views/shared/_item_comment.html.erb
@@ -1,8 +1,8 @@
 <% if current_request.item_commentable? %>
 <div class='form-group'>
-  <%= f.label :item_comment, label_for_comments_field, class: "#{label_column_class} control-label" %>
+  <%= f.label :item_comment, label_for_comments_field, class: "#{label_column_class} control-label required" %>
   <div class='<%= content_column_class %>'>
-    <%= f.text_area_without_bootstrap :item_comment, class: 'form-control' %>
+    <%= f.text_area_without_bootstrap :item_comment, class: 'form-control', required: true %>
     <% if current_request.library_location.mhld.any? { |mhld| mhld.library_has.present? } %>
     <p class='help-block'>
       Library has: <%= current_request.library_location.mhld.map(&:library_has).join(' ').html_safe %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -98,7 +98,8 @@ module SULRequests
       'SAL-NEWARK'
     ]
 
-    config.item_commentable_libraries = ['SAL-NEWARK']
+    config.ad_hoc_item_commentable_libraries = ['SAL-NEWARK', 'SPEC-COLL']
+    config.item_commentable_libraries = ['SAL-NEWARK', 'SPEC-COLL']
 
     config.location_specific_pickup_libraries = {
       'PAGE-AR' => ['ART', 'SPEC-COLL'],

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -54,12 +54,38 @@ describe Request do
     end
 
     describe 'item_commentable?' do
-      it 'is true when the library is SAL-NEWARK' do
-        subject.origin = 'SAL-NEWARK'
-        expect(subject).to be_item_commentable
+      describe 'with holdings' do
+        before do
+          allow(subject).to receive_messages(holdings: [{}])
+          allow(subject).to receive_messages(holdings_object: double('mhld', mhld: [{}]))
+        end
+        it 'is true when the library is SAL-NEWARK or SPEC-COLL' do
+          subject.origin = 'SAL-NEWARK'
+          expect(subject).to be_item_commentable
+
+          subject.origin = 'SPEC-COLL'
+          expect(subject).to be_item_commentable
+        end
+
+        it 'is false when the library is not SAL-NEWARK or SPEC-COLL' do
+          subject.origin = 'GREEN'
+          expect(subject).to_not be_item_commentable
+        end
       end
-      it 'is false when the library is not SAL-NEWARK' do
-        expect(subject).to_not be_item_commentable
+
+      describe 'without holdings' do
+        before do
+          allow(subject).to receive_messages(holdings: [{}])
+          allow(subject).to receive_messages(holdings_object: double('mhld', mhld: nil))
+        end
+
+        it 'is false when the library is SAL-NEWARK or SPEC-COLL' do
+          subject.origin = 'SAL-NEWARK'
+          expect(subject).not_to be_item_commentable
+
+          subject.origin = 'SPEC-COLL'
+          expect(subject).not_to be_item_commentable
+        end
       end
     end
   end

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -7,6 +7,18 @@ describe HoldRecall do
     it { is_expected.not_to be_requestable_with_sunet_only }
   end
 
+  describe 'item_commentable?' do
+    it 'is false' do
+      expect(subject).not_to be_item_commentable
+    end
+  end
+
+  describe 'ad_hoc_item_commentable?' do
+    it 'is false' do
+      expect(subject).not_to be_ad_hoc_item_commentable
+    end
+  end
+
   it 'should have the properly assigned Rails STI attribute value' do
     expect(subject.type).to eq 'HoldRecall'
   end

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -76,6 +76,13 @@ describe MediatedPage do
       expect(subject).to_not be_request_commentable
     end
   end
+
+  describe 'item_commentable?' do
+    it 'is false' do
+      expect(subject).not_to be_item_commentable
+    end
+  end
+
   describe 'TokenEncryptable' do
     it 'should mixin TokenEncryptable' do
       expect(subject).to be_kind_of TokenEncryptable

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -32,4 +32,10 @@ describe Scan do
       expect(subject.appears_in_myaccount?).to be false
     end
   end
+
+  describe 'item_commentable?' do
+    it 'is false' do
+      expect(subject).not_to be_item_commentable
+    end
+  end
 end


### PR DESCRIPTION
… (unless Hold/Recall or Scan).