### PR TITLE
Make Required label inline-block to fix chrome wrapping issue.

### DIFF
--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -24,6 +24,7 @@
       @extend .label;
       @extend .label-warning;
       content: 'Required';
+      display: inline-block;
       margin-left: 5px;
     }
   }


### PR DESCRIPTION
### Before
<img width="494" alt="chrome-before" src="https://cloud.githubusercontent.com/assets/96776/9650716/cda86f3a-51bb-11e5-8928-24c009d35316.png">

### After
<img width="506" alt="chrome-after" src="https://cloud.githubusercontent.com/assets/96776/9650717/cdc20616-51bb-11e5-8458-ca15b174e69c.png">
