### PR TITLE
Refactor SearchworksItem::..::RequestStatus to top-level ItemStatus

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -19,7 +19,7 @@ class AdminController < ApplicationController
   end
 
   def approve_item
-    status = SearchworksItem::RequestedHoldings::RequestStatus.new(@request, params[:item])
+    status = @request.item_status(params[:item])
     status.approve!(current_user.webauth) unless status.approved?
     render json: status, layout: false
   end

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -23,7 +23,7 @@ module RequestsHelper
   end
 
   def request_status_for_ad_hoc_item(request, item)
-    SearchworksItem::RequestedHoldings::RequestStatus.new(request, item)
+    request.item_status(item)
   end
 
   def status_text_for_item(item)

--- a/app/models/item_status.rb
+++ b/app/models/item_status.rb
@@ -1,0 +1,64 @@
+###
+#  ItemStatus class to handle the status data and approval for each barcoded item
+###
+class ItemStatus
+  def initialize(request, id)
+    @request = request
+    @id = id
+    @request.request_status_data ||= {}
+  end
+
+  def as_json(*)
+    {
+      id: @id,
+      approved: approved?,
+      approver: approver,
+      approval_time: localized_approval_time
+    }
+  end
+
+  def approved?
+    status_object[:approved]
+  end
+
+  def approver
+    status_object[:approver]
+  end
+
+  def approval_time
+    status_object[:approval_time]
+  end
+
+  def approve!(user)
+    self.status_object = {
+      approved: true,
+      approval_time: Time.zone.now.to_s,
+      approver: user
+    }
+    @request.send_to_symphony!(barcodes: [@id])
+    @request.save!
+  end
+
+  private
+
+  def localized_approval_time
+    return nil unless approval_time.present?
+    I18n.l(Time.zone.parse(approval_time), format: :short)
+  end
+
+  def status_object
+    @request.request_status_data[@id] || default_status_object
+  end
+
+  def status_object=(value = {})
+    @request.request_status_data[@id] = value
+  end
+
+  def default_status_object
+    {
+      approved: false,
+      approver: nil,
+      approval_time: nil
+    }.with_indifferent_access
+  end
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -134,4 +134,8 @@ class Request < ActiveRecord::Base
       end
     end
   end
+
+  def item_status(id)
+    ItemStatus.new(self, id)
+  end
 end

--- a/app/models/searchworks_item.rb
+++ b/app/models/searchworks_item.rb
@@ -72,7 +72,7 @@ class SearchworksItem
     def all
       return [] unless location.present?
       location.items.map do |item|
-        item.request_status = RequestStatus.new(@searchworks_item.request, item.barcode)
+        item.request_status = @searchworks_item.request.item_status(item.barcode)
         item
       end
     end
@@ -109,68 +109,6 @@ class SearchworksItem
       return unless library.present?
       library.locations.find do |location|
         location.code == @searchworks_item.request.origin_location
-      end
-    end
-
-    ###
-    #  RequestStatus class to handle the status data and approval for each barcoded item
-    ###
-    class RequestStatus
-      def initialize(request, id)
-        @request = request
-        @id = id
-        request.request_status_data ||= {}
-        request.request_status_data[id] ||= {
-          approved: false,
-          approver: nil,
-          approval_time: nil
-        }
-      end
-
-      def as_json(*)
-        {
-          id: @id,
-          approved: approved?,
-          approver: approver,
-          approval_time: localized_approval_time
-        }
-      end
-
-      def status_object
-        @request.request_status_data[@id]
-      end
-
-      def approved?
-        status_object[:approved]
-      end
-
-      def approver
-        status_object[:approver]
-      end
-
-      def approval_time
-        status_object[:approval_time]
-      end
-
-      def approve!(user)
-        self.status_object = {
-          approved: true,
-          approval_time: Time.zone.now.to_s,
-          approver: user
-        }
-        @request.send_to_symphony!(barcodes: [@id])
-        @request.save!
-      end
-
-      private
-
-      def localized_approval_time
-        return nil unless approval_time.present?
-        I18n.l(Time.zone.parse(approval_time), format: :short)
-      end
-
-      def status_object=(value = {})
-        @request.request_status_data[@id] = value
       end
     end
   end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -58,13 +58,8 @@ describe RequestsHelper do
     let(:request) { create(:request) }
     it 'returns the request status object for the item' do
       request_status = request_status_for_ad_hoc_item(request, 'ABC 123')
-      expect(request_status).to be_a SearchworksItem::RequestedHoldings::RequestStatus
-      expect(request.request_status_data['ABC 123']).to eq(
-        'approved' => false,
-        'approver' => nil,
-        'approval_time' => nil
-      )
-      expect(request_status.status_object).to eq(
+      expect(request_status).to be_a ItemStatus
+      expect(request_status.send(:status_object)).to eq(
         'approved' => false,
         'approver' => nil,
         'approval_time' => nil

--- a/spec/models/item_status_spec.rb
+++ b/spec/models/item_status_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe ItemStatus do
+  let(:request) { create(:request) }
+  let(:barcode) { '3610512345' }
+
+  subject { described_class.new(request, barcode) }
+
+  describe '#status_object' do
+    it 'fetches the status object from the request_status_data hash' do
+      expect(subject.send(:status_object)).to eq(
+        'approved' => false,
+        'approver' => nil,
+        'approval_time' => nil
+      )
+    end
+
+    it 'is updated when the item is approved' do
+      expect(request).to receive(:save!)
+      subject.approve!('jstanford')
+      expect(subject.send(:status_object)['approved']).to be true
+      expect(subject.send(:status_object)['approver']).to eq 'jstanford'
+      expect(subject.send(:status_object)['approval_time']).not_to be_nil
+    end
+  end
+
+  describe '#approve!' do
+    it 'persists the status to the request' do
+      expect(request).to receive(:save!)
+      subject.approve!('jstanford')
+
+      status = request.request_status_data[barcode]
+
+      expect(status['approved']).to be true
+      expect(status['approver']).to eq 'jstanford'
+      expect(status['approval_time']).not_to be_nil
+    end
+
+    it 'triggers a request to symphony when an item is approved' do
+      expect(request).to receive(:save!)
+      expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request, barcodes: [barcode])
+      subject.approve!('jstanford')
+    end
+  end
+
+  describe '#as_json' do
+    let(:json) { subject.as_json }
+    before { subject.approve!('jstanford') }
+    it 'returns the identifier' do
+      expect(json[:id]).to eq barcode
+    end
+
+    it 'returns the approved status' do
+      expect(json[:approved]).to be true
+    end
+
+    it 'returns the approver' do
+      expect(json[:approver]).to eq 'jstanford'
+    end
+
+    it 'returns the formatted approval time' do
+      expect(json[:approval_time]).to eq(
+        I18n.l(Time.zone.parse(subject.approval_time), format: :short)
+      )
+    end
+  end
+
+  describe 'accessors' do
+    it 'aliases approved? to the status object' do
+      expect(subject.approved?).to eq subject.send(:status_object)['approved']
+    end
+
+    it 'aliases approver to the status object' do
+      expect(subject.approver).to eq subject.send(:status_object)['approver']
+    end
+
+    it 'aliases approval_time to the status object' do
+      expect(subject.approval_time).to eq subject.send(:status_object)['approval_time']
+    end
+  end
+end


### PR DESCRIPTION
…and only persist non-default statuses (fixes #331 ?)