### PR TITLE
Add status icons/due dates to item selector as well as a note for…

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -26,6 +26,12 @@ linters:
     enabled: true
     max_depth: 5
 
+  # Ignoring particular selectors from format
+  # linting since they are out of our control
+  SelectorFormat:
+    ignored_names:
+      - noncirc_page
+
   StringQuotes:
     enabled: true
     style: single_quotes

--- a/app/assets/javascripts/item_selector/item_selector_checkedout_note.js
+++ b/app/assets/javascripts/item_selector/item_selector_checkedout_note.js
@@ -1,0 +1,37 @@
+var itemSelectorCheckedoutNote = (function() {
+  return $.extend({}, itemSelector, {
+    init: function() {
+      var _this = this;
+      $(document).on('ready page:load', function(){
+        _this.addCheckedoutNoteToggleBehavior();
+      });
+    },
+
+    addCheckedoutNoteToggleBehavior: function() {
+      var _this = this;
+      _this.selectorElement().on('item-selector:selected', function(_, item) {
+        _this.showCheckedoutNote(item);
+      });
+      _this.selectorElement().on('item-selector:deselected', function(_, item) {
+        _this.hideCheckedoutNote(item);
+      });
+    },
+
+    showCheckedoutNote: function(item) {
+      var note = this.checkedoutNote(item);
+      if (note) { note.show(); }
+    },
+
+    hideCheckedoutNote: function(item) {
+      var note = this.checkedoutNote(item);
+      if (note) { note.hide(); }
+    },
+
+    checkedoutNote: function(item) {
+      return item.closest('.input-group')
+                 .find('[data-behavior="checkedout-note"]');
+    }
+  });
+})();
+
+itemSelectorCheckedoutNote.init();

--- a/app/assets/stylesheets/modules/icons.scss
+++ b/app/assets/stylesheets/modules/icons.scss
@@ -1,0 +1,34 @@
+.availability {
+  &:before {
+    margin-right: 5px;
+  }
+
+  &.available {
+    @extend .sul-i-check-2;
+
+    &:after {
+      color: $sul-available-icon-color;
+    }
+  }
+
+  &.noncirc_page {
+    @extend .sul-i-truck-1;
+
+    &:before {
+      color: $sul-noncirc-icon-color;
+    }
+  }
+
+  &.page {
+    @extend .sul-i-truck-1;
+
+    &:before {
+      color: $sul-available-icon-color;
+    }
+  }
+
+  &.unavailable {
+    @extend .sul-i-remove-2;
+    color: $sul-unavailabe-icon-color;
+  }
+}

--- a/app/assets/stylesheets/modules/item-selector.scss
+++ b/app/assets/stylesheets/modules/item-selector.scss
@@ -40,6 +40,11 @@
   max-height: 200px;
   overflow: auto;
 
+  .checkedout-note {
+    color: $color-cardinal-red;
+    display: none;
+  }
+
   .input-group .form-control {
     border-color: $item-selector-border-color;
     border-radius: 0;
@@ -56,6 +61,7 @@
     border-radius: 0;
     border-top: 0;
     color: $btn-default-color;
+    vertical-align: top;
   }
 
   .list .input-group:first-child {
@@ -64,7 +70,8 @@
     }
   }
 
-  .public-note {
+  .public-note,
+  .checkedout-note {
     border-bottom: 1px solid $public-note-border-color;
     border-bottom-right-radius: 4px;
     border-left: 1px solid $public-note-border-color;

--- a/app/assets/stylesheets/sul-requests.scss
+++ b/app/assets/stylesheets/sul-requests.scss
@@ -9,6 +9,7 @@
 @import 'modules/flashes';
 @import 'modules/forms';
 @import 'modules/home-page';
+@import 'modules/icons';
 @import 'modules/item-selector';
 @import 'modules/mediation';
 @import 'modules/messages';

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -28,6 +28,11 @@ $sul-request-form-scan-border-color: $grayish-yellow;
 $sul-topnav-bg-color: $color-cardinal-red;
 $sul-topnavbar-link-color: $color-cardinal-red;
 $sul-paging-estimate-highlight: $pure-yellow;
+$sul-available-icon-color: $color-pantone-334;
+$sul-noncirc-icon-color: $color-pantone-144;
+$sul-unavailabe-icon-color: $color-cardinal-red;
+
+
 
 $btn-beige-color: $color-black;
 $btn-beige-bg: $color-beige-30;

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -51,6 +51,18 @@ module RequestsHelper
     current_request.origin
   end
 
+  def label_for_item_selector_holding(holding)
+    if holding.current_location.try(:code) == 'CHECKEDOUT'
+      content_tag :span, class: 'status pull-right availability unavailable' do
+        "Due #{holding.due_date}"
+      end
+    else
+      content_tag :span, class: "status pull-right availability #{holding.status.availability_class}" do
+        holding.status.status_text
+      end
+    end
+  end
+
   private
 
   def select_for_multiple_libraries(form, pickup_libraries)

--- a/app/views/shared/_item_selector.html.erb
+++ b/app/views/shared/_item_selector.html.erb
@@ -34,7 +34,7 @@
                   </span>
                   <%= barcode.label "_#{holding.barcode}", class: 'form-control' do %>
                     <span class='callnumber'><%= holding.callnumber %></span>
-                    <span class='status pull-right <%= holding.status.availability_class %>'><%= holding.status.status_text %></span>
+                    <%= label_for_item_selector_holding(holding) %>
                   <% end %>
                 <% else %>
                   <span class='input-group-addon barcode-checkbox'>
@@ -42,8 +42,14 @@
                   </span>
                   <%= barcode.label holding.barcode, class: 'form-control' do %>
                     <span class='callnumber'><%= holding.callnumber %></span>
-                    <span class='status pull-right <%= holding.status.availability_class %>'><%= holding.status.status_text %></span>
+                    <%= label_for_item_selector_holding(holding) %>
                   <% end %>
+                <% end %>
+
+                <% if holding.current_location.try(:code) == 'CHECKEDOUT' %>
+                  <div data-behavior='checkedout-note' class='checkedout-note'>
+                    This item is currently in use by another patron. We can still get it for you but we can't estimate the delivery date.
+                  </div>
                 <% end %>
 
                 <% if holding.public_note.present? %>

--- a/spec/factories/searchworks_api_json.rb
+++ b/spec/factories/searchworks_api_json.rb
@@ -469,4 +469,47 @@ FactoryGirl.define do
       end.to_h
     end
   end
+
+  factory :checkedout_holdings, class: Hash do
+    title 'Checked out item'
+
+    format ['Book']
+
+    holdings [
+      { 'code' => 'SAL3',
+        'locations' => [
+          { 'code' => 'STACKS',
+            'items' => [
+              { 'barcode' => '12345678',
+                'callnumber' => 'ABC 123',
+                'type' => 'STKS',
+                'status' => {
+                  'availability_class' => 'available',
+                  'status_text' => 'Available'
+                }
+              },
+              { 'barcode' => '87654321',
+                'callnumber' => 'ABC 321',
+                'current_location' => {
+                  'code' => 'CHECKEDOUT'
+                },
+                'due_date' => '01/01/2015',
+                'type' => 'STKS',
+                'status' => {
+                  'availability_class' => 'page',
+                  'status_text' => 'Available'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+    initialize_with do
+      attributes.map do |k, h|
+        [k.to_s, h]
+      end.to_h
+    end
+  end
 end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -332,4 +332,26 @@ describe 'Item Selector' do
       expect(Request.last.ad_hoc_items).to eq(['ZZZ 321', 'ZZZ 456'])
     end
   end
+
+  describe 'checked out items', js: true do
+    before do
+      stub_current_user(create(:webauth_user))
+      stub_searchworks_api_json(build(:checkedout_holdings))
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+    end
+
+    it 'has the due date' do
+      within('#item-selector') do
+        expect(page).to have_css('.unavailable', text: 'Due 01/01/2015')
+      end
+    end
+
+    it 'toggles the checked out note' do
+      within('#item-selector') do
+        expect(page).not_to have_css('.checkedout-note')
+        find('.unavailable', text: 'Due 01/01/2015').click
+        expect(page).to have_css('.checkedout-note')
+      end
+    end
+  end
 end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -117,4 +117,40 @@ describe RequestsHelper do
       expect(helper.i18n_location_title_key).to eq 'ON-ORDER'
     end
   end
+
+  describe 'label_for_item_selector_holding' do
+    let(:subject) { Capybara.string(label_for_item_selector_holding(holding)) }
+
+    describe 'checked out items' do
+      let(:holding) do
+        double('holding', current_location: double('location', code: 'CHECKEDOUT'), due_date: Time.zone.today)
+      end
+
+      it 'includes the unavailable class' do
+        expect(subject).to have_css('.unavailable')
+      end
+
+      it 'includes the due date' do
+        expect(subject).to have_content("Due #{Time.zone.today}")
+      end
+    end
+
+    describe 'non checked out items' do
+      let(:holding) do
+        double(
+          'holding',
+          current_location: nil,
+          status: double('status', availability_class: 'noncirc_page', status_text: 'In-library use only')
+        )
+      end
+
+      it 'includes the status icon' do
+        expect(subject).to have_css('.noncirc_page')
+      end
+
+      it 'includes the status text' do
+        expect(subject).to have_content('In-library use only')
+      end
+    end
+  end
 end

--- a/spec/javascripts/fixtures/checkedout_item_selector.html.erb
+++ b/spec/javascripts/fixtures/checkedout_item_selector.html.erb
@@ -1,0 +1,8 @@
+<div data-behavior='item-selector' data-filter-selected-items='true'>
+  <div class='input-group'>
+    <input type='checkbox' data-barcode='123' data-callnumber='ABC 123' />
+    <div data-behavior='checkedout-note' style='display:none;'>
+      This is the checked out note
+    </div>
+  </div>
+</div>

--- a/spec/javascripts/item_selector_checkedout_note_spec.js
+++ b/spec/javascripts/item_selector_checkedout_note_spec.js
@@ -1,0 +1,85 @@
+//= require item_selector/item_selector_checkedout_note
+//= require jasmine-jquery
+
+fixture.preload('checkedout_item_selector.html');
+
+describe('Checked Out Note Toggling', function() {
+  beforeAll(function() {
+    this.fixtures = fixture.load('checkedout_item_selector.html');
+  });
+
+  describe('toggling behavior on item select events', function() {
+    beforeEach(function(){
+      itemSelectorCheckedoutNote.addCheckedoutNoteToggleBehavior();
+    });
+
+    it('shows the item checkedout note with the selected event', function() {
+      var checkbox = $('input[type="checkbox"]');
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).not.toBeVisible();
+
+      itemSelectorCheckedoutNote
+        .selectorElement()
+        .trigger('item-selector:selected', [checkbox]);
+
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).toBeVisible();
+    });
+
+    it('hides the item checkedout note with the deselected event', function() {
+      var checkbox = $('input[type="checkbox"]');
+      $('[data-behavior="checkedout-note"]').show();
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).toBeVisible();
+
+      itemSelectorCheckedoutNote
+        .selectorElement()
+        .trigger('item-selector:deselected', [checkbox]);
+
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).not.toBeVisible();
+    });
+  });
+
+  describe('showCheckedoutNote()', function() {
+    it('displays the hidden note', function() {
+      var checkbox = $('input[type="checkbox"]');
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).not.toBeVisible();
+
+      itemSelectorCheckedoutNote.showCheckedoutNote(checkbox);
+
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).toBeVisible();
+    });
+  });
+
+  describe('hideCheckedoutNote()', function() {
+    it('hides the visible note', function() {
+      var checkbox = $('input[type="checkbox"]');
+      $('[data-behavior="checkedout-note"]').show();
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).toBeVisible();
+
+      itemSelectorCheckedoutNote.hideCheckedoutNote(checkbox);
+
+      expect(
+        itemSelectorCheckedoutNote.checkedoutNote(checkbox)
+      ).not.toBeVisible();
+    });
+  });
+
+  describe('checkedoutNote()', function() {
+    it('returns the checkedout note given a checkbox', function() {
+      var checkbox = $('input[type="checkbox"]');
+      expect(itemSelectorCheckedoutNote.checkedoutNote(checkbox)).toExist();
+    });
+  });
+});


### PR DESCRIPTION
…checkedout items about delivery estimates.

Closes #349

<img width="507" alt="in-library-use" src="https://cloud.githubusercontent.com/assets/96776/9696121/cc395bd6-531f-11e5-8b80-cdc16e870d1e.png">
![checkedout-note-toggle](https://cloud.githubusercontent.com/assets/96776/9696120/cb4e4178-531f-11e5-905b-bdcb01ef49d0.gif)
