### PR TITLE
Fixed item title in openurl

### DIFF
--- a/app/models/illiad_openurl.rb
+++ b/app/models/illiad_openurl.rb
@@ -19,7 +19,7 @@ class IlliadOpenurl
   end
 
   def citation_data
-    { 'rft.jtitle': @scan.item_title,
+    { 'rft.jtitle': @scan.searchworks_item.title,
       'rft.au': @scan.authors,
       'rft.pages': @scan.data[:page_range],
       'rft.atitle': @scan.data[:section_title] }


### PR DESCRIPTION
If either of you happen to see this today, please review this PR and merge if it looks good. The SW item title was not being sent in the OpenURL to illiad, but this PR should fix it. If you could deploy it to the requests-dev server as well that would be great. We were going to do a demo for Lane Med today, but I can also demo it from this branch (just not the SW part...). Thanks.
@jkeck @cbeer 