### PR TITLE
Add 'regular staff' as eligible to scan; fixes #417

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ site_admin_groups: []
 scan_pilot_groups:
   - 'stanford:faculty'
   - 'stanford:student'
-  - 'stanford:staff:academic'
+  - 'stanford:staff'
   - 'stanford:affiliate:fellow'
   - 'stanford:affiliate:visitscholarvs'
   - 'stanford:affiliate:visitscholarvt'


### PR DESCRIPTION
Once @jvine confirms 'stanford:staff' is good enough, we can merge this. 