### PR TITLE
Set the site admin contact email to the newly created list; fixes #421

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,7 +17,7 @@ origin_admin_groups:
   PAGE-MP: []
   SPEC-COLL: []
 
-contact_email: 'someone@stanford.edu'
+contact_email: 'site-admin-sul-requests@lists.stanford.edu'
 
 token_encrypt:
   secret: ''


### PR DESCRIPTION
I went back and forth whether this was an environment setting or should just go in the global settings.yml.  Happy to do it on the boxes if that makes more sense to you..