### PR TITLE
Remove short-circuiting of item_commentable? in mediated pages.

### DIFF
--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -23,10 +23,6 @@ class MediatedPage < Request
     commentable_library_whitelist.include?(origin)
   end
 
-  def item_commentable?
-    false
-  end
-
   def requestable_by_all?
     return false if origin == 'HOPKINS'
     true

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -95,12 +95,6 @@ describe MediatedPage do
     end
   end
 
-  describe 'item_commentable?' do
-    it 'is false' do
-      expect(subject).not_to be_item_commentable
-    end
-  end
-
   describe 'all_approved?' do
     let(:subject) { build(:mediated_page_with_holdings) }
     before do


### PR DESCRIPTION
Should have been done in #345. I believe this may have just been an oversight.