### PR TITLE
Allow mediated pages with no needed_date to show up under active scope.

### DIFF
--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -8,7 +8,7 @@ class MediatedPage < Request
   validate :destination_is_a_pickup_library
 
   scope :archived, -> { where('needed_date < ?', Time.zone.today) }
-  scope :active, -> { where('needed_date >= ?', Time.zone.today) }
+  scope :active, -> { where('needed_date IS NULL OR needed_date >= ?', Time.zone.today) }
   scope :for_origin, ->(origin) { where('origin = ? OR origin_location = ?', origin, origin) }
 
   include TokenEncryptable

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -60,8 +60,12 @@ describe MediatedPage do
     end
 
     describe 'active' do
-      it 'reutrns the records whose needed_date is today or a future date' do
+      it 'reutrns the records whose needed_date is today, or a future date' do
         expect(MediatedPage.active.length).to eq 2
+      end
+      it 'reutrns the records whose needed_date is null' do
+        build(:mediated_page).save(validate: false)
+        expect(MediatedPage.active.length).to eq 3
       end
     end
 


### PR DESCRIPTION
Fixes #446 