### PR TITLE
Update production.yml with sul_illiad URL

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+# ILLiad production base URL for OpenURL Requests
+sul_illiad: 'http://scandeliver.stanford.edu/'


### PR DESCRIPTION
Closes #427: Change the sul_illiad url on the production server to: http://scandeliver.stanford.edu/

This is the new webauthproxy url for https://sul-illiad.stanford.edu/illiad/