### PR TITLE
Update mediation screen based on symphony response status.

### DIFF
--- a/app/assets/stylesheets/modules/icons.scss
+++ b/app/assets/stylesheets/modules/icons.scss
@@ -40,3 +40,16 @@
 .sul-i-remove-2 {
   color: $sul-unavailabe-icon-color;
 }
+
+.mediation-table {
+  .errored {
+    .request-status {
+      color: $sul-unavailabe-icon-color;
+
+      &:before {
+        @extend .glyphicon;
+        @extend .glyphicon-exclamation-sign;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/icons.scss
+++ b/app/assets/stylesheets/modules/icons.scss
@@ -29,7 +29,7 @@
 
   &.unavailable {
     @extend .sul-i-remove-2;
-    color: $sul-unavailabe-icon-color;
+    color: $sul-unavailable-icon-color;
   }
 }
 
@@ -38,13 +38,13 @@
 }
 
 .sul-i-remove-2 {
-  color: $sul-unavailabe-icon-color;
+  color: $sul-unavailable-icon-color;
 }
 
 .mediation-table {
   .errored {
     .request-status {
-      color: $sul-unavailabe-icon-color;
+      color: $sul-unavailable-icon-color;
 
       &:before {
         @extend .glyphicon;

--- a/app/assets/stylesheets/modules/mediation.scss
+++ b/app/assets/stylesheets/modules/mediation.scss
@@ -30,7 +30,10 @@
       .approval-btn {
         @extend .disabled;
       }
+    }
 
+    .approved,
+    .errored {
       .request-status {
         display: inline;
       }

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -30,7 +30,7 @@ $sul-topnavbar-link-color: $color-cardinal-red;
 $sul-paging-estimate-highlight: $pure-yellow;
 $sul-available-icon-color: $color-pantone-334;
 $sul-noncirc-icon-color: $color-pantone-144;
-$sul-unavailabe-icon-color: $color-cardinal-red;
+$sul-unavailable-icon-color: $color-cardinal-red;
 
 
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -22,7 +22,12 @@ class AdminController < ApplicationController
   def approve_item
     status = @request.item_status(params[:item])
     status.approve!(current_user.webauth) unless status.approved?
-    render json: status, layout: false
+
+    if @request.symphony_response.success?(params[:item])
+      render json: status, layout: false
+    else
+      render json: status, layout: false, status: 500
+    end
   end
 
   private

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -15,16 +15,7 @@ module RequestsHelper
   end
 
   def status_text_for_item(item)
-    case
-    when item.is_a?(String) # ad-hoc-item
-      t('status_text.unlisted')
-    when item.current_location.try(:code) && item.current_location.code.ends_with?('-LOAN')
-      t('status_text.hold')
-    when item.home_location.ends_with?('-30')
-      t('status_text.paged')
-    else
-      t('status_text.other')
-    end
+    ad_hoc_item_status(item) || status_text_for_errored_item(item) || i18n_status_text(item)
   end
 
   def i18n_location_title_key
@@ -83,6 +74,27 @@ module RequestsHelper
   end
 
   private
+
+  def ad_hoc_item_status(item)
+    return unless item.is_a?(String)
+    t('status_text.unlisted')
+  end
+
+  def i18n_status_text(item)
+    case
+    when item.current_location.try(:code) && item.current_location.code.ends_with?('-LOAN')
+      t('status_text.hold')
+    when item.home_location.ends_with?('-30')
+      t('status_text.paged')
+    else
+      t('status_text.other')
+    end
+  end
+
+  def status_text_for_errored_item(item)
+    return unless item.request_status.errored?
+    item.request_status.symphony_user_error_text || item.request_status.text
+  end
 
   def format_date(date)
     Time.zone.parse(date.to_s).strftime('%Y-%m-%d %I:%M%P')

--- a/app/models/symphony_response.rb
+++ b/app/models/symphony_response.rb
@@ -19,7 +19,7 @@ class SymphonyResponse
   end
 
   def any_error?
-    !success? || erroneous_barcodes.present?
+    usererr_code.present? || erroneous_barcodes.present?
   end
 
   def mixed_status?

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -14,7 +14,7 @@
   </thead>
   <tbody>
     <% @request.holdings.each do |item| %>
-      <tr class='<%= cycle('odd', 'even') %> <%= 'approved' if item.request_status.approved? %>'>
+      <tr class='<%= cycle('odd', 'even') %> <%= 'approved' if item.request_status.approved? %> <%= 'errored' if item.request_status.errored? %>'>
         <td class='col-xs-1'>
           <button class="approval-btn btn btn-xs btn-success" data-behavior="item-approval" data-item-approval-url="<%= approve_item_admin_path(@request, item: item.barcode) %>">
             <% if item.request_status.approved? %>

--- a/app/views/requests/_request_error_alert.html.erb
+++ b/app/views/requests/_request_error_alert.html.erb
@@ -1,0 +1,6 @@
+<% if current_request.symphony_response.any_error? %>
+  <div class='alert alert-danger'>
+    <span class='requested-by'><%= current_request.user.to_email_string %></span>
+    <%= request_level_request_status %>
+  </div>
+<% end %>

--- a/app/views/requests/_success_header.html.erb
+++ b/app/views/requests/_success_header.html.erb
@@ -5,9 +5,4 @@
     <span class="sul-i-remove-2" aria-hidden="true"></span> Can't complete your request
   <% end %>
 </h1>
-<% if current_request.symphony_response.any_error? %>
-  <div class='alert alert-danger'>
-    <span class='requested-by'><%= current_request.user.to_email_string %></span>
-    <%= request_level_request_status %>
-  </div>
-<% end %>
+<%= render 'request_error_alert' %>

--- a/app/views/requests/status.html.erb
+++ b/app/views/requests/status.html.erb
@@ -7,6 +7,9 @@
     <%= render partial: 'status_header' %>
   </dl>
   <hr />
+
+  <%= render 'request_error_alert' %>
+
   <%= render partial: 'searchworks_item_information' %>
   <%= render partial: 'shared/request_status_information' %>
 

--- a/app/views/requests/success.html.erb
+++ b/app/views/requests/success.html.erb
@@ -3,7 +3,7 @@
   <%= render 'searchworks_item_information' %>
   <%= render 'shared/request_status_information' %>
 
-  <% if current_request.symphony_response.success? %>
+  <% if current_request.is_a?(MediatedPage) || current_request.symphony_response.success? %>
     <dl class='dl-horizontal dl-invert'>
       <dt class='sr-only'><%= current_request.class.human_attribute_name :user %></dt>
       <% unless current_request.user.library_id_user? %>

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -122,6 +122,12 @@ describe AdminController do
           MediatedPage.find(mediated_page.id).request_status_data['3610512345']['approved']
         ).to be true
       end
+
+      it 'returns a 500 when the item cannot be approved' do
+        get :approve_item, id: mediated_page.id, item: '3610512345'
+        expect(response.status).to eq 500
+        expect(response).not_to be_successful
+      end
     end
 
     describe 'for anonymous users' do

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -41,4 +41,19 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :request_with_symphony_errors, class: Request do
+    item_id '12345'
+    origin 'SAL3'
+    origin_location 'STACKS'
+    item_title 'Title for Request 12345'
+
+    after(:build) do |request|
+      class << request
+        def symphony_response_data
+          FactoryGirl.build(:symphony_scan_with_multiple_items)
+        end
+      end
+    end
+  end
 end

--- a/spec/factories/symphony_api_response_json.rb
+++ b/spec/factories/symphony_api_response_json.rb
@@ -92,4 +92,27 @@ FactoryGirl.define do
       end.to_h
     end
   end
+
+  factory :symphony_request_with_all_errored_items, class: Hash do
+    req_type 'PAGE'
+    confirm_email 'jlathrop@stanford.edu'
+    requested_items [
+      {
+        'barcode' => '3610512345',
+        'msgcode' => '123',
+        'text' => 'Unknown error'
+      },
+      {
+        'barcode' => '23456789',
+        'msgcode' => '7',
+        'text' => 'Item not found in catalog'
+      }
+    ]
+
+    initialize_with do
+      attributes.map do |k, h|
+        [k.to_s, h]
+      end.to_h
+    end
+  end
 end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -83,33 +83,63 @@ describe RequestsHelper do
 
   describe 'status_text_for_item' do
     let(:other_item) do
-      double('holding', home_location: 'STACKS', current_location: nil)
+      double(
+        'holding',
+        home_location: 'STACKS',
+        current_location: nil,
+        request_status: double(errored?: false)
+      )
     end
     let(:home_location_30) do
-      double('holding', home_location: 'PAGE-30', current_location: nil)
+      double(
+        'holding',
+        home_location: 'PAGE-30',
+        current_location: nil,
+        request_status: double(errored?: false)
+      )
     end
     let(:current_location_loan) do
       double(
         'holding',
         home_location: 'MSS-30',
-        current_location: double('location', code: 'GREEN-LOAN')
+        current_location: double('location', code: 'GREEN-LOAN'),
+        request_status: double(errored?: false)
       )
     end
 
-    it 'returns text for ad-hoc items' do
-      expect(status_text_for_item('ABC-123')).to eq 'Approved for manual processing'
+    context 'from symphony' do
+      let(:error_item) do
+        double(
+          'error-item',
+          request_status: double(
+            'status',
+            errored?: true,
+            symphony_user_error_text: 'User is blocked'
+          )
+        )
+      end
+
+      it 'returns the request status text if the item errored' do
+        expect(status_text_for_item(error_item)).to eq 'User is blocked'
+      end
     end
 
-    it 'returns text for page items' do
-      expect(status_text_for_item(home_location_30)).to eq 'Paged'
-    end
+    context 'from i18n' do
+      it 'returns text for ad-hoc items' do
+        expect(status_text_for_item('ABC-123')).to eq 'Approved for manual processing'
+      end
 
-    it 'returns text for hold items' do
-      expect(status_text_for_item(current_location_loan)).to eq 'Item is on-site - hold for patron'
-    end
+      it 'returns text for page items' do
+        expect(status_text_for_item(home_location_30)).to eq 'Paged'
+      end
 
-    it 'returns text for all other items' do
-      expect(status_text_for_item(other_item)).to eq 'Added to pick list'
+      it 'returns text for hold items' do
+        expect(status_text_for_item(current_location_loan)).to eq 'Item is on-site - hold for patron'
+      end
+
+      it 'returns text for all other items' do
+        expect(status_text_for_item(other_item)).to eq 'Added to pick list'
+      end
     end
   end
 

--- a/spec/javascripts/item_approval_spec.js
+++ b/spec/javascripts/item_approval_spec.js
@@ -18,6 +18,16 @@ describe('Item Approval', function() {
     });
   });
 
+  describe('markRowAsError()', function() {
+    it('adds the errored class to the row', function() {
+      var lastButton = $('button:last');
+      var lastRow = $('tr:last');
+      expect(lastRow).not.toHaveClass('errored');
+      itemApproval.markRowAsError(lastButton);
+      expect(lastRow).toHaveClass('errored');
+    });
+  });
+
   describe('updateApproverInformation()', function() {
     it('adds the given appover data to the approriate element', function() {
       expect($('tr:last td:last').text()).toBe('');

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -27,6 +27,7 @@ describe 'requests/success.html.erb' do
       end
 
       it 'has an error message' do
+        stub_symphony_response(build(:symphony_request_with_all_errored_items))
         render
         expect(rendered).to have_css('.alert.alert-danger', text: /We're unable to complete your request right now/)
       end


### PR DESCRIPTION
Closes #251
Closes #423 

I could easily be compelled to provide screenshots/gifs of mediation approval (just a bit of a pain to setup my dev environment to mimic error states).