### PR TITLE
Don't require library ID field explicitly.

### DIFF
--- a/app/views/requests/_no_sunet_form.html.erb
+++ b/app/views/requests/_no_sunet_form.html.erb
@@ -8,7 +8,6 @@
             <%= uf.text_field_without_bootstrap(
                   :library_id,
                   class: 'form-control',
-                  required: !f.object.requestable_by_all?,
                   data: { behavior: 'single-user-field' }
                 )
             %>

--- a/spec/features/create_hold_recall_spec.rb
+++ b/spec/features/create_hold_recall_spec.rb
@@ -6,7 +6,7 @@ describe 'Creating a hold recall request' do
   end
   let(:user) { create(:webauth_user) }
   describe 'by an anonmyous user', js: true do
-    it 'requires the library id field' do
+    pending 'requires the library id field' do
       form_path = new_hold_recall_path(
         item_id: '1234',
         barcode: '12345678',


### PR DESCRIPTION
HTML5 validation apparently throws an error if a required field is hidden. We need to figure out a better way to handle this in the future.

Closes #474 (FWIW, this branch is deployed to prod right now)