### PR TITLE
Send Item Barcode in ILLiad ILL Number Field

### DIFF
--- a/app/models/illiad_openurl.rb
+++ b/app/models/illiad_openurl.rb
@@ -15,6 +15,7 @@ class IlliadOpenurl
   def item_data
     { 'rft.location': @scan.origin,
       'rft.call_number': first_holding.try(:callnumber),
+      'rft.ill_number': first_holding.try(:barcode),
       'rft.item': first_holding.try(:barcode) }
   end
 


### PR DESCRIPTION
We still want the barcode in the item number field as well as the ill number field.