### PR TITLE
Change event that triggers additional form validation.

### DIFF
--- a/app/assets/javascripts/additional_form_validation.js
+++ b/app/assets/javascripts/additional_form_validation.js
@@ -47,7 +47,7 @@ var additionalFormValidation = (function() {
 
     addInputListenerBehavior: function(input) {
       var _this = this;
-      input.on('blur', function() {
+      input.on('propertychange change input paste blur', function() {
         if(_this.submitButtons().is(':visible')) {
           if ( _this.fieldsAreValid() ) {
             _this.enableButton();


### PR DESCRIPTION
`blur` alone means that the user can get to the end of the form (filled out properly) and the button is still disabled.  When they click on the `Send request` button the `blur` event is fired and the button is enabled (allowing submit) but it is confusing for the user.

This will enable the button as soon as a character is entered that makes the form submittable (further html5 validation can still prevent the form from being submitted, like an invalid email address format).