### PR TITLE
Don't redirect success pages through webauth login.

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -83,7 +83,8 @@ class RequestsController < ApplicationController
   end
 
   def rescue_status_pages
-    return unless !current_user.webauth_user? && %w(success status).include?(params[:action])
+    return unless params[:action].to_sym == :status
+    return if current_user.webauth_user?
     redirect_to login_path(referrer: request.original_url)
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -266,14 +266,11 @@ describe PagesController do
 
     context 'by non-webuth users' do
       let(:user) { create(:non_webauth_user) }
-      it 'redirects the user to the webauth login with the current url' do
+      it 'raised an AccessDenied error' do
         page = create(:page, user: create(:non_webauth_user, email: 'jjstanford@stanford.edu'))
-        get :success, id: page[:id]
-        expect(response).to redirect_to(
-          login_path(
-            referrer: successful_page_url(page[:id])
-          )
-        )
+        expect do
+          get :success, id: page[:id]
+        end.to raise_error(CanCan::AccessDenied)
       end
     end
   end


### PR DESCRIPTION
Users should already be authed when they're redirected to the success page.

