### PR TITLE
Add an interstitial page to have WebAuth redirect to to complete requests

### DIFF
--- a/app/controllers/interstitial_controller.rb
+++ b/app/controllers/interstitial_controller.rb
@@ -1,0 +1,23 @@
+###
+#  This controller simply handles incoming requests (and responds immediately)
+#  then redirects the user to the requested url. This allows us to take the user from WebAuth
+#  and send them to their destination w/o allowing them to submit multiple superfluous requests
+###
+class InterstitialController < ApplicationController
+  layout false
+
+  before_action do
+    render(file: 'public/500.html', status: 500) unless redirect_param_same_as_host?
+  end
+
+  def show
+    @redirect_to = URI.decode(params[:redirect_to])
+  end
+
+  private
+
+  def redirect_param_same_as_host?
+    return false if params[:redirect_to].blank?
+    URI.parse(URI.decode(params[:redirect_to])).host == request.host
+  end
+end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -89,7 +89,8 @@ class RequestsController < ApplicationController
 
   def bounce_request_through_webauth
     request_params = params[:request].except(:user_attributes)
-    referrer = polymorphic_path([:create, current_request], request_context_params.merge(request: request_params))
+    create_path = polymorphic_url([:create, current_request], request_context_params.merge(request: request_params))
+    referrer = interstitial_path(redirect_to: create_path)
     redirect_to login_path(referrer: referrer)
   end
 

--- a/app/views/interstitial/show.html.erb
+++ b/app/views/interstitial/show.html.erb
@@ -1,0 +1,8 @@
+<div id='redirectNote'>
+  <a href='<%= @redirect_to %>'>Click here if you are not redirected.</a>
+</div>
+<script type='text/javascript'>
+  var div = document.getElementById('redirectNote');
+  div.innerHTML = 'Processing...';
+  window.location.href = '<%= @redirect_to %>';
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   #sorry page route
   get 'sorry/unable'
 
+  get 'interstitial' => 'interstitial#show', as: :interstitial
+
   # Auhtorization routes
   get 'webauth/login' => 'authentication#login', as: :login
   get 'webauth/logout' => 'authentication#logout', as: :logout

--- a/spec/controllers/hold_recall_controller_spec.rb
+++ b/spec/controllers/hold_recall_controller_spec.rb
@@ -36,8 +36,10 @@ describe HoldRecallsController do
         post :create, request: normal_params
         expect(response).to redirect_to(
           login_path(
-            referrer: create_hold_recalls_path(
-              request: normal_params
+            referrer: interstitial_path(
+              redirect_to: create_hold_recalls_url(
+                request: normal_params
+              )
             )
           )
         )

--- a/spec/controllers/interstitial_controller_spec.rb
+++ b/spec/controllers/interstitial_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe InterstitialController do
+  describe 'show' do
+    it 'renders a 500 error if there is no redirect_to parameter' do
+      get :show
+      expect(response).not_to be_success
+      expect(response.status).to eq 500
+    end
+
+    it 'renders a 500 error if the redirect_to parameter does not include the original request host' do
+      get :show, redirect_to: 'http://google.com?p=http://test.host'
+      expect(response).not_to be_success
+      expect(response.status).to eq 500
+    end
+
+    it 'successfully responds when the redirec_to parameter is the same host' do
+      get :show, redirect_to: 'http://test.host/some-route'
+      expect(response).to be_success
+      expect(response.status).to eq 200
+    end
+
+    it 'assigns the decoded url to the @redirect_to variable' do
+      get :show, redirect_to: 'http:%2F%2Ftest.host%2Fsome-route'
+      expect(assigns(:redirect_to)).to eq 'http://test.host/some-route'
+    end
+  end
+end

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -42,10 +42,12 @@ describe MediatedPagesController do
         }
         expect(response).to redirect_to(
           login_path(
-            referrer: create_mediated_pages_path(
-              request: {
-                item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS', destination: 'SPEC-COLL'
-              }
+            referrer: interstitial_path(
+              redirect_to: create_mediated_pages_url(
+                request: {
+                  item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS', destination: 'SPEC-COLL'
+                }
+              )
             )
           )
         )

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -35,8 +35,10 @@ describe PagesController do
         post :create, request: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS', destination: 'BIOLOGY' }
         expect(response).to redirect_to(
           login_path(
-            referrer: create_pages_path(
-              request: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS', destination: 'BIOLOGY' }
+            referrer: interstitial_path(
+              redirect_to: create_pages_url(
+                request: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS', destination: 'BIOLOGY' }
+              )
             )
           )
         )

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -36,8 +36,10 @@ describe ScansController do
         post :create, request: { item_id: '12345', origin: 'GREEN', origin_location: 'STACKS' }
         expect(response).to redirect_to(
           login_path(
-            referrer: create_scans_path(
-              request: { item_id: '12345', origin: 'GREEN', origin_location: 'STACKS' }
+            referrer: interstitial_path(
+              redirect_to: create_scans_url(
+                request: { item_id: '12345', origin: 'GREEN', origin_location: 'STACKS' }
+              )
             )
           )
         )

--- a/spec/features/interstitial_redirect_spec.rb
+++ b/spec/features/interstitial_redirect_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'Interstitial page redirect' do
+  it 'redirects to the page in the redirect_to parameter', js: true do
+    allow(Capybara).to receive_messages(app_host: 'http://www.example.com')
+    visit interstitial_path(redirect_to: root_url)
+
+    # This is the heading for www.example.com (I don't really know a better way to test this, we may need to chuck it)
+    expect(page).to have_css('h1', text: 'Example Domain')
+  end
+
+  it 'includes a link to allow non-js browsers to continue with the redirect' do
+    visit interstitial_path(redirect_to: root_url)
+
+    expect(page).to have_css('#redirectNote a', text: 'Click here if you are not redirected.')
+  end
+end


### PR DESCRIPTION
This allows us to take over from WebAuth as soon as possible and show the user a message while we're processing (instead of leaving them in the WebAuth form where subsequent requests cause errors).

@cbeer `¯\_(ツ)_/¯`