### PR TITLE
Empty the ad-hoc item commentable libraries configuration.

### DIFF
--- a/app/models/requests/hold_recall.rb
+++ b/app/models/requests/hold_recall.rb
@@ -18,8 +18,4 @@ class HoldRecall < Request
   def item_commentable?
     false
   end
-
-  def ad_hoc_item_commentable?
-    false
-  end
 end

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -21,10 +21,6 @@ class Scan < Request
     false
   end
 
-  def ad_hoc_item_commentable?
-    false
-  end
-
   def destination
     'SCAN'
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,7 +101,10 @@ module SULRequests
       'SAL-NEWARK'
     ]
 
-    config.ad_hoc_item_commentable_libraries = ['SAL-NEWARK', 'SPEC-COLL']
+    # ad_hoc_item_commentable_libraries is configured to not display for any library.
+    # Keeping this feature in case SPEC-COLL changes thier minds or we need to add
+    # this behavior for another library.
+    config.ad_hoc_item_commentable_libraries = []
     config.item_commentable_libraries = ['SAL-NEWARK', 'SPEC-COLL']
 
     config.location_specific_pickup_libraries = {

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -259,6 +259,7 @@ describe 'Item Selector' do
 
   describe 'ad-hoc items', js: true do
     before do
+      expect(SULRequests::Application.config).to receive(:ad_hoc_item_commentable_libraries).and_return(['SPEC-COLL'])
       stub_searchworks_api_json(build(:searchable_holdings))
       visit new_mediated_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS')
     end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -88,6 +88,31 @@ describe Request do
         end
       end
     end
+
+    describe 'ad_hoc_item_commentable?' do
+      context 'when no libraries are configured' do
+        it 'is false' do
+          expect(subject).not_to be_ad_hoc_item_commentable
+        end
+      end
+
+      context 'when a library is configured' do
+        before do
+          libs = ['SAL-NEWARK']
+          expect(SULRequests::Application.config).to receive(:ad_hoc_item_commentable_libraries).and_return(libs)
+        end
+
+        it 'is true for that library' do
+          subject.origin = 'SAL-NEWARK'
+          expect(subject).to be_ad_hoc_item_commentable
+        end
+
+        it 'is false for other libraries' do
+          subject.origin = 'NOT-SAL-NEWARK'
+          expect(subject).not_to be_ad_hoc_item_commentable
+        end
+      end
+    end
   end
 
   describe 'requestable' do

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -13,12 +13,6 @@ describe HoldRecall do
     end
   end
 
-  describe 'ad_hoc_item_commentable?' do
-    it 'is false' do
-      expect(subject).not_to be_ad_hoc_item_commentable
-    end
-  end
-
   it 'should have the properly assigned Rails STI attribute value' do
     expect(subject.type).to eq 'HoldRecall'
   end

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -90,17 +90,6 @@ describe MediatedPage do
     end
   end
 
-  describe '#ad_hoc_item_commentable?' do
-    it 'is true when the library is SPEC-COLL' do
-      subject.origin = 'SPEC-COLL'
-      expect(subject).to be_ad_hoc_item_commentable
-    end
-
-    it 'is false when the library is not SPEC-COLL' do
-      expect(subject).not_to be_ad_hoc_item_commentable
-    end
-  end
-
   describe '#request_commentable?' do
     it 'is true when the library is SPEC-COLL' do
       subject.origin = 'SPEC-COLL'

--- a/spec/views/shared/_item_selector.html.erb_spec.rb
+++ b/spec/views/shared/_item_selector.html.erb_spec.rb
@@ -4,6 +4,7 @@ describe 'shared/_item_selector.html.erb' do
   let(:user) { create(:webauth_user) }
 
   before do
+    allow(SULRequests::Application.config).to receive(:ad_hoc_item_commentable_libraries).and_return(['SPEC-COLL'])
     view.bootstrap_form_for(request, url: '/') do |f|
       @f = f
     end


### PR DESCRIPTION
Closes #510 

## Before
<img width="600" alt="before" src="https://cloud.githubusercontent.com/assets/96776/19095500/c867a536-8a4a-11e6-8821-facaefde040d.png">

## After
<img width="621" alt="after" src="https://cloud.githubusercontent.com/assets/96776/19095501/c867d6fa-8a4a-11e6-93b4-6f68d97e9a8b.png">
