### PR TITLE
confirmation email: include year in 'not needed after' date

### DIFF
--- a/app/views/confirmation_mailer/request_confirmation.text.erb
+++ b/app/views/confirmation_mailer/request_confirmation.text.erb
@@ -9,7 +9,7 @@ Item(s) requested:
 <%= @request.data_to_email_s %>
 
 <% if @request.needed_date.present? %>
-<%= "#{@request.class.human_attribute_name(:needed_date)}: #{l @request.needed_date, format: :quick}" %>
+<%= "#{@request.class.human_attribute_name(:needed_date)}: #{l @request.needed_date, format: :long}" %>
 <% end %>
 
 Check the status of your request at <%= @status_url %>

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -82,7 +82,7 @@ describe ConfirmationMailer do
         end
 
         it 'has a planned date of use' do
-          expect(body).to include "Planned date of use: #{I18n.l request.needed_date, format: :quick}"
+          expect(body).to include "Planned date of use: #{I18n.l request.needed_date, format: :long}"
         end
       end
 


### PR DESCRIPTION
closes #528 

Once I figured out 
* where the email text came from (`app/views/confirmation_mailer/request_confirmation.text.erb`) 
* where `format: :quick` came from (`config/locales/en.yml`  `date/formats`) 

then it was easy to use the `long` format instead of the `quick` format in the email.

@jkeck Presumably only the confirmation email needs the change, not the mediation email or the admin/library_table.