### PR TITLE
Add a data flag on the item approval link that allows us to ensure…

### DIFF
--- a/app/assets/javascripts/item_approval.js
+++ b/app/assets/javascripts/item_approval.js
@@ -18,10 +18,13 @@ var itemApproval = (function() {
     addApprovalBehavior: function() {
       var _this = this;
       $(document).on('click', _this.options.buttonSelector, function() {
-        var row = $(this).closest('tr');
-        if(!_this.rowIsApproved(row)) {
-          _this.approveItem($(this));
+        if($(this).data('approval-behavior-added') === undefined) {
+          var row = $(this).closest('tr');
+          if(!_this.rowIsApproved(row)) {
+            _this.approveItem($(this));
+          }
         }
+        $(this).data('approval-behavior-added', 'true');
       });
     },
 


### PR DESCRIPTION
…that a single click only triggers a single ajax request.

I believe that this will alleviate some of the issues `User already has a hold` with item approval in the mediation admin.

## Before
![approval-before](https://cloud.githubusercontent.com/assets/96776/19289283/e08c5728-8fbe-11e6-9b90-894e03291c2a.gif)

## After
![approval-after](https://cloud.githubusercontent.com/assets/96776/19289289/e5fddf06-8fbe-11e6-8ce3-90abfa00c768.gif)
