### PR TITLE
mediation page: title and status links should open in a new window

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -100,8 +100,8 @@ module RequestsHelper
     Time.zone.parse(date.to_s).strftime('%Y-%m-%d %I:%M%P')
   end
 
-  def searchworks_link(item_id, item_title)
-    link_to item_title, "#{Settings.searchworks_link}/#{item_id}", 'data-behavior': 'truncate'
+  def searchworks_link(item_id, item_title, html_options = {})
+    link_to item_title, "#{Settings.searchworks_link}/#{item_id}", html_options
   end
 
   def requester_info(user)

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -21,11 +21,11 @@
           </span>
         </td>
         <td class='needed_date'><%= time_tag(request.needed_date, :quick) %></td>
-        <td class='title'><%= searchworks_link(request.item_id, request.item_title) %></td>
+        <td class='title'><%= searchworks_link(request.item_id, request.item_title, target: '_blank', rel: 'noopener noreferrer', 'data-behavior' => 'truncate') %></td>
         <td class='requester'><%= requester_info(request.user) %></td>
         <td class='created_at'><%= time_tag(request.created_at, :short) %></td>
         <td class='comment'><%= request.request_comment %></td>
-        <td><%= link_to('Status', polymorphic_path([:status, request])) %></td>
+        <td><%= link_to('Status', polymorphic_path([:status, request]), target: '_blank', rel: 'noopener noreferrer') %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -38,7 +38,7 @@
           <td><%= request.type %></td>
           <td><%= request.origin %></td>
           <td><%= request.destination %></td>
-          <td><%= searchworks_link(request.item_id, request.item_title) %></td>
+          <td><%= searchworks_link(request.item_id, request.item_title, 'data-behavior' => 'truncate') %></td>
           <td><%= requester_info(request.user) %></td>
           <td><%= time_tag(request.created_at, :short) %></td>
           <td><%= link_to('Status', polymorphic_path([:status, request])) %></td>

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -198,5 +198,12 @@ describe 'Mediation table', js: true do
         expect(page).to have_css('td', text: 'ABC 321')
       end
     end
+
+    it 'has title and status links that open in a new window, with rel="noopener noreferrer"' do
+      expect(page).to have_css('td.title a[target="_blank"]', text: 'Title of MediatedPage 1234')
+      expect(page).to have_css('td.title a[rel="noopener noreferrer"]', text: 'Title of MediatedPage 1234')
+      expect(page).to have_css('td a[target="_blank"]', text: 'Status')
+      expect(page).to have_css('td a[rel="noopener noreferrer"]', text: 'Status')
+    end
   end
 end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -49,9 +49,9 @@ describe RequestsHelper do
     end
   end
   describe 'searchworks link' do
-    it 'should construct a searchworks link' do
-      result = '<a data-behavior="truncate" href="http://searchworks.stanford.edu/view/234">A title</a>'
-      expect(searchworks_link('234', 'A title')).to eq result
+    it 'should construct a searchworks link including the passed in html_options' do
+      result = '<a data-elt-opt="somebehavior" href="http://searchworks.stanford.edu/view/234">A title</a>'
+      expect(searchworks_link('234', 'A title', 'data-elt-opt' => 'somebehavior')).to eq result
     end
   end
   describe 'requester info' do


### PR DESCRIPTION
* requests_helper.rb: allow specification of additional html_options for link_to
* _library_table.html.erb: set target to '_blank' and rel to 'noopener noreferrer' for title and status links
* mediation_table_spec.rb: add tests for mediation page title and status links, check that link is defined to open in new window.

<img width="1449" alt="screen shot 2016-10-11 at 6 42 23 pm" src="https://cloud.githubusercontent.com/assets/7741604/19294546/9abea394-8fe2-11e6-8fd5-9fb1f7433a18.png">

closes #509
connects to #509