### PR TITLE
Don't lock the capistrano version.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,3 @@
-# config valid only for current version of Capistrano
-lock '3.6.0'
-
 set :application, 'sul-requests'
 set :repo_url, 'https://github.com/sul-dlss/sul-requests.git'
 set :deploy_host, "requests-#{fetch(:stage)}.stanford.edu"


### PR DESCRIPTION
This hasn't really bitten anybody and we should figure out deploy problems as they occur (since we'll also be managing our version of capistrano).