### PR TITLE
Add a class to the alert that wraps the destination selector and date…

### DIFF
--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -4,6 +4,10 @@
   }
 }
 
+.destination-note-callout {
+  color: $text-color;
+}
+
 hr {
   border: 0;
   border-top: 1px solid $grayish-yellow;

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -9,7 +9,7 @@
 
   <%= render partial: 'form_additional', locals: { f: f } %>
 
-  <div class="alert alert-warning">
+  <div class="alert alert-warning destination-note-callout">
     <%= render partial: 'destination_selector', locals: { f: f } %>
 
     <% if current_request.requires_needed_date? %>


### PR DESCRIPTION
… picker and style the font color to the base font color.

Closes #576 

## Before
<img width="578" alt="text-color-before" src="https://cloud.githubusercontent.com/assets/96776/19331374/7e216ab6-9099-11e6-950f-ac4787420dd7.png">

## After
<img width="599" alt="text-color-after" src="https://cloud.githubusercontent.com/assets/96776/19331375/7e326028-9099-11e6-9f6d-ab3a05847f28.png">
