### PR TITLE
truncate comments (with toggle) in library table

### DIFF
--- a/app/assets/javascripts/truncate.js
+++ b/app/assets/javascripts/truncate.js
@@ -1,13 +1,33 @@
 var truncate = (function() {
     return {
         init: function() {
-          $(document).on('turbolinks:load', function() {
-            $("[data-behavior='truncate']").trunk8({
-              lines: 2,
-              tooltip: false
+            var toggleLess = ' <a class="trunk8toggle-less" href="#">less</a>';
+            var toggleMore = ' <a class="trunk8toggle-more" href="#">more</a>';
+            var trunk8Settings = {
+                lines: 2,
+                tooltip: false
+            };
+
+            $(document).on('turbolinks:load', function() {
+                $("[data-behavior='truncate'],[data-behavior='trunk8toggle']").trunk8(trunk8Settings);
+
+                $("[data-behavior='trunk8toggle']").each(function() {
+                    if ($(this).text()) {
+                        $(this).append(toggleMore);
+                    }
+                });
             });
-          });
-      }
+
+            $(document).on('click', '.trunk8toggle-more', function () {
+                $(this).parent().trunk8('revert').append(toggleLess);
+                return false;
+            });
+
+            $(document).on('click', '.trunk8toggle-less', function () {
+                $(this).parent().trunk8(trunk8Settings).append(toggleMore);
+                return false;
+           });
+        }
     };
 }());
 

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -24,7 +24,7 @@
         <td class='title'><%= searchworks_link(request.item_id, request.item_title, target: '_blank', rel: 'noopener noreferrer', 'data-behavior' => 'truncate') %></td>
         <td class='requester'><%= requester_info(request.user) %></td>
         <td class='created_at'><%= time_tag(request.created_at, :short) %></td>
-        <td class='comment'><%= request.request_comment %></td>
+        <td class='comment'><div data-behavior='trunk8toggle'><%= request.request_comment %></div></td>
         <td><%= link_to('Status', polymorphic_path([:status, request]), target: '_blank', rel: 'noopener noreferrer') %></td>
       </tr>
     <% end %>

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -1,3 +1,7 @@
+long_comment = <<-LONG
+  It's wonderful to be here it's certainly a thrill you're such a lovely audience we'd love to take you home with us we'd love to take you home no really we'd really really love to take you home especially if you are a cute puppy.
+LONG
+
 FactoryGirl.define do
   factory :mediated_page do
     item_id '1234'
@@ -55,6 +59,7 @@ FactoryGirl.define do
     origin_location 'STACKS'
     destination 'SPEC-COLL'
     needed_date Time.zone.today
+    request_comment long_comment
     association :user, factory: :sequence_webauth_user
 
     after(:build) do |request|

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -29,7 +29,31 @@ describe 'Mediation table', js: true do
       visit admin_path('SPEC-COLL')
     end
 
-    describe 'successfull symphony response' do
+    context 'toggleable truncation of user request comments' do
+      let(:symphony_response) { build(:symphony_request_with_mixed_status) }
+      it 'truncates long comments and shows a more link' do
+        expect(page).to have_css('td.comment > div[data-behavior="trunk8toggle"]', count: 3)
+        expect(page).to have_css('a.trunk8toggle-more', count: 3)
+      end
+      it 'can open and close long comments independently' do
+        expect(page).to have_css('a.trunk8toggle-more', count: 3)
+        expect(page).not_to have_css('a.trunk8toggle-less')
+
+        page.first('a.trunk8toggle-more').trigger('click')
+        expect(page).to have_css('a.trunk8toggle-more', count: 2)
+        expect(page).to have_css('a.trunk8toggle-less', count: 1)
+
+        page.first('a.trunk8toggle-more').trigger('click')
+        expect(page).to have_css('a.trunk8toggle-more', count: 1)
+        expect(page).to have_css('a.trunk8toggle-less', count: 2)
+
+        page.first('a.trunk8toggle-less').trigger('click')
+        expect(page).to have_css('a.trunk8toggle-more', count: 2)
+        expect(page).to have_css('a.trunk8toggle-less', count: 1)
+      end
+    end
+
+    describe 'successful symphony response' do
       let(:symphony_response) { build(:symphony_page_with_multiple_items) }
       it 'has toggleable rows that display holdings' do
         expect(page).to have_css('[data-mediate-request]', count: 3)


### PR DESCRIPTION
closes #540

## Before  (Spec library table)

![toggle comments before](https://cloud.githubusercontent.com/assets/96775/19458127/0f68ad52-947f-11e6-819b-3b16fe7115c2.png)

## After
![toggle comments after](https://cloud.githubusercontent.com/assets/96775/19458091/cc9b1bc2-947e-11e6-905f-3f341d6f404f.png)
