### PR TITLE
do not truncate or show more link for short request_comment values

### DIFF
--- a/app/assets/javascripts/truncate.js
+++ b/app/assets/javascripts/truncate.js
@@ -7,15 +7,16 @@ var truncate = (function() {
                 lines: 2,
                 tooltip: false
             };
+            var trunk8ToggleSettings = {
+                lines: 2,
+                fill: '&hellip;' + toggleMore,
+                tooltip: false
+            };
 
             $(document).on('turbolinks:load', function() {
-                $("[data-behavior='truncate'],[data-behavior='trunk8toggle']").trunk8(trunk8Settings);
+                $("[data-behavior='truncate']").trunk8(trunk8Settings);
 
-                $("[data-behavior='trunk8toggle']").each(function() {
-                    if ($(this).text()) {
-                        $(this).append(toggleMore);
-                    }
-                });
+                $("[data-behavior='trunk8toggle']").trunk8(trunk8ToggleSettings);
             });
 
             $(document).on('click', '.trunk8toggle-more', function () {
@@ -24,7 +25,7 @@ var truncate = (function() {
             });
 
             $(document).on('click', '.trunk8toggle-less', function () {
-                $(this).parent().trunk8(trunk8Settings).append(toggleMore);
+                $(this).parent().trunk8(trunk8ToggleSettings);
                 return false;
            });
         }

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Mediation table', js: true do
   let(:top_level_columns) { 7 }
+  let(:short_comment) { 'not a long comment' }
 
   context 'Library Mediation' do
     before do
@@ -26,13 +27,17 @@ describe 'Mediation table', js: true do
         ad_hoc_items: ['ABC 123'],
         created_at: Time.zone.now + 1.day
       )
+      create(
+        :mediated_page,
+        request_comment: short_comment
+      )
       visit admin_path('SPEC-COLL')
     end
 
     context 'toggleable truncation of user request comments' do
       let(:symphony_response) { build(:symphony_request_with_mixed_status) }
       it 'truncates long comments and shows a more link' do
-        expect(page).to have_css('td.comment > div[data-behavior="trunk8toggle"]', count: 3)
+        expect(page).to have_css('td.comment > div[data-behavior="trunk8toggle"]', count: 4)
         expect(page).to have_css('a.trunk8toggle-more', count: 3)
       end
       it 'can open and close long comments independently' do
@@ -51,13 +56,18 @@ describe 'Mediation table', js: true do
         expect(page).to have_css('a.trunk8toggle-more', count: 2)
         expect(page).to have_css('a.trunk8toggle-less', count: 1)
       end
+      it 'no truncation or "more" link for short comments' do
+        within('td.comment > div[data-behavior="trunk8toggle"]', text: short_comment) do
+          expect(page).not_to have_css('a.trunk8toggle-more')
+        end
+      end
     end
 
     describe 'successful symphony response' do
       let(:symphony_response) { build(:symphony_page_with_multiple_items) }
       it 'has toggleable rows that display holdings' do
-        expect(page).to have_css('[data-mediate-request]', count: 3)
-        expect(page).to have_css('tbody tr', count: 3)
+        expect(page).to have_css('[data-mediate-request]', count: 4)
+        expect(page).to have_css('tbody tr', count: 4)
         within(first('[data-mediate-request]')) do
           expect(page).to have_css('td', count: top_level_columns)
           page.find('a.mediate-toggle').trigger('click')


### PR DESCRIPTION
fixes error made with my implementation of #540.

Note:  I could have used jQuery to merge a new setting into the trunk8Settings hash ... do we care?

closes #583