### PR TITLE
Add the ability for users to create admin comments on requests...

### DIFF
--- a/app/assets/javascripts/adminComments.js
+++ b/app/assets/javascripts/adminComments.js
@@ -1,0 +1,77 @@
+/* global alert */
+
+var adminComments = (function() {
+  var adminCommentFormSelector = '#new_admin_comment';
+  var adminCommentListSelector = '[data-behavior="admin-comments-list"]';
+  var adminCommentToggleSelector = '[data-behavior="toggle-admin-comment-form"]';
+  var adminCommentFormCancelButton = '[data-behavior="admin-comment-cancel"]';
+
+  function commentTemplate(comment) {
+    return '<li>' +
+             comment.comment +
+             '<span class="text-muted">' +
+               ' - ' +
+               comment.commenter + ' - ' +
+               comment.created_at +
+              '</span>' +
+           '</li>';
+  }
+
+  return {
+    init: function(holdingsTable) {
+      this.holdingsTable = $(holdingsTable);
+      this.form = this.holdingsTable.find(adminCommentFormSelector);
+
+      this.addCommentToggleBehavior();
+
+      this.onAjaxSuccess();
+
+      this.onAjaxError();
+
+      this.addCancelButtonBehavior();
+    },
+
+    addCommentToggleBehavior: function() {
+      var _this = this;
+      var commentToggle = _this.holdingsTable.find(adminCommentToggleSelector);
+      commentToggle.on('click', function() {
+        _this.toggleForm();
+      });
+    },
+
+    onAjaxSuccess: function() {
+      var _this = this;
+      _this.form.on('ajax:success', function(e, comment){
+        _this.form.find('input[type="text"]').val('');
+        var commentList = _this.holdingsTable.find(adminCommentListSelector);
+
+        commentList.append(commentTemplate(comment));
+      });
+    },
+
+    onAjaxError: function() {
+      this.form.on('ajax:error', function() {
+        alert('There was a problem saving your comment.');
+      });
+    },
+
+    addCancelButtonBehavior: function() {
+      var _this = this;
+      var cancelButton = _this.holdingsTable.find(adminCommentFormCancelButton);
+      cancelButton.on('click', function(e){
+        e.preventDefault();
+
+        _this.clearForm();
+        _this.toggleForm();
+      });
+    },
+
+    clearForm: function() {
+      this.form.find('input[type="text"]').val('');
+    },
+
+    toggleForm: function() {
+      this.form.slideToggle();
+    }
+  };
+})();

--- a/app/assets/javascripts/mediation_table.js
+++ b/app/assets/javascripts/mediation_table.js
@@ -1,3 +1,5 @@
+/* global adminComments */
+
 var mediationTable = (function() {
   var defaultOptions = {
     selector: '[data-mediate-request]'
@@ -105,6 +107,7 @@ var mediationTable = (function() {
         $.ajax(row.data('mediate-request')).done(function(data){
           holdingsRow.find('td').html(data);
           row.addClass('expanded');
+          adminComments.init(holdingsRow.find('td'));
         });
       }
     },

--- a/app/assets/stylesheets/modules/mediation.scss
+++ b/app/assets/stylesheets/modules/mediation.scss
@@ -40,6 +40,10 @@
     }
   }
 
+  .admin-comment-input {
+    width: 350px;
+  }
+
   .mediation-header {
     @include sort-icons;
   }

--- a/app/assets/stylesheets/modules/mediation.scss
+++ b/app/assets/stylesheets/modules/mediation.scss
@@ -17,9 +17,16 @@
   }
 
   .holdings {
-    table {
+    table,
+    .admin-comments {
       margin: 0 auto;
       width: 90%;
+    }
+
+    .admin-comments {
+      .button-group {
+        margin-bottom: 5px;
+      }
     }
 
     .request-status {

--- a/app/controllers/admin_comments_controller.rb
+++ b/app/controllers/admin_comments_controller.rb
@@ -1,0 +1,24 @@
+##
+# Controller to handle the creation of admin comments on requests
+class AdminCommentsController < ApplicationController
+  load_and_authorize_resource :mediated_page
+  load_and_authorize_resource :admin_comment, through: :mediated_page
+
+  def create
+    respond_to do |format|
+      if @admin_comment.save
+        format.html { redirect_to :back, notice: 'Comment was successfully created.' }
+        format.js   { render json: @admin_comment }
+      else
+        format.html { redirect_to :back, flash: { error: 'There was an error creating your comment.' } }
+        format.js   { render json: { status: :error }, status: :bad_request }
+      end
+    end
+  end
+
+  protected
+
+  def create_params
+    params.require(:admin_comment).permit(:comment).to_h.merge(commenter: current_user.webauth)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,6 +65,10 @@ class Ability
       end
     end
 
+    can :create, AdminComment do |admin_comment|
+      can? :manage, admin_comment.request
+    end
+
     cannot :create, Scan unless user.super_admin? || current_user_in_scan_pilot_group?
   end
   # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/app/models/admin_comment.rb
+++ b/app/models/admin_comment.rb
@@ -1,0 +1,7 @@
+##
+# A class to store admin comments on requests
+class AdminComment < ActiveRecord::Base
+  belongs_to :request
+
+  validates :comment, :commenter, presence: true
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -25,6 +25,7 @@ class Request < ActiveRecord::Base
   ], coder: JSON
   serialize :barcodes, Array
 
+  has_many :admin_comments
   belongs_to :user, autosave: true
   accepts_nested_attributes_for :user
 

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -1,5 +1,10 @@
-<%= render 'admin_comments/form' %>
-<%= render 'admin_comments/comments' %>
+<div class='admin-comments'>
+  <div class='button-group'>
+    <button class='btn btn-default btn-xs' data-behavior='toggle-admin-comment-form'>Comment</button>
+  </div>
+  <%= render 'admin_comments/form' %>
+  <%= render 'admin_comments/comments' %>
+</div>
 
 <% if @request.data['comments'].present? %>
   <p><%= @request.data['comments'] %></p>

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -1,3 +1,6 @@
+<%= render 'admin_comments/form' %>
+<%= render 'admin_comments/comments' %>
+
 <% if @request.data['comments'].present? %>
   <p><%= @request.data['comments'] %></p>
 <% end %>

--- a/app/views/admin_comments/_comments.html.erb
+++ b/app/views/admin_comments/_comments.html.erb
@@ -1,0 +1,9 @@
+<ul data-behavior='admin-comments-list'>
+  <% if @request.admin_comments.any? %>
+    <% @request.admin_comments.each do |admin_comment| %>
+      <li>
+        <%= admin_comment.comment %> <span class='text-muted'>- <%= admin_comment.commenter %> - <%= admin_comment.created_at %></span>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/admin_comments/_form.html.erb
+++ b/app/views/admin_comments/_form.html.erb
@@ -1,0 +1,4 @@
+<%= bootstrap_form_for([@request, AdminComment.new], layout: :inline, control_col: 'col-sm-5', remote: true, html: { 'data-type': 'json' }) do |f| %>
+  <%= f.text_field :comment, label_class: 'sr-only', class: 'admin-comment-input' %>
+  <%= f.submit 'OK' %><a class='btn btn-text' href='javscript:;'>Cancel</a>
+<% end %>

--- a/app/views/admin_comments/_form.html.erb
+++ b/app/views/admin_comments/_form.html.erb
@@ -1,4 +1,7 @@
-<%= bootstrap_form_for([@request, AdminComment.new], layout: :inline, control_col: 'col-sm-5', remote: true, html: { 'data-type': 'json' }) do |f| %>
+<%= bootstrap_form_for([@request, AdminComment.new], layout: :inline, control_col: 'col-sm-5', remote: true, html: { 'data-behavior': 'admin-comment-form',  'data-type': 'json', style: 'display: none;' }) do |f| %>
   <%= f.text_field :comment, label_class: 'sr-only', class: 'admin-comment-input' %>
-  <%= f.submit 'OK' %><a class='btn btn-text' href='javscript:;'>Cancel</a>
+  <%= f.submit 'OK' %>
+  <a class='btn btn-text' data-behavior='admin-comment-cancel' href='javscript:;'>
+    Cancel
+  </a>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,10 +37,14 @@ Rails.application.routes.draw do
     end
   end
 
+  concern :admin_commentable do
+    resources :admin_comments
+  end
+
   resources :requests, only: :new
   resources :pages, concerns: [:creatable_via_get_redirect, :successable, :statusable]
   resources :scans, concerns: [:creatable_via_get_redirect, :successable, :statusable]
-  resources :mediated_pages, concerns: [:creatable_via_get_redirect, :successable, :statusable]
+  resources :mediated_pages, concerns: [:admin_commentable, :creatable_via_get_redirect, :successable, :statusable]
   resources :hold_recalls, concerns: [:creatable_via_get_redirect, :successable, :statusable]
 
   resources :admin, only: [:index, :show] do

--- a/db/migrate/20161019221036_add_admin_comments.rb
+++ b/db/migrate/20161019221036_add_admin_comments.rb
@@ -1,0 +1,11 @@
+class AddAdminComments < ActiveRecord::Migration
+  def change
+    create_table :admin_comments do |t|
+      t.string :commenter
+      t.string :comment
+      t.integer :request_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151031202203) do
+ActiveRecord::Schema.define(version: 20161019221036) do
+
+  create_table "admin_comments", force: :cascade do |t|
+    t.string   "commenter"
+    t.string   "comment"
+    t.integer  "request_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "messages", force: :cascade do |t|
     t.text     "text"

--- a/spec/features/admin_comment_spec.rb
+++ b/spec/features/admin_comment_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe 'Admin Comments', js: true do
+  let(:user) { create(:superadmin_user) }
+  before do
+    stub_searchworks_api_json(build(:searchable_holdings))
+    stub_current_user(user)
+    create(
+      :mediated_page_with_holdings,
+      user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+      barcodes: %w(34567890),
+      ad_hoc_items: ['ABC 123'],
+      created_at: Time.zone.now + 1.day
+    )
+    visit admin_path('SPEC-COLL')
+  end
+
+  describe 'toggling admin comment form' do
+    it 'begins with the form closed and allows the fom to be toggled open' do
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      within('.admin-comments') do
+        expect(page).to have_css('form#new_admin_comment', visible: false)
+        click_button 'Comment'
+        expect(page).to have_css('form#new_admin_comment', visible: true)
+      end
+    end
+  end
+
+  describe 'saving comments' do
+    it 'updates the page with the saved comment' do
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      within('.admin-comments') do
+        click_button 'Comment'
+        expect(page).to have_css('form#new_admin_comment', visible: true)
+
+        expect(page).to have_css('ul[data-behavior="admin-comments-list"]')
+        expect(page).not_to have_css('ul[data-behavior="admin-comments-list"] li')
+
+        fill_in 'Comment', with: 'An admin comment'
+        click_button 'OK'
+
+        expect(page).to have_css('ul[data-behavior="admin-comments-list"] li', text: 'An admin comment')
+      end
+    end
+  end
+
+  describe 'cancel button' do
+    it 'clears and hides the form' do
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      within('.admin-comments') do
+        click_button 'Comment'
+        expect(page).to have_css('form#new_admin_comment', visible: true)
+
+        fill_in 'Comment', with: 'A comment I do not like'
+        input = page.find('form#new_admin_comment input[type="text"]')
+        expect(input['value']).to eq 'A comment I do not like'
+
+        click_link 'Cancel'
+
+        expect(page).to have_css('form#new_admin_comment', visible: false)
+        input = page.find('form#new_admin_comment input[type="text"]')
+        expect(input['value']).to eq ''
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'cancan/matchers'
 
 describe Ability do
+  let(:admin_comment) { AdminComment.new(request: request) }
   let(:request) { Request.new }
   let(:custom) { Custom.new }
   let(:hold_recall) { HoldRecall.new }
@@ -72,6 +73,8 @@ describe Ability do
     it { is_expected.not_to be_able_to(:read, message) }
     it { is_expected.not_to be_able_to(:update, message) }
     it { is_expected.not_to be_able_to(:delete, message) }
+
+    it { is_expected.not_to be_able_to(:create, admin_comment) }
 
     describe 'who fills out a name and email' do
       let(:user) { build(:non_webauth_user) }
@@ -190,6 +193,7 @@ describe Ability do
     it { is_expected.to be_able_to(:manage, mediated_page) }
     it { is_expected.to be_able_to(:manage, page) }
     it { is_expected.to be_able_to(:manage, scan) }
+    it { is_expected.to be_able_to(:create, admin_comment) }
   end
 
   describe 'a site admin' do
@@ -208,6 +212,7 @@ describe Ability do
     it { is_expected.to be_able_to(:read, message) }
     it { is_expected.to be_able_to(:update, message) }
     it { is_expected.to be_able_to(:delete, message) }
+    it { is_expected.to be_able_to(:create, admin_comment) }
   end
 
   describe 'an origin library admin' do
@@ -236,6 +241,8 @@ describe Ability do
     it { is_expected.not_to be_able_to(:read, message) }
     it { is_expected.not_to be_able_to(:update, message) }
     it { is_expected.not_to be_able_to(:delete, message) }
+
+    it { is_expected.to be_able_to(:create, admin_comment) }
   end
 
   describe 'an origin location admin' do
@@ -258,5 +265,6 @@ describe Ability do
     it { is_expected.to be_able_to(:manage, mediated_page) }
     it { is_expected.to be_able_to(:manage, page) }
     it { is_expected.to be_able_to(:manage, scan) }
+    it { is_expected.to be_able_to(:create, admin_comment) }
   end
 end

--- a/spec/models/admin_comment_spec.rb
+++ b/spec/models/admin_comment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe AdminComment do
+  describe 'validations' do
+    it 'a comment is required' do
+      expect { AdminComment.create!(commenter: 'user') }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'a commenter is required' do
+      expect { AdminComment.create!(comment: 'The Comment') }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'is successful when a comment and a commenter are provided' do
+      expect(AdminComment.create!(comment: 'The Comment', commenter: 'user')).to be_a AdminComment
+    end
+  end
+end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -48,6 +48,16 @@ describe Request do
     end
   end
 
+  describe 'associations' do
+    it 'has many admin comments' do
+      request = create(:request)
+      admin_comment = AdminComment.create!(comment: 'The Comment', commenter: 'user')
+      request.admin_comments = [admin_comment]
+      request.save!
+      expect(request.admin_comments).to eq([admin_comment])
+    end
+  end
+
   describe 'commentable' do
     it 'mixin should be included' do
       expect(subject).to be_kind_of Commentable

--- a/spec/requests/admin_comments_requests_spec.rb
+++ b/spec/requests/admin_comments_requests_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe 'AdminComments' do
+  let(:user) { create(:superadmin_user) }
+  let(:mediated_page) { create(:mediated_page) }
+  let(:headers) { { 'HTTP_REFERER' => 'http://example.com' } }
+  let(:url) { "/mediated_pages/#{mediated_page.id}/admin_comments" }
+
+  before do
+    stub_current_user(user)
+  end
+
+  describe '#create' do
+    context 'when successful' do
+      it "merges the current user's webauth into the persisted comment as the commenter" do
+        post(url, { admin_comment: { comment: 'This is a comment' } }, headers)
+        expect(AdminComment.last.commenter).to eq user.webauth
+      end
+
+      context 'html response' do
+        it 'redirects back with a flash notice' do
+          post(url, { admin_comment: { comment: 'This is another comment' } }, headers)
+          expect(response).to redirect_to(:back)
+          expect(flash[:notice]).to eq 'Comment was successfully created.'
+          expect(AdminComment.last.comment).to eq 'This is another comment'
+        end
+      end
+
+      context 'js response' do
+        it 'returns a succesful status code' do
+          post("#{url}.js", { admin_comment: { comment: 'This is yet another comment' } }, headers)
+          expect(response).to be_success
+        end
+        it 'returns the JSON of the comment object that was just created' do
+          post("#{url}.js", { admin_comment: { comment: 'This is yet another comment' } }, headers)
+          response_comment = JSON.parse(response.body)
+          last_comment = AdminComment.last
+          expect(response_comment['id']).to eq last_comment.id
+          expect(response_comment['comment']).to eq last_comment.comment
+          expect(response_comment['commenter']).to eq last_comment.commenter
+        end
+      end
+    end
+
+    context 'when unsuccesful' do
+      before { expect_any_instance_of(AdminComment).to receive(:save).and_return(false) }
+      context 'html response' do
+        it 'redirects back with a flash error' do
+          post(url, { admin_comment: { comment: 'A comment that will not be persisted' } }, headers)
+          expect(response).to redirect_to(:back)
+          expect(flash[:error]).to eq 'There was an error creating your comment.'
+        end
+      end
+
+      context 'js response' do
+        it 'returns a failure status code' do
+          post("#{url}.js", { admin_comment: { comment: 'A comment that will not be persisted' } }, headers)
+          expect(response).not_to be_success
+          expect(JSON.parse(response.body)).to eq('status' => 'error')
+        end
+      end
+    end
+  end
+
+  context 'by a user who cannot add admin comments' do
+    let(:user) { create(:webauth_user) }
+
+    it 'raises an access denied error' do
+      expect { post(url, admin_comment: { comment: 'A comment' }) }.to raise_error(CanCan::AccessDenied)
+    end
+  end
+end


### PR DESCRIPTION
...they can manage.

Closes #519 

![admin-comments-spec](https://cloud.githubusercontent.com/assets/96776/19613733/410a65c2-97a3-11e6-9147-8e9034a67911.gif)
