### PR TITLE
Add a feature flag (initially set false by default) to determine if…

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -5,6 +5,7 @@ module RequestsHelper
   include PickupLibrariesHelper
 
   def render_remote_user_check?
+    return false unless Settings.features.remote_ip_check
     return unless current_request && current_user.try(:ip_address)
     current_request.check_remote_ip? && !IPRange.includes?(current_user.ip_address)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,3 +56,5 @@ worst_case_paging_padding: 3
 stanford_ips:
   singletons: []
   ranges: []
+features:
+  remote_ip_check: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -17,3 +17,6 @@ token_encrypt:
   salt: 'dGcTBhXrQjsvQkbDQCkAIdogYjzOiIQpjToNLjqyzslKShfTvxIJHmMZhzdNjOqtDZKtxutyHBZmNHKOcGMfHzxwCFeOTBeEHYHNedtrmdfLzHMTRSDJCRMURaAjRrDq'
 
 mailer_host: 'example.com'
+
+features:
+  remote_ip_check: true


### PR DESCRIPTION
…we should render the remote user check.

The IP ranges we are working from are incomplete so this allows us to ship with this feature behind a flag until we can setting on what IP addresses truly identify on vs off campus.