### PR TITLE
Position the html5 popover shim to work better in the modal context.

### DIFF
--- a/app/assets/javascripts/html5_webshim.js
+++ b/app/assets/javascripts/html5_webshim.js
@@ -7,7 +7,14 @@ $(document).on('turbolinks:load', function(){
       type: 'date',
       date: {
         startView: 2,
-        openOnFocus: true
+        openOnFocus: true,
+        popover: {
+          position: {
+            my: 'center bottom',
+            at: 'center top',
+            collision: 'none'
+          }
+        }
       }
     });
 

--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -83,6 +83,13 @@ hr {
   display: none;
 }
 
+// This is done because the html5 shim uses an element with the .help-block class
+// to display error messages. When a successful date is chosen the shim will remove
+// elements with a .help-block class which removes our note.
+.needed-date-help-block {
+  @extend .help-block;
+}
+
 .no-js .go-back-link {
   display: none;
 }

--- a/app/views/requests/_needed_date.html.erb
+++ b/app/views/requests/_needed_date.html.erb
@@ -4,7 +4,7 @@
     <div class='<%= content_column_class %>'>
       <%= f.date_field_without_bootstrap :needed_date, class: 'form-control', required: true, min: Time.zone.today , data: { request_type: current_request.type.underscore } %>
       <% if current_request.holdings_object.library_instructions.present? %>
-        <p class='help-block'>
+        <p class='needed-date-help-block'>
           <%= current_request.holdings_object.library_instructions[:text] %>
         </p>
       <% end %>

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -5,7 +5,7 @@ describe 'Library Instructions' do
   it 'returns the library instructions from the API' do
     visit new_request_path(item_id: '12345', origin: 'SPEC-COLL', origin_location: 'STACKS')
 
-    within('p.help-block') do
+    within('p.needed-date-help-block') do
       expect(page).to have_content('This is the library instruction')
     end
   end


### PR DESCRIPTION
Part of #492 
## Before

<img width="584" alt="before" src="https://cloud.githubusercontent.com/assets/96776/19824549/59cc686c-9d25-11e6-953d-9aede07f6bfa.png">

## After

<img width="591" alt="after" src="https://cloud.githubusercontent.com/assets/96776/19824548/59c86a50-9d25-11e6-909e-6563cc9df165.png">
