### PR TITLE
Add a button to allow mediators to mark a request as completed/done…

### DIFF
--- a/app/assets/javascripts/item_approval.js
+++ b/app/assets/javascripts/item_approval.js
@@ -71,10 +71,9 @@ var itemApproval = (function() {
 
     updateAllApprovedNote: function(item) {
       if(this.allItemsAreApproved(item)) {
-        item.closest('tr.holdings')
-            .prev('tr')
-            .find('[data-behavior="all-approved-note"]')
-            .show();
+        var tableRow = item.closest('tr.holdings').prev('tr');
+        tableRow.find('[data-behavior="all-approved-note"]').show();
+        tableRow.find('[data-behavior="mixed-approved-note"]').hide();
       }
     },
 

--- a/app/assets/javascripts/markAsComplete.js
+++ b/app/assets/javascripts/markAsComplete.js
@@ -1,0 +1,53 @@
+/* global alert */
+
+var markAsComplete = (function() {
+  var buttonSelector = '[data-behavior="mark-as-complete"]';
+
+  return {
+    init: function(holdingsTable){
+      this.holdingsTable = $(holdingsTable);
+
+      this.onAjaxSuccess();
+      this.onAjaxError();
+    },
+
+    onAjaxSuccess: function() {
+      var _this = this;
+      _this.markAsCompleteForm().on('ajax:success', function(_, request) {
+        if(request.approval_status === 'marked_as_done') {
+          _this.disableMarkAsCompleteButton();
+          _this.markRequestRowAsMixedStatus();
+        }
+      });
+    },
+
+    onAjaxError: function() {
+      this.markAsCompleteForm().on('ajax:error', function() {
+        alert('There was a problem marking this request as complete.');
+      });
+    },
+
+    disableMarkAsCompleteButton: function() {
+      this.markAsCompleteButton().attr('disabled', 'true');
+    },
+
+    markRequestRowAsMixedStatus: function() {
+      var requestRow =  this.holdingsTable
+                            .closest('tr.holdings')
+                            .prev('tr');
+      if(requestRow.find('[data-behavior="all-approved-note"]').is(':hidden')) {
+        requestRow
+          .find('[data-behavior="mixed-approved-note"]')
+          .show();
+      }
+    },
+
+    markAsCompleteButton: function() {
+      return this.holdingsTable.find(buttonSelector);
+    },
+
+    markAsCompleteForm: function() {
+      return this.markAsCompleteButton().parent('form');
+    }
+  };
+})();

--- a/app/assets/javascripts/mediation_table.js
+++ b/app/assets/javascripts/mediation_table.js
@@ -1,4 +1,5 @@
 /* global adminComments */
+/* global markAsComplete */
 
 var mediationTable = (function() {
   var defaultOptions = {
@@ -108,6 +109,7 @@ var mediationTable = (function() {
           holdingsRow.find('td').html(data);
           row.addClass('expanded');
           adminComments.init(holdingsRow.find('td'));
+          markAsComplete.init(holdingsRow.find('td'));
         });
       }
     },

--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -93,3 +93,7 @@ hr {
 .no-js .go-back-link {
   display: none;
 }
+
+.mark-as-complete-form {
+  display: inline;
+}

--- a/app/controllers/mediated_pages_controller.rb
+++ b/app/controllers/mediated_pages_controller.rb
@@ -4,7 +4,21 @@
 class MediatedPagesController < RequestsController
   before_action :check_if_proxy_sponsor, only: :create
 
+  def update
+    respond_to do |format|
+      if current_request.update(update_params)
+        format.js { render json: current_request }
+      else
+        format.js { render json: { status: :error }, status: :bad_request }
+      end
+    end
+  end
+
   protected
+
+  def update_params
+    params.require(:mediated_page).permit(:approval_status)
+  end
 
   def send_confirmation
     current_request.send_confirmation!

--- a/app/models/item_status.rb
+++ b/app/models/item_status.rb
@@ -58,6 +58,7 @@ class ItemStatus
       approval_time: Time.zone.now.to_s,
       approver: user
     }.with_indifferent_access
+    @request.approval_status = :approved if @request.all_approved?
     @request.save!
   end
 

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -64,6 +64,16 @@ class MediatedPage < Request
     )[:email]
   end
 
+  def self.mark_all_archived_as_complete!
+    archived.find_each do |mediated_page|
+      if mediated_page.all_approved?
+        mediated_page.approved!
+      else
+        mediated_page.marked_as_done!
+      end
+    end
+  end
+
   private
 
   def needed_date_is_required

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -2,6 +2,8 @@
 #  Request class for making page requests that require mediation
 ###
 class MediatedPage < Request
+  enum approval_status: { unapproved: 0, marked_as_done: 1, approved: 2 }
+
   validate :mediated_page_validator
   validates :destination, presence: true
   validate :needed_date_is_required

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -16,7 +16,10 @@
           <a class="mediate-toggle" data-behavior='mediate-toggle' href='javascript:;'>
             <i class="glyphicon"></i>
           </a>
-          <span data-behavior='all-approved-note' class='label label-success' style='<%= 'display:none;' unless request.all_approved? %>'>
+          <span data-behavior='all-approved-note' class='label label-success' style='<%= 'display:none;' unless request.approved? %>'>
+            <%= t('.all_approved') %>
+          </span>
+          <span data-behavior='mixed-approved-note' class='label label-warning' style='<%= 'display:none;' unless request.marked_as_done? %>'>
             <%= t('.all_approved') %>
           </span>
         </td>

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -1,5 +1,10 @@
 <div class='admin-comments'>
   <div class='button-group'>
+    <%= bootstrap_form_for(@request, remote: true, html: { class: 'mark-as-complete-form', 'data-type': 'json' }) do |f| %>
+      <%= f.hidden_field :approval_status, value: 'marked_as_done' %>
+      <button class='btn btn-default btn-xs' <%= 'disabled' unless @request.unapproved? %> data-behavior='mark-as-complete'>Mark as done</button>
+    <% end %>
+
     <button class='btn btn-default btn-xs' data-behavior='toggle-admin-comment-form'>Comment</button>
   </div>
   <%= render 'admin_comments/form' %>

--- a/db/migrate/20161028235652_add_approval_status_column_to_requests.rb
+++ b/db/migrate/20161028235652_add_approval_status_column_to_requests.rb
@@ -1,0 +1,5 @@
+class AddApprovalStatusColumnToRequests < ActiveRecord::Migration
+  def change
+    add_column :requests, :approval_status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027202255) do
+ActiveRecord::Schema.define(version: 20161028235652) do
 
   create_table "admin_comments", force: :cascade do |t|
     t.string   "commenter"
@@ -35,8 +35,8 @@ ActiveRecord::Schema.define(version: 20161027202255) do
     t.string   "type"
     t.date     "needed_date"
     t.string   "status"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.string   "origin"
     t.string   "destination"
     t.string   "origin_location"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20161027202255) do
     t.text     "item_title"
     t.text     "barcodes"
     t.string   "estimated_delivery"
+    t.integer  "approval_status",    default: 0
   end
 
   add_index "requests", ["needed_date"], name: "index_requests_on_needed_date"

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,6 @@
+namespace :data_migration do
+  desc "Update all item's approval status whose needed_date has passed as either done or approved"
+  task mark_all_archived_mediated_pages_as_complete: :environment do
+    MediatedPage.mark_all_archived_as_complete!
+  end
+end

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -46,6 +46,24 @@ FactoryGirl.define do
     association :user, factory: :sequence_webauth_user
   end
 
+  factory :mediated_page_with_single_holding, parent: :mediated_page do
+    item_id '12345'
+    origin 'SPEC-COLL'
+    origin_location 'STACKS'
+    destination 'SPEC-COLL'
+    needed_date Time.zone.today
+    request_comment long_comment
+    association :user, factory: :sequence_webauth_user
+
+    after(:build) do |request|
+      class << request
+        def symphony_response_data
+          FactoryGirl.build(:symphony_page_with_single_item)
+        end
+      end
+    end
+  end
+
   factory :mediated_page_with_holdings, parent: :mediated_page do
     item_id '1234'
     origin 'SPEC-COLL'

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe 'Mark As Complete', js: true do
+  let(:user) { create(:superadmin_user) }
+
+  before do
+    stub_searchworks_api_json(build(:searchable_holdings))
+    stub_current_user(user)
+  end
+
+  describe 'marking an item as complete' do
+    let!(:mediated_page) do
+      create(
+        :mediated_page_with_holdings,
+        user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+        barcodes: %w(34567890),
+        ad_hoc_items: ['ABC 123'],
+        created_at: Time.zone.now + 1.day
+      )
+    end
+
+    before { visit admin_path('SPEC-COLL') }
+
+    it 'saves state for the request object' do
+      expect(mediated_page).not_to be_marked_as_done
+
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      click_button 'Mark as done'
+
+      expect(page).to have_css('[data-behavior="mixed-approved-note"]', visible: true) # to wait for ajax
+
+      expect(MediatedPage.find(mediated_page.id)).to be_marked_as_done
+    end
+
+    it 'disables the button' do
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      button = page.find('button', text: 'Mark as done')
+      expect(button).not_to be_disabled
+
+      click_button 'Mark as done'
+
+      button = page.find('button', text: 'Mark as done')
+      expect(button).to be_disabled
+    end
+
+    it 'shows the mixed-approval label on the request row' do
+      expect(page).not_to have_css('[data-behavior="mixed-approved-note"]', visible: true)
+
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      click_button 'Mark as done'
+
+      expect(page).to have_css('[data-behavior="mixed-approved-note"]', visible: true)
+    end
+  end
+
+  describe 'a request that has already been marked as complete' do
+    let!(:mediated_page) do
+      create(
+        :mediated_page_with_holdings,
+        user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+        barcodes: %w(34567890),
+        approval_status: :marked_as_done,
+        ad_hoc_items: ['ABC 123'],
+        created_at: Time.zone.now + 1.day
+      )
+    end
+
+    before { visit admin_path('SPEC-COLL') }
+
+    it 'has a disabled button' do
+      within(first('[data-mediate-request]')) do
+        page.find('a.mediate-toggle').trigger('click')
+      end
+
+      button = page.find('button', text: 'Mark as done')
+      expect(button).to be_disabled
+    end
+
+    it 'shows the mixed-approval label on the request row' do
+      expect(page).to have_css('[data-behavior="mixed-approved-note"]', visible: true)
+    end
+  end
+end

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -182,4 +182,38 @@ describe MediatedPage do
       ).to eq SULRequests::Application.config.mediator_contact_info['PAGE-MP'][:email]
     end
   end
+
+  describe '#mark_all_archived_as_complete' do
+    let!(:mediated_page) { create(:mediated_page) }
+    before do
+      mediated_page.needed_date = Time.zone.today - 5.days
+      mediated_page.save
+    end
+
+    context 'requests that have all of their items approved' do
+      before do
+        expect_any_instance_of(MediatedPage).to receive(:all_approved?).at_least(:once).and_return(true)
+      end
+      it 'are marked as approved' do
+        expect(mediated_page).not_to be_approved
+
+        MediatedPage.mark_all_archived_as_complete!
+
+        expect(mediated_page.reload).to be_approved
+      end
+    end
+
+    context 'requests that do not have all their items approved' do
+      before do
+        expect_any_instance_of(MediatedPage).to receive(:all_approved?).at_least(:once).and_return(false)
+      end
+      it 'are marked as done' do
+        expect(mediated_page).not_to be_marked_as_done
+
+        MediatedPage.mark_all_archived_as_complete!
+
+        expect(mediated_page.reload).to be_marked_as_done
+      end
+    end
+  end
 end


### PR DESCRIPTION
…without approving all items.

Closes #539 

_Marking this as a **[WIP]** because I notice there is something in #514 that may affect the approach we take here_

![mark-as-done](https://cloud.githubusercontent.com/assets/96776/19900238/066ccede-a020-11e6-9fbd-879434c2f240.gif)
