### PR TITLE
Allow for PAGE-GR materials to be scannable

### DIFF
--- a/app/models/concerns/scannable.rb
+++ b/app/models/concerns/scannable.rb
@@ -2,6 +2,9 @@
 #  Mixin to encapsulate defining if a request is scannable
 ###
 module Scannable
+  ITEM_TYPES = %w(BUS-STACKS STKS STKS-MONO STKS-PERI).freeze
+  LOCATIONS = %w(BUS-STACKS STACKS).freeze
+
   def scannable?
     scannable_library? &&
       scannable_location? &&
@@ -15,12 +18,19 @@ module Scannable
   end
 
   def scannable_location?
-    %w(BUS-STACKS STACKS).include?(location)
+    LOCATIONS.include?(location)
   end
 
   def includes_scannable_item?
     request.holdings.any? do |item|
-      %w(BUS-STACKS STKS STKS-MONO STKS-PERI).include?(item.type)
+      scannable_item_types.include?(item.type)
     end
+  end
+
+  def scannable_item_types
+    return ITEM_TYPES unless location
+    location_item_types_method_name = "#{location.underscore}_scannable_item_types".to_sym
+    return ITEM_TYPES unless respond_to?(location_item_types_method_name, true)
+    send(location_item_types_method_name)
   end
 end

--- a/app/models/concerns/scannable.rb
+++ b/app/models/concerns/scannable.rb
@@ -3,7 +3,7 @@
 ###
 module Scannable
   ITEM_TYPES = %w(BUS-STACKS STKS STKS-MONO STKS-PERI).freeze
-  LOCATIONS = %w(BUS-STACKS STACKS).freeze
+  LOCATIONS = %w(BUS-STACKS PAGE-GR STACKS).freeze
 
   def scannable?
     scannable_library? &&
@@ -32,5 +32,9 @@ module Scannable
     location_item_types_method_name = "#{location.underscore}_scannable_item_types".to_sym
     return ITEM_TYPES unless respond_to?(location_item_types_method_name, true)
     send(location_item_types_method_name)
+  end
+
+  def page_gr_scannable_item_types
+    %w(NEWSPAPER NH-INHOUSE).concat(ITEM_TYPES)
   end
 end

--- a/spec/models/concerns/scannable_spec.rb
+++ b/spec/models/concerns/scannable_spec.rb
@@ -26,6 +26,12 @@ describe Scannable do
         expect(subject).to be_scannable
       end
 
+      it 'is true when from SAL3 + PAGE-GR' do
+        subject.library = 'SAL3'
+        subject.location = 'PAGE-GR'
+        expect(subject).to be_scannable
+      end
+
       it 'is true when from SAL3 + BUS-STACKS' do
         subject.library = 'SAL3'
         subject.location = 'BUS-STACKS'
@@ -45,6 +51,8 @@ describe Scannable do
     describe 'holdings' do
       let(:scannable_items) { [double(type: 'STKS')] }
       let(:unscannable_items) { [double(type: 'NOT-STKS')] }
+      let(:page_gr_scannable_items) { [double(type: 'NH-INHOUSE')] }
+
       before do
         allow(subject).to receive_messages(scannable_library?: true)
         allow(subject).to receive_messages(scannable_location?: true)
@@ -62,6 +70,12 @@ describe Scannable do
 
       it 'is true when there are mixed items in the location' do
         subject.request = double('request', holdings: [scannable_items, unscannable_items].flatten)
+        expect(subject).to be_scannable
+      end
+
+      it 'is true for special PAGE-GR locations' do
+        subject.location = 'PAGE-GR'
+        subject.request = double('request', holdings: page_gr_scannable_items)
         expect(subject).to be_scannable
       end
     end


### PR DESCRIPTION
Closes #543 

`/requests/new?item_id=11613538&origin=SAL3&origin_location=PAGE-GR`

## Before
Directly delegates to a `Page` request

<img width="612" alt="11613538-before" src="https://cloud.githubusercontent.com/assets/96776/19906577/8f1c60c4-a038-11e6-9eb7-866ba3ca9861.png">

## After
Gives the option to chose a `Scan` or `Page` request.

<img width="603" alt="11613538-after" src="https://cloud.githubusercontent.com/assets/96776/19906576/8f030e12-a038-11e6-85d1-813dd9aac881.png">

