### PR TITLE
add column sizes to mediation table headers

### DIFF
--- a/app/views/admin/_table_header.html.erb
+++ b/app/views/admin/_table_header.html.erb
@@ -1,31 +1,31 @@
 <thead class='mediation-header'>
   <tr>
-    <th>Mediate</th>
-    <th>
+    <th class="col-sm-1">Mediate</th>
+    <th class="col-sm-1">
       <a class='sort' data-sort='needed_date' href='javascript:;'>
         Needed on <i></i>
       </a>
     </th>
-    <th>
+    <th class="col-sm-3">
       <a class='sort' data-sort='title' href='javascript:;'>
         Title <i></i>
       </a>
     </th>
-    <th>
+    <th class="col-sm-2">
       <a class='sort' data-sort='requester' href='javascript:;'>
         Requester <i></i>
       </a>
     </th>
-    <th>
+    <th class="col-sm-1">
       <a class='sort asc' data-sort='created_at' href='javascript:;'>
         Requested on <i></i>
       </a>
     </th>
-    <th>
+    <th class="col-sm-3">
       <a class='sort' data-sort='comment' href='javascript:;'>
         Comment <i></i>
       </a>
     </th>
-    <th>Status</th>
+    <th class="col-sm-1">Status</th>
   </tr>
 </thead>

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -61,6 +61,9 @@ describe 'Mediation table', js: true do
           expect(page).not_to have_css('a.trunk8toggle-more')
         end
       end
+      it 'column has size in header' do
+        expect(page).to have_css('th.col-sm-3', text: 'Comment')
+      end
     end
 
     describe 'current location' do


### PR DESCRIPTION
closes #610 

Note:  I did not resize my browser window between screen shots.

## Before Fix

### before toggling 
![columns before closed](https://cloud.githubusercontent.com/assets/96775/19909300/3c517652-a044-11e6-9085-c7ffa750e4cf.png)

### after toggling 
![columns before open](https://cloud.githubusercontent.com/assets/96775/19909301/3c525464-a044-11e6-8730-680db6bc1d12.png)

## After Fix

### before toggling
![columns after closed](https://cloud.githubusercontent.com/assets/96775/19909299/3c4dad06-a044-11e6-98e1-c79159284b43.png)

### after toggling
![columns after open](https://cloud.githubusercontent.com/assets/96775/19909302/3c52a842-a044-11e6-8d6d-59855442c30e.png)
