### PR TITLE
Make Hoover library no longer mediatable

### DIFF
--- a/app/models/concerns/mediateable.rb
+++ b/app/models/concerns/mediateable.rb
@@ -8,7 +8,7 @@ module Mediateable
     mediated_library? ||
       page_mp? ||
       hopkins_stacks? ||
-      hoover_in_sal3?
+      hoover_archive_in_sal3?
   end
 
   private
@@ -25,16 +25,8 @@ module Mediateable
     @library == 'HOPKINS' && @location == 'STACKS'
   end
 
-  def hoover_in_sal3?
-    hoover_library_in_sal3? || hoover_archive_in_sal3?
-  end
-
   def hoover_archive_in_sal3?
     @library == 'HV-ARCHIVE' && location_lives_in_sal3?
-  end
-
-  def hoover_library_in_sal3?
-    @library == 'HOOVER' && location_lives_in_sal3?
   end
 
   def location_lives_in_sal3?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,6 @@ scan_pilot_groups:
 origin_admin_groups:
   HOPKINS: []
   HV-ARCHIVE: []
-  HOOVER: []
   PAGE-MP: []
   SPEC-COLL: []
 

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -39,13 +39,6 @@ FactoryGirl.define do
     association :user, factory: :sequence_webauth_user
   end
 
-  factory :hoover_mediated_page, parent: :mediated_page do
-    origin 'HOOVER'
-    origin_location 'SOMEWHERE-30'
-    destination 'GREEN'
-    association :user, factory: :sequence_webauth_user
-  end
-
   factory :hoover_archive_mediated_page, parent: :mediated_page do
     origin 'HV-ARCHIVE'
     origin_location 'SOMEWHERE-30'

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -45,7 +45,7 @@ describe 'Viewing all requests' do
         stub_current_user(create(:superadmin_user))
         create(:mediated_page)
         create(:mediated_page)
-        create(:hoover_mediated_page)
+        create(:hoover_archive_mediated_page)
       end
 
       it 'should list all the mediated pages for the given library' do
@@ -55,9 +55,9 @@ describe 'Viewing all requests' do
 
         expect(page).to have_css('table tbody tr', count: 2)
 
-        visit admin_path('HOOVER')
+        visit admin_path('HV-ARCHIVE')
 
-        expect(page).to have_css('h2', text: 'Hoover Library')
+        expect(page).to have_css('h2', text: 'Hoover Archive')
 
         expect(page).to have_css('table tbody tr', count: 1)
       end

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -101,7 +101,7 @@ describe 'Creating a mediated page request' do
       expect(MediatedPage.last.request_comment).to eq comment
     end
     it 'should not include a comments for requests that do not get them' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'HOOVER', origin_location: 'STACKS-30')
+      visit new_mediated_page_path(item_id: '1234', origin: 'HV-ARCHIVE', origin_location: 'STACKS-30')
 
       expect(page).to_not have_field('Comments')
     end

--- a/spec/models/concerns/mediateable_spec.rb
+++ b/spec/models/concerns/mediateable_spec.rb
@@ -40,28 +40,15 @@ describe Mediateable do
         expect(subject).to_not be_mediateable
       end
     end
-    describe 'HOOVER' do
-      describe 'library' do
-        before { subject.library = 'HOOVER' }
-        it 'should return true if the item is in a *-30 location' do
-          subject.location = 'SOMEWHERE-30'
-          expect(subject).to be_mediateable
-        end
-        it 'should return false if the item is not in a *-30 location' do
-          subject.location = 'SOMEWHERE-ELSE'
-          expect(subject).not_to be_mediateable
-        end
+    describe 'HV-ARCHIVE' do
+      before { subject.library = 'HV-ARCHIVE' }
+      it 'should return true if the item is in a *-30 location' do
+        subject.location = 'SOMEWHERE-30'
+        expect(subject).to be_mediateable
       end
-      describe 'archives' do
-        before { subject.library = 'HV-ARCHIVE' }
-        it 'should return true if the item is in a *-30 location' do
-          subject.location = 'SOMEWHERE-30'
-          expect(subject).to be_mediateable
-        end
-        it 'should return false if the item is not in a *-30 location' do
-          subject.location = 'SOMEWHERE-ELSE'
-          expect(subject).not_to be_mediateable
-        end
+      it 'should return false if the item is not in a *-30 location' do
+        subject.location = 'SOMEWHERE-ELSE'
+        expect(subject).not_to be_mediateable
       end
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -475,11 +475,11 @@ describe Request do
   describe 'mediateable_origins' do
     before do
       create(:mediated_page)
-      create(:hoover_mediated_page)
+      create(:hoover_archive_mediated_page)
       create(:hopkins_mediated_page)
     end
     it 'should return the subset of origin codes that are configured and mediated pages that exist in the database' do
-      expect(Request.mediateable_origins).to eq %w(HOPKINS HOOVER SPEC-COLL)
+      expect(Request.mediateable_origins).to eq %w(HOPKINS HV-ARCHIVE SPEC-COLL)
     end
   end
 

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -57,8 +57,8 @@ describe MediatedPage do
       build(:mediated_page, user: user, needed_date: Time.zone.today - 3.days).save(validate: false)
       build(:mediated_page, user: user, needed_date: Time.zone.today - 2.days).save(validate: false)
       build(:mediated_page, user: user, needed_date: Time.zone.today - 1.day).save(validate: false)
-      create(:hoover_mediated_page, user: user, needed_date: Time.zone.today)
-      create(:hoover_mediated_page, user: user, needed_date: Time.zone.today + 1.day)
+      create(:hoover_archive_mediated_page, user: user, needed_date: Time.zone.today)
+      create(:hoover_archive_mediated_page, user: user, needed_date: Time.zone.today + 1.day)
     end
     describe 'archived' do
       it 'returns records whose needed_date is older than today' do
@@ -85,7 +85,7 @@ describe MediatedPage do
     describe 'for_origin' do
       it 'returns the records for a given origin' do
         expect(MediatedPage.for_origin('SPEC-COLL').length).to eq 3
-        expect(MediatedPage.for_origin('HOOVER').length).to eq 2
+        expect(MediatedPage.for_origin('HV-ARCHIVE').length).to eq 2
       end
     end
   end
@@ -96,7 +96,7 @@ describe MediatedPage do
       expect(subject).to be_request_commentable
     end
     it 'is false when the library is not SPEC-COLL' do
-      subject.origin = 'HOOVER'
+      subject.origin = 'HV-ARCHIVE'
       expect(subject).to_not be_request_commentable
     end
   end


### PR DESCRIPTION
(which means it will fall-back to a simple Page request).

Closes #578 

We will need to make a PR to the Requests shared_configs branches to remove `HOOVER` from the `origin_admin_groups`, but we should get this deployed first to ensure that no requests end up in their mediation queue in the interim.