### PR TITLE
add requested_date for picklist

### DIFF
--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -76,6 +76,7 @@ class SubmitSymphonyRequestJob < ActiveJob::Base
         home_lib: request.origin,
         item_comments: request.item_comment,
         req_comment: request.request_comment,
+        requested_date: request.created_at.strftime('%m/%d/%Y'),
         pickup_lib: (request.destination unless request.is_a? Scan),
         not_needed_after: (request.needed_date.strftime('%m/%d/%Y') if request.needed_date)
       }

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
 
       it 'contains the request information' do
         expect(subject.request_params).to include ckey: '12345', home_lib: 'SAL3'
+        expect(subject.request_params).to include requested_date: %r(\d{2}/\d{2}/\d{4}$)
       end
 
       context 'with a non-webauth user' do


### PR DESCRIPTION
This sends the "requested on" date to Symphony so it can appear on the picklists made for staff retrieving items from their libraries.

This is being merged to a BRANCH; that branch cannot be deployed to production without coordinating with Darsi.

connects to #495

## Before
![status w-o requested_date](https://cloud.githubusercontent.com/assets/96775/20156141/f0f37584-a683-11e6-8f85-8503d97b2ac2.png)

## After  (diff request, but you can see `requested_date`)
![status w requested_date](https://cloud.githubusercontent.com/assets/96775/20156142/f0f44996-a683-11e6-8cf4-a6b188910420.png)

