### PR TITLE
sort completed mediated pages by needed_date, desc

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -15,6 +15,7 @@ class Request < ActiveRecord::Base
   attr_reader :requested_barcode
   attr_accessor :live_lookup
   scope :recent, -> { order(created_at: :desc) }
+  scope :needed_date_desc, -> { order(needed_date: :desc) }
   scope :for_date, ->(date) { where(needed_date: date) }
 
   delegate :hold_recallable?, :mediateable?, :pageable?, :scannable?, to: :library_location

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -10,7 +10,9 @@ class MediatedPage < Request
   validate :destination_is_a_pickup_library
   validate :needed_date_is_valid, on: :create, if: :requires_needed_date?
 
-  scope :completed, -> { where(approval_status: MediatedPage.approval_statuses.except('unapproved').values) }
+  scope :completed, lambda {
+    where(approval_status: MediatedPage.approval_statuses.except('unapproved').values).needed_date_desc
+  }
   scope :archived, -> { where('needed_date < ?', Time.zone.today).order(needed_date: :desc) }
   scope :for_origin, ->(origin) { where('origin = ? OR origin_location = ?', origin, origin) }
 

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -27,7 +27,7 @@ describe 'Viewing all requests' do
       end
     end
 
-    describe 'by an anonmyous user' do
+    describe 'by an anonymous user' do
       before { stub_current_user(create(:anon_user)) }
 
       it 'should redirect to the login page' do
@@ -87,9 +87,9 @@ describe 'Viewing all requests' do
         end
       end
 
-      it 'allows the user to toggle between expired and active mediated pages (and updates button class)' do
-        build(:mediated_page, approval_status: :approved, needed_date: Time.zone.today - 3.days).save(validate: false)
+      it 'allows the user to toggle between done and pending mediated pages (and updates button class)' do
         build(:mediated_page, approval_status: :approved, needed_date: Time.zone.today - 2.days).save(validate: false)
+        build(:mediated_page, approval_status: :approved, needed_date: Time.zone.today - 3.days).save(validate: false)
         build(:mediated_page, approval_status: :approved, needed_date: Time.zone.today - 1.day).save(validate: false)
         visit admin_path('SPEC-COLL')
 
@@ -105,6 +105,10 @@ describe 'Viewing all requests' do
         expect(page).to have_css('a.btn-primary', text: 'All done')
         expect(page).to have_css('a', text: 'All pending')
         expect(page).not_to have_css('a.btn-primary', text: 'All pending')
+
+        # requests are sorted properly (in descending needed_date order)
+        expected_regex = /#{Time.zone.today - 1.day}.*#{Time.zone.today - 2.days}.*#{Time.zone.today - 3.days}/
+        expect(page).to have_content(expected_regex)
 
         click_link 'All pending'
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -61,6 +61,21 @@ describe Request do
         expect(Request.for_date(Time.zone.today + 2.days).count).to eq 1
       end
     end
+
+    describe 'needed_date_desc' do
+      before do
+        create(:request, needed_date: Time.zone.today + 1.day)
+        create(:request, needed_date: Time.zone.today + 3.days)
+        create(:request, needed_date: Time.zone.today + 2.days)
+      end
+
+      it 'returns records in descending needed date order' do
+        sorted = Request.needed_date_desc.limit(3)
+        expect(sorted[0].needed_date).to eq Time.zone.today + 3.days
+        expect(sorted[1].needed_date).to eq Time.zone.today + 2.days
+        expect(sorted[2].needed_date).to eq Time.zone.today + 1.day
+      end
+    end
   end
 
   describe 'associations' do

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -94,6 +94,11 @@ describe MediatedPage do
       it 'returns the requests with an approval status of anything other than unnaproved' do
         expect(MediatedPage.completed.count).to eq 3
       end
+      it 'returns records in descending needed date order' do
+        expect(MediatedPage.completed[0].needed_date).to eq Time.zone.today - 1.day
+        expect(MediatedPage.completed[1].needed_date).to eq Time.zone.today - 2.days
+        expect(MediatedPage.completed[2].needed_date).to eq Time.zone.today - 3.days
+      end
     end
 
     describe 'for_origin' do


### PR DESCRIPTION
Orders the "all done" mediation list so the ones needed the soonest are first.  This is the same sort order as "archived" (before "pending" and "done" buttons were added).

closes #636