### PR TITLE
requests dashboard filter by type

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -11,7 +11,7 @@ class AdminController < ApplicationController
   def index
     authorize! :manage, Request.new
     @dashboard = Dashboard.new
-    @requests = @dashboard.recent_requests(params[:page], params[:per] || 100)
+    @requests = @dashboard.recent_requests(params[:page], params[:per] || 100).for_type(filter_type)
   end
 
   def show
@@ -46,6 +46,15 @@ class AdminController < ApplicationController
     params[:date].present?
   end
   helper_method :filtered_by_date?
+
+  def filter_metric
+    params[:metric].to_sym if params[:metric].present?
+  end
+  helper_method :filter_metric
+
+  def filter_type
+    params[:metric].classify if params[:metric].present?
+  end
 
   def mediated_pages
     if filtered_by_done?

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -17,6 +17,7 @@ class Request < ActiveRecord::Base
   scope :recent, -> { order(created_at: :desc) }
   scope :needed_date_desc, -> { order(needed_date: :desc) }
   scope :for_date, ->(date) { where(needed_date: date) }
+  scope :for_type, ->(request_type) { where(type: request_type) if request_type }
 
   delegate :hold_recallable?, :mediateable?, :pageable?, :scannable?, to: :library_location
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -11,7 +11,19 @@
   <tfoot>
     <tr>
       <% @dashboard.metrics.each do |metric| %>
-        <td><span class='text-muted'><%= t(".#{metric}") %></span></td>
+        <td>
+          <span class='text-muted'>
+            <%=
+              # if the metric is selected, give an [x] link to go back to the unfiltered request
+              # list.  otherwise, give a link to the filtered list for the request type.
+              if filter_metric == metric
+                (t(".#{metric}") + " ").html_safe + link_to('[x]', admin_index_path)
+              else
+                link_to(t(".#{metric}"), admin_index_path(metric: metric))
+              end
+            %>
+          </span>
+        </td>
       <% end %>
     </tr>
   </tfoot>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
   admin:
     index:
       custom: 'Custom requests'
-      hold_recall: 'Hold recalls'
+      hold_recalls: 'Hold recalls'
       mediated_pages: 'Mediated pages'
       pages: 'Pages'
       scans: 'Scan requests'

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -13,7 +13,14 @@ describe 'Viewing all requests' do
                       request_comment: 'I can has this item?',
                       user: User.create(name: 'Joe', email: 'joe@xyz.com')
               )
+        create(:mediated_page, ad_hoc_items: ['ZZZ-123'],
+                               item_title: 'A Different Type of Page',
+                               origin: 'SPEC-COLL',
+                               request_comment: 'I can has this mediated item?',
+                               user: User.create(name: 'Jane', email: 'jane@example.com')
+              )
       end
+
       it 'should list data in a table' do
         visit admin_index_path
 
@@ -23,7 +30,44 @@ describe 'Viewing all requests' do
         expect(page).to have_css('td a[data-behavior="truncate"]', text: 'An American in Paris')
         expect(page).to have_css('td a[href="mailto:joe@xyz.com"]', text: /Joe \(joe@xyz.com\)/)
 
+        expect(page).to have_css('td a[data-behavior="truncate"]', text: 'A Different Type of Page')
+        expect(page).to have_css('td a[href="mailto:jane@example.com"]', text: /Jane \(jane@example.com\)/)
+
         expect(page).to have_selector('table.table-striped', count: 1)
+      end
+
+      it 'allows filtering by request type' do
+        visit admin_index_path
+
+        expect(page).to have_css('td a', text: 'Mediated pages')
+        expect(page).to have_css('td a', text: 'Pages')
+
+        click_link 'Mediated pages'
+
+        expect(page).to have_css('td', text: 'Mediated pages [x]')
+        expect(page).to have_css('td a', text: 'Pages')
+
+        expect(page).to_not have_css('td a[data-behavior="truncate"]', text: 'An American in Paris')
+        expect(page).to_not have_css('td a[href="mailto:joe@xyz.com"]', text: /Joe \(joe@xyz.com\)/)
+
+        expect(page).to have_css('td a[data-behavior="truncate"]', text: 'A Different Type of Page')
+        expect(page).to have_css('td a[href="mailto:jane@example.com"]', text: /Jane \(jane@example.com\)/)
+
+        click_link 'Pages'
+
+        expect(page).to have_css('td a', text: 'Mediated pages')
+        expect(page).to have_css('td', text: 'Pages [x]')
+
+        expect(page).to have_css('td a[data-behavior="truncate"]', text: 'An American in Paris')
+        expect(page).to have_css('td a[href="mailto:joe@xyz.com"]', text: /Joe \(joe@xyz.com\)/)
+
+        expect(page).to_not have_css('td a[data-behavior="truncate"]', text: 'A Different Type of Page')
+        expect(page).to_not have_css('td a[href="mailto:jane@example.com"]', text: /Jane \(jane@example.com\)/)
+
+        click_link '[x]'
+
+        expect(page).to have_css('td a', text: 'Mediated pages')
+        expect(page).to have_css('td a', text: 'Pages')
       end
     end
 


### PR DESCRIPTION
allows users to filter the requests dashboard by type.  each type name (under its respective count) links to a version of the page filtered by type.  if a type filter is on, an `[x]` link to its right provides a way to remove that filter and show all requests.  i was just running with @jkeck's idea for how to implement this simply, it could definitely use design vetting from @jvine.

attaching screenshots from the capybara tests because i did something to mess up my local test data when instantiating test objects from the factory, and the default unfiltered version of the page now 500s on me.  would be nice to test this manually, either locally or on stage, before merging.

![capybara-201611101050404614639155](https://cloud.githubusercontent.com/assets/7741604/20190205/5246cffa-a735-11e6-857c-eed27de8f98c.png)

![capybara-201611101050402221951178](https://cloud.githubusercontent.com/assets/7741604/20190233/6e2fcd16-a735-11e6-856e-2045f70b1add.png)

![capybara-201611101050401483245569](https://cloud.githubusercontent.com/assets/7741604/20190247/79112f18-a735-11e6-9f25-56143fe85fda.png)

closes #625 