### PR TITLE
install capistrano-sidekiq

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -25,6 +25,7 @@ require 'dlss/capistrano'
 require 'capistrano/passenger'
 require 'capistrano/honeybadger'
 require 'capistrano/shared_configs'
+require 'capistrano/sidekiq'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -112,5 +112,6 @@ group :deployment do
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
   gem 'capistrano-shared_configs'
+  gem 'capistrano-sidekiq'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
     capistrano-releaseboard (0.0.1)
       faraday
     capistrano-shared_configs (0.1.1)
+    capistrano-sidekiq (0.5.4)
+      capistrano
+      sidekiq (>= 3.4)
     capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
@@ -324,6 +327,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
+  capistrano-sidekiq
   capybara
   codeclimate-test-reporter
   coffee-rails (~> 4.2.1)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,3 +63,6 @@ stanford_ips:
   ranges: []
 features:
   remote_ip_check: false
+
+background_jobs:
+  enabled: false


### PR DESCRIPTION
in the little testing i did, i was able to successfully stop, start, and restart sidekiq (on dev from my laptop) using the capistrano tasks.

the second commit is not strictly related to the capistrano-sidekiq stuff, but my rails server was crashing without the change when i tried to start it, since `config/environments/development.rb` expects it to be set.  seemed like it wasn't worth a separate PR, but happy to split out if people would prefer.

@tingulfsen?

closes #641