### PR TITLE
Remove log file reference in Sidekiq initializer

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,5 @@
 if Settings.background_jobs && Settings.background_jobs.enabled
   Sidekiq.configure_client do |config|
-    Sidekiq::Logging.initialize_logger(Settings.background_jobs.logfile) if Settings.background_jobs.logfile
     Sidekiq.logger.level = Settings.background_jobs.log_level.constantize if Settings.background_jobs.log_level
   end
 end


### PR DESCRIPTION
Now that the log file specification has been removed from our settings (see sul-dlss/shared_configs#198 and sul-dlss/shared_configs#199 and sul-dlss/shared_configs#188), we can remove a superfluous statement from the initializer.