### PR TITLE
Reload the request record before updating the approval status data…

### DIFF
--- a/app/models/item_status.rb
+++ b/app/models/item_status.rb
@@ -52,6 +52,7 @@ class ItemStatus
 
   def approve!(user)
     @request.send_to_symphony_now!(barcodes: [@id])
+    reload_request # reloading to get any attributes saved to the database above
     return unless symphony_item_successful?
     self.status_object = {
       approved: true,
@@ -97,6 +98,12 @@ class ItemStatus
   def symphony_user_error_code
     return unless @request.symphony_response && @request.symphony_response.usererr_code.present?
     @request.symphony_response.usererr_code
+  end
+
+  def reload_request
+    return unless @request.persisted?
+    @request.reload
+    @request.request_status_data ||= {}
   end
 
   def default_status_object

--- a/spec/models/item_status_spec.rb
+++ b/spec/models/item_status_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
+def update_symphony_data_and_save(request, symphony_data)
+  r = Request.find(request.id)
+  r.symphony_response_data = symphony_data
+  r.save!
+end
+
 describe ItemStatus do
   let(:request) { create(:mediated_page_with_single_holding) }
   let(:barcode) { '3610512345' }
@@ -40,6 +46,20 @@ describe ItemStatus do
       expect(request).to receive(:save!)
       expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, barcodes: [barcode])
       subject.approve!('jstanford')
+    end
+
+    context 'persisting data' do
+      let(:request) { create(:mediated_page) }
+      it 'reloads the record to ensure that any serialized attributes are updated' do
+        response = build(:symphony_page_with_single_item)
+        expect(request.symphony_response_data).to be_nil
+
+        expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, barcodes: [barcode]).and_return(
+          update_symphony_data_and_save(request, response)
+        )
+        subject.approve!('jstanford')
+        expect(request.symphony_response_data).to eq response
+      end
     end
 
     describe 'request approval status' do
@@ -108,7 +128,7 @@ describe ItemStatus do
     end
 
     context 'symphony errors' do
-      let(:request) { build(:request_with_symphony_errors) }
+      let(:request) { create(:request_with_symphony_errors) }
       let(:barcode) { '12345678901234' }
       it 'returns user level error codes' do
         expect(json[:usererr_code]).to eq 'U003'


### PR DESCRIPTION
…to ensure serialized data is not overwritten.