### PR TITLE
disable the "Approve" button when it's clicked to approve a mediated request, re-enable the button if the approval fails

### DIFF
--- a/app/assets/javascripts/item_approval.js
+++ b/app/assets/javascripts/item_approval.js
@@ -31,6 +31,8 @@ var itemApproval = (function() {
     approveItem: function(item) {
       var _this = this;
       var url = item.data('item-approval-url');
+
+      _this.disableElement(item);
       $.ajax(url).success(function(data) {
          _this.markRowAsApproved(item);
          _this.updateApproverInformation(item, data);
@@ -41,7 +43,16 @@ var itemApproval = (function() {
            _this.markRowAsError(item);
          }
          _this.addHoldingsLevelAlert(item, data);
+         _this.enableElement(item);
        });
+    },
+
+    disableElement: function(elt) {
+      elt.attr('disabled', 'disabled');
+    },
+
+    enableElement: function(elt) {
+      elt.removeAttr('disabled');
     },
 
     markRowAsApproved: function(item) {

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -117,6 +117,7 @@ describe 'Mediation table', js: true do
           end
           expect(page).to have_css('tr.approved')
           expect(page).to have_css('td button', text: 'Approved')
+          expect(page).to have_button('Approve', disabled: true)
 
           within(first('tr')) do
             expect(page).to have_css('td', text: 'Added to pick list', visible: true)
@@ -145,10 +146,12 @@ describe 'Mediation table', js: true do
         within('tbody td table tbody') do
           within(all('tr').first) do
             click_button('Approve')
+            expect(page).to have_button('Approve', disabled: true)
           end
 
           within(all('tr').last) do
             click_button('Approve')
+            expect(page).to have_button('Approve', disabled: true)
           end
         end
 
@@ -197,6 +200,10 @@ describe 'Mediation table', js: true do
         within('tbody td table tbody') do
           within(all('tr').last) do
             click_button('Approve')
+
+            wait_for_ajax
+            approval_btn = page.find('button.approval-btn')
+            expect(approval_btn['disabled']).to eq false
           end
         end
 
@@ -215,7 +222,11 @@ describe 'Mediation table', js: true do
               expect(page).not_to have_css('td', text: 'Item not found in catalog')
               stub_symphony_response(build(:symphony_request_with_mixed_status))
               click_button('Approve')
+
+              wait_for_ajax
               expect(page).to have_css('td', text: 'Item not found in catalog')
+              approval_btn = page.find('button.approval-btn')
+              expect(approval_btn['disabled']).to eq false
             end
           end
         end

--- a/spec/javascripts/item_approval_spec.js
+++ b/spec/javascripts/item_approval_spec.js
@@ -46,4 +46,20 @@ describe('Item Approval', function() {
       expect(itemApproval.rowIsApproved($('tr:last'))).toBe(false);
     });
   });
+
+  describe('disableElement()', function() {
+    it('sets the disabled attr on the button', function() {
+      var lastButton = $('button:last');
+      itemApproval.disableElement(lastButton);
+      expect(lastButton.prop('disabled')).toBe(true);
+    })
+  });
+
+  describe('enableElement()', function() {
+    it('removes the disabled attr from the button', function() {
+      var lastButton = $('button:last');
+      itemApproval.enableElement(lastButton);
+      expect(lastButton.prop('disabled')).toBe(false);
+    })
+  });
 });


### PR DESCRIPTION
* item_approval.js:  add disableElement and enableElement methods, call on attempted approval and approval failure, respectively.
* mediation_table_spec.rb:  confirm that "Approve" button is in correct enabled/disabled state after it's clicked.
* item_approval_spec.js:  unit tests for enableElement and disableElement methods

closes #603 