### PR TITLE
add 'jump to' create date calendar picker to dashboard and mediation UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,8 @@ Metrics/LineLength:
 
 Metrics/ClassLength:
   Max: 120
+  Exclude:
+    - 'app/models/request.rb'
 
 Style/StringLiterals:
   Enabled: true

--- a/app/assets/javascripts/html5_webshim.js
+++ b/app/assets/javascripts/html5_webshim.js
@@ -1,22 +1,27 @@
-$(document).on('turbolinks:load', function(){
+$(document).on('turbolinks:load', function() {
   if (window.webshim) {
-    window.webshim.setOptions('forms-ext', {
+    var webShimOptions = {
       lazyCustomMessages: true,
       replaceUI: true,
       waitReady: true,
       type: 'date',
       date: {
         startView: 2,
-        openOnFocus: true,
-        popover: {
-          position: {
-            my: 'center bottom',
-            at: 'center top',
-            collision: 'none'
-          }
-        }
+        openOnFocus: true
       }
-    });
+    };
+
+    if ($('[data-behavior="admin-date-picker"]').length === 0) {
+      webShimOptions.date.popover = {
+        position: {
+          my: 'center bottom',
+          at: 'center top',
+          collision: 'none'
+        }
+      };
+    }
+
+    window.webshim.setOptions('forms-ext', webShimOptions);
 
     window.webshim.activeLang('en-US');
     window.webshim.polyfill('forms-ext');

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -17,6 +17,9 @@ class Request < ActiveRecord::Base
   scope :recent, -> { order(created_at: :desc) }
   scope :needed_date_desc, -> { order(needed_date: :desc) }
   scope :for_date, ->(date) { where(needed_date: date) }
+  scope :for_create_date, lambda { |date|
+    where(created_at: Time.zone.parse(date).beginning_of_day..Time.zone.parse(date).end_of_day)
+  }
   scope :for_type, ->(request_type) { where(type: request_type) if request_type }
 
   delegate :hold_recallable?, :mediateable?, :pageable?, :scannable?, to: :library_location

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -2,11 +2,12 @@
 
 <h2><%= LibraryLocation.library_name_by_code(origin) %></h2>
 
-<p>
-  <%= link_to('All pending', admin_path(params[:id]), class: "btn btn-md btn-default #{'btn-primary' unless filtered_by_done? || filtered_by_date?}") %>
+<div>
+  <%= link_to('All pending', admin_path(params[:id]), class: "btn btn-md btn-default #{'btn-primary' unless filtered_by_done? || filtered_by_date? || filtered_by_create_date?}") %>
   <%= render 'date_buttons' %>
   <%= link_to('All done', admin_path(params[:id], done: true), class: "btn btn-md btn-default #{'btn-primary' if filtered_by_done?}") %>
-</p>
+  <%= render 'shared/jump_to_date', form_path: admin_path %>
+</div>
 
 <table id='mediation-table' class="table table-striped mediation-table">
   <%= render 'table_header' %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -31,6 +31,7 @@
 
 <div class='admin-requests'>
   <h2>Recent Requests</h2>
+  <%= render 'shared/jump_to_date', form_path: admin_index_path %>
 
   <table class="table table-striped">
     <thead>
@@ -59,6 +60,6 @@
     </tbody>
   </table>
 
-  <%= paginate @requests, theme: 'bootstrap' %>
+  <%= paginate @requests, theme: 'bootstrap' unless filtered_by_create_date? %>
 
 </div>

--- a/app/views/requests/_needed_date.html.erb
+++ b/app/views/requests/_needed_date.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group">
     <%= f.label :needed_date, class: "#{label_column_class} required control-label" %>
     <div class='<%= content_column_class %>'>
-      <%= f.date_field_without_bootstrap :needed_date, class: 'form-control', required: true, min: Time.zone.today , data: { request_type: current_request.type.underscore } %>
+      <%= f.date_field_without_bootstrap :needed_date, class: 'form-control', required: true, min: Time.zone.today, data: { request_type: current_request.type.underscore } %>
       <% if current_request.holdings_object.library_instructions.present? %>
         <p class='needed-date-help-block'>
           <%= current_request.holdings_object.library_instructions[:text] %>

--- a/app/views/shared/_jump_to_date.html.erb
+++ b/app/views/shared/_jump_to_date.html.erb
@@ -1,0 +1,4 @@
+<%= bootstrap_form_tag(url: form_path, method: 'get', layout: :inline, :html => {class: "pull-right"}) do |f| %>
+  <%= f.date_field(:created_at, value: params[:created_at] || Time.zone.today, label: 'Find by date requested: &nbsp;'.html_safe, 'data-behavior': 'admin-date-picker') %>
+  <%= f.primary "Go" %>
+<% end %>

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -56,9 +56,22 @@ describe Request do
         create(:request, needed_date: Time.zone.today + 2.days)
       end
 
-      it 'returns requests that match the given date' do
+      it 'returns requests with needed_date matching the given date' do
         expect(Request.for_date(Time.zone.today + 1.day).count).to eq 2
         expect(Request.for_date(Time.zone.today + 2.days).count).to eq 1
+      end
+    end
+
+    describe 'for_create_date' do
+      before do
+        create(:request, created_at: Time.zone.today - 1.day)
+        create(:request, created_at: Time.zone.today - 1.day)
+        create(:request, created_at: Time.zone.today - 2.days)
+      end
+
+      it 'returns requests with created_at matching the given date' do
+        expect(Request.for_create_date((Time.zone.today - 1.day).to_s).count).to eq 2
+        expect(Request.for_create_date((Time.zone.today - 2.days).to_s).count).to eq 1
       end
     end
 


### PR DESCRIPTION
this branch is also currently deploy to requests-stage if you want to check out the interactions.  Note:  known bug with date picker after clicking something:  #671.  That can be addressed separately.

# Dashboard Before
![dashboard before](https://cloud.githubusercontent.com/assets/96775/20415218/af704da8-aceb-11e6-95a6-2234a3c6cea6.png)

# Dashboard After
![dashboard after](https://cloud.githubusercontent.com/assets/96775/20415688/c46bf4f2-acee-11e6-975b-18a0bf72e132.png)

# Mediation UI Before
![mediation before](https://cloud.githubusercontent.com/assets/96775/20415216/af6cb698-aceb-11e6-8e55-43f24f2c3176.png)

# Mediation UI After
![mediation after](https://cloud.githubusercontent.com/assets/96775/20415689/c46c514a-acee-11e6-9393-01d380e8516b.png)

closes #632 
closes #659