### PR TITLE
remove default sort indicator from 'Requested on' column in mediation table

### DIFF
--- a/app/views/admin/_table_header.html.erb
+++ b/app/views/admin/_table_header.html.erb
@@ -17,7 +17,7 @@
       </a>
     </th>
     <th class="col-sm-1">
-      <a class='sort asc' data-sort='created_at' href='javascript:;'>
+      <a class='sort' data-sort='created_at' href='javascript:;'>
         Requested on <i></i>
       </a>
     </th>

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -168,6 +168,12 @@ describe 'Mediation table', js: true do
         click_link 'Requested on'
 
         within '.mediation-table tbody' do
+          expect(page).to have_content(/Jane Stanford.*Joe Doe.*Jim Doe/)
+        end
+
+        click_link 'Requested on'
+
+        within '.mediation-table tbody' do
           expect(page).to have_content(/Jim Doe.*Joe Doe.*Jane Stanford/)
         end
       end


### PR DESCRIPTION
fix test that expected to be reversing the old default sort order (it'll be applying that sort order for the first time)

![screen shot 2016-11-16 at 6 16 23 pm](https://cloud.githubusercontent.com/assets/7741604/20373820/4fcf0e06-ac29-11e6-82e9-f88d7259da23.png)

closes #642 