### PR TITLE
default sort orderings for pending and done mediated requests

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -67,7 +67,7 @@ class AdminController < ApplicationController
   end
 
   def completed_mediated_pages
-    origin_filtered_mediated_pages.completed.page(page).per(per)
+    origin_filtered_mediated_pages.completed.page(page).per(per).order(needed_date: 'desc', created_at: 'desc')
   end
 
   def date_filtered_mediated_pages
@@ -75,7 +75,7 @@ class AdminController < ApplicationController
   end
 
   def pending_mediated_pages
-    origin_filtered_mediated_pages.unapproved
+    origin_filtered_mediated_pages.unapproved.order(needed_date: 'asc', created_at: 'desc')
   end
 
   def origin_filtered_mediated_pages

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -89,7 +89,7 @@ describe 'Mediation table', js: true do
       it 'has toggleable rows that display holdings' do
         expect(page).to have_css('[data-mediate-request]', count: 4)
         expect(page).to have_css('tbody tr', count: 4)
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           expect(page).to have_css('td', count: top_level_columns)
           page.find('a.mediate-toggle').trigger('click')
         end
@@ -103,7 +103,7 @@ describe 'Mediation table', js: true do
       end
 
       it 'has holdings that can be approved' do
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           page.find('a.mediate-toggle').trigger('click')
         end
 
@@ -128,7 +128,7 @@ describe 'Mediation table', js: true do
         # and check that it is persisted
         visit admin_path('SPEC-COLL')
 
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           page.find('a.mediate-toggle').trigger('click')
         end
 
@@ -138,7 +138,7 @@ describe 'Mediation table', js: true do
       end
 
       it 'indicates when all items in a request have been approved' do
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           expect(page).to_not have_css('[data-behavior="all-approved-note"]', text: 'Done')
           page.find('a.mediate-toggle').trigger('click')
         end
@@ -155,14 +155,14 @@ describe 'Mediation table', js: true do
           end
         end
 
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           expect(page).to have_css('[data-behavior="all-approved-note"]', text: 'Done')
         end
       end
 
       it 'has sortable columns' do
         within '.mediation-table tbody' do
-          expect(page).to have_content(/Jane Stanford.*Joe Doe.*Jim Doe/)
+          expect(page).to have_content(/Jim Doe.*Joe Doe.*Jane Stanford/)
         end
 
         click_link 'Requested on'
@@ -183,7 +183,7 @@ describe 'Mediation table', js: true do
       let(:symphony_response) { build(:symphony_request_with_mixed_status) }
 
       it 'has the persisted item level error message' do
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           page.find('a.mediate-toggle').trigger('click')
         end
 
@@ -197,7 +197,7 @@ describe 'Mediation table', js: true do
       end
 
       it 'returns the item level error text if it is not user-based' do
-        within(first('[data-mediate-request]')) do
+        within(all('[data-mediate-request]').last) do
           page.find('a.mediate-toggle').trigger('click')
         end
 
@@ -219,7 +219,7 @@ describe 'Mediation table', js: true do
       describe 'on item approval' do
         let(:symphony_response) { build(:symphony_page_with_multiple_items) }
         it 'updates the item level error messages' do
-          within(first('[data-mediate-request]')) do
+          within(all('[data-mediate-request]').last) do
             page.find('a.mediate-toggle').trigger('click')
           end
 


### PR DESCRIPTION
as per #658:
> **All done** should be sorted like so (and I think is):
> 1. "needed on" descending, then
> 2. "requested on" descending
> 
> **All pending** should be sorted like so:
> 1. "needed on" **ascending**, then
> 2. "requested on" descending

this PR implements those default sort orderings and:
* fixes the existing affected mediated page tests to expect things in the new default order.
* breaks apart the existing sort-specific test into two to make the default "pending" sort order part of the test distinct from the javascript sortable columns part of the test.
* adds some new completed request test data and a new test for default sort order for the "done" filter.

deployed to stage, in combination with @ndushay's 632-jump-to-date branch via this branch:
https://github.com/sul-dlss/sul-requests/tree/632-659-658_2016-11-18

note that there was a small conflict in rebasing this branch on naomi's.  i resolved it by making line 93 of `admin_controller.rb` read:
```ruby
origin_filtered_mediated_pages.completed.page(page).per(per_page).order(needed_date: 'desc', created_at: 'desc')
```

which may be useful if both PRs get merged pretty much as they currently are.

paired w/ @tingulfsen 

closes #658 