### PR TITLE
Warn user immediately when an invalid date is selected

### DIFF
--- a/app/assets/javascripts/date_selector.js
+++ b/app/assets/javascripts/date_selector.js
@@ -2,7 +2,8 @@ var dateSelector = (function() {
   var defaultOptions = {
     mediatedPageFieldSelector: 'input[data-request-type="mediated_page"]',
     dropdownSelector: '[data-paging-schedule-updater="true"]',
-    singleLibrarySelector: '[data-single-library-value]'
+    singleLibrarySelector: '[data-single-library-value]',
+    neededDateWarningSelector: '#needed-date-warning'
   };
 
   return {
@@ -80,17 +81,22 @@ var dateSelector = (function() {
       this.mediatedDateField().closest('.form-group').removeClass('has-error');
       this.mediatedDateField()[0].setCustomValidity('');
       this.mediatedDateField().siblings('.help-block').remove();
+      this.mediatedDateWarning().text('');
     },
 
     setDateFieldAsInvalid: function() {
+      var message = 'This library is not open on ' + this.selectedDate();
+      this.mediatedDateField()[0].setCustomValidity(message);
+      this.mediatedDateWarning().text(message);
       this.mediatedDateField().closest('.form-group').addClass('has-error');
-      this.mediatedDateField()[0].setCustomValidity(
-        'This library is not open on ' + this.selectedDate()
-      );
     },
 
     mediatedDateField: function() {
       return $(this.options.mediatedPageFieldSelector);
+    },
+
+    mediatedDateWarning: function() {
+      return $(this.options.neededDateWarningSelector);
     },
 
     hoursLookupUrl: function(destination, date) {

--- a/app/views/requests/_needed_date.html.erb
+++ b/app/views/requests/_needed_date.html.erb
@@ -3,8 +3,9 @@
     <%= f.label :needed_date, class: "#{label_column_class} required control-label" %>
     <div class='<%= content_column_class %>'>
       <%= f.date_field_without_bootstrap :needed_date, class: 'form-control', required: true, min: Time.zone.today, data: { request_type: current_request.type.underscore } %>
+      <div id='needed-date-warning' class='has-error needed-date-help-block'></div>
       <% if current_request.holdings_object.library_instructions.present? %>
-        <p class='needed-date-help-block'>
+        <p class='needed-date-info-block'>
           <%= current_request.holdings_object.library_instructions[:text] %>
         </p>
       <% end %>

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -5,7 +5,7 @@ describe 'Library Instructions' do
   it 'returns the library instructions from the API' do
     visit new_request_path(item_id: '12345', origin: 'SPEC-COLL', origin_location: 'STACKS')
 
-    within('p.needed-date-help-block') do
+    within('p.needed-date-info-block') do
       expect(page).to have_content('This is the library instruction')
     end
   end

--- a/spec/javascripts/date_selector_spec.js
+++ b/spec/javascripts/date_selector_spec.js
@@ -16,6 +16,7 @@ describe('Date Selector', function() {
       dateSelector.setDateFieldAsValid();
       expect(formGroup).not.toHaveClass('has-error');
       expect(dateSelector.mediatedDateField().siblings('.help-block').length).toBe(0);
+      expect(dateSelector.mediatedDateWarning().text()).toBe('');
     });
   });
 
@@ -26,6 +27,7 @@ describe('Date Selector', function() {
       expect(formGroup).not.toHaveClass('has-error');
       dateSelector.setDateFieldAsInvalid();
       expect(formGroup).toHaveClass('has-error');
+      expect(dateSelector.mediatedDateWarning().text()).toBe('This library is not open on 2016-01-01');
     });
   });
 

--- a/spec/javascripts/fixtures/date_selector.html
+++ b/spec/javascripts/fixtures/date_selector.html
@@ -2,5 +2,6 @@
 
 <div class='form-group'>
   <input type="date" data-request-type="mediated_page" />
+  <div id='needed-date-warning' class='has-error needed-date-help-block'></div>
   <div class="help-block">This is an error message</div>
 </div>


### PR DESCRIPTION
Users are presented with date selector to notify the library when they want to access certain materials (e.g. special collections). The current approach relies exclusively on the Bootstrap validation tool, which only pops up a message when the entire form is submitted. This PR adds code to immediately display a warning below the date selector when an invalid date is chosen.

Closes #651 

After:

<img width="652" alt="screen shot 2016-11-22 at 12 16 06 am" src="https://cloud.githubusercontent.com/assets/3740294/20515986/f5d8393a-b048-11e6-8c19-06a325295fb1.png">
