### PR TITLE
Make the feedback link have a blank target…

### DIFF
--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -13,7 +13,7 @@
         <%= link_to "Login", login_path(referrer: request.original_url) %>
       <% end %>
       <%= link_to "My Account", "http://library.stanford.edu/myaccount" %>
-      <%= link_to "Feedback", "http://searchworks.stanford.edu/feedback"  %>
+      <%= link_to "Feedback", "http://searchworks.stanford.edu/feedback", target: '_blank', rel: 'noopener noreferrer'  %>
     </div>
 
   </header>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -15,6 +15,13 @@ feature 'Home Page' do
       expect(page).to have_css('.header-links a', text: 'My Account')
       expect(page).to have_css('.header-links a', text: 'Feedback')
     end
+
+    it 'should have a target="_blank" feedback link (with appropriate rel attribute)' do
+      feedback_link = page.find('.header-links a', text: 'Feedback')
+      expect(feedback_link['target']).to eq '_blank'
+      expect(feedback_link['rel']).to eq 'noopener noreferrer'
+    end
+
     it 'should display SUL footer' do
       expect(page).to have_css('#sul-footer #sul-footer-img img')
       expect(page).to have_css('#sul-footer-links a', text: 'Stanford University Libraries')


### PR DESCRIPTION
…(as well as the appropriate rel attr).

Closes #663 
