### PR TITLE
send "approval status" email after async call to symphony

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,8 @@ Rails:
 
 Metrics/LineLength:
   Max: 120
+  Exclude:
+    - 'spec/mailers/approval_status_mailer_spec.rb'
 
 Metrics/ClassLength:
   Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 120
 
+Metrics/ModuleLength:
+  Max: 120
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: single_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,8 @@ gem 'sidekiq-statistic'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
+  # or call 'binding.pry'  (you may need require 'pry-byebug' first)
+  gem 'pry-byebug'
 
   # RSpec for testing
   gem 'rspec-rails', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       xpath (~> 2.0)
     cliver (0.3.2)
     codeclimate-test-reporter (1.0.1)
+    coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -163,6 +164,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -185,6 +187,13 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     public_suffix (2.0.4)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -270,6 +279,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -322,7 +332,6 @@ DEPENDENCIES
   bootstrap-editable-rails
   bootstrap-sass (~> 3.3.4)
   bootstrap_form
-  byebug
   cancancan (~> 1.10)
   capistrano (~> 3.0)
   capistrano-bundler
@@ -352,6 +361,7 @@ DEPENDENCIES
   nested_form
   okcomputer
   poltergeist
+  pry-byebug
   rails (= 4.2.7.1)
   redcarpet
   rspec-rails (~> 3.0)

--- a/app/assets/stylesheets/modules/success.scss
+++ b/app/assets/stylesheets/modules/success.scss
@@ -8,6 +8,13 @@
   .requested-by {
     font-size: 1.6em;
   }
+
+  .user-contact-information {
+    .requested-by {
+      color: $alert-red;
+      font-weight: 300;
+    }
+  }
 }
 
 .approval-error {

--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -15,6 +15,7 @@ class SubmitSymphonyRequestJob < ActiveJob::Base
     Sidekiq::Logging.logger.debug("Symphony response string: #{response}")
     request.merge_symphony_response_data(response.with_indifferent_access)
     request.save
+    request.send_approval_status!
     Sidekiq::Logging.logger.info("Completed SubmitSymphonyRequestJob for request #{request_id}")
   end
 

--- a/app/mailers/approval_status_mailer.rb
+++ b/app/mailers/approval_status_mailer.rb
@@ -1,0 +1,62 @@
+###
+#  Mailer class to send approval status emails after requests have been submitted
+###
+class ApprovalStatusMailer < ApplicationMailer
+  def request_approval_status(request)
+    @request = request
+    @status_url = success_url
+    @contact_info = formatted_contact_info
+    mail(
+      to: request.notification_email_address,
+      from: from_address,
+      subject: subject
+    )
+  end
+
+  private
+
+  def from_address
+    %("Stanford Libraries Requests" <#{contact_info[:email]}>)
+  end
+
+  def subject
+    I18n.t(
+      "approval_status_email.#{@request.class.name.underscore}.subject.#{suffix}",
+      title: @request.item_title,
+      default: I18n.t("approval_status_email.request.subject.#{suffix}")
+    )
+  end
+
+  def contact_info
+    contact_info_config[@request.origin_location] ||
+      contact_info_config[@request.origin] ||
+      contact_info_config[@request.destination] ||
+      contact_info_config['default']
+  end
+
+  def contact_info_config
+    SULRequests::Application.config.contact_info
+  end
+
+  def formatted_contact_info
+    "  #{contact_info[:phone]}\n  #{contact_info[:email]}"
+  end
+
+  def success_url
+    if !@request.user.webauth_user? && @request.is_a?(TokenEncryptable)
+      polymorphic_url([:status, @request], token: @request.encrypted_token)
+    else
+      polymorphic_url([:status, @request])
+    end
+  end
+
+  def suffix
+    @suffix ||= begin
+      if @request.symphony_response.success?
+        'success'
+      else
+        'failure'
+      end
+    end
+  end
+end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,5 +1,5 @@
 ###
-#  Mailer class to send confimration emails after requests have been submitted
+#  Mailer class to send confirmation emails after requests have been submitted
 ###
 class ConfirmationMailer < ApplicationMailer
   def request_confirmation(request)

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -16,7 +16,7 @@ class ConfirmationMailer < ApplicationMailer
   private
 
   def from_address
-    contact_info[:email]
+    %("Stanford Libraries Requests" <#{contact_info[:email]}>)
   end
 
   def subject

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -52,7 +52,7 @@ class Request < ActiveRecord::Base
   end
 
   def send_confirmation!
-    ConfirmationMailer.request_confirmation(self).deliver_later if notification_email_address.present?
+    true
   end
 
   def delegate_request!

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -55,6 +55,10 @@ class Request < ActiveRecord::Base
     true
   end
 
+  def send_approval_status!
+    ApprovalStatusMailer.request_approval_status(self).deliver_later if notification_email_address.present?
+  end
+
   def delegate_request!
     case
     when mediateable? then becomes!(MediatedPage)

--- a/app/models/request_approval_status.rb
+++ b/app/models/request_approval_status.rb
@@ -16,7 +16,14 @@ class RequestApprovalStatus
   def to_html
     return content_wrapper { pending_text } if pending?
     return content_wrapper { user_error_text } if user_error?
-    safe_join(item_list_with_status)
+    safe_join(item_list_with_status_markup)
+  end
+
+  def to_text
+    return pending_text if pending?
+    # Not putting user errors here because it
+    # is handled elswehere in the context of the plain text status
+    item_list_with_status.join("\n")
   end
 
   def pending?
@@ -49,6 +56,16 @@ class RequestApprovalStatus
   def item_list_with_status
     request.holdings.map do |item|
       if request.symphony_response.success?(item.barcode)
+        succcess_text_for_item(item.callnumber)
+      elsif request.symphony_response.item_failed?(item.barcode)
+        error_text_for_item(item)
+      end
+    end
+  end
+
+  def item_list_with_status_markup
+    request.holdings.map do |item|
+      if request.symphony_response.success?(item.barcode)
         success_markup_for_item(item.callnumber)
       elsif request.symphony_response.item_failed?(item.barcode)
         error_markup_for_item(item)
@@ -57,23 +74,23 @@ class RequestApprovalStatus
   end
 
   def error_markup_for_item(item)
-    content_wrapper(css_class: 'approval-error') do
-      t(
-        :'approval_status.default.error',
-        callnumber: item.callnumber,
-        error_text: item.request_status.try(:text)
-      )
-    end
+    content_wrapper(css_class: 'approval-error') { error_text_for_item(item) }
+  end
+
+  def error_text_for_item(item)
+    t(:'approval_status.default.error', callnumber: item.callnumber, error_text: item.request_status.try(:text))
   end
 
   def success_markup_for_item(item)
-    content_wrapper do
-      t(
-        :"approval_status.#{request_class_name}.success",
-        default: [:"approval_status.#{request_origin}.success", :'approval_status.default.success'],
-        item: item
-      )
-    end
+    content_wrapper { succcess_text_for_item(item) }
+  end
+
+  def succcess_text_for_item(item)
+    t(
+      :"approval_status.#{request_class_name}.success",
+      default: [:"approval_status.#{request_origin}.success", :'approval_status.default.success'],
+      item: item
+    )
   end
 
   def user_error_text

--- a/app/models/request_approval_status.rb
+++ b/app/models/request_approval_status.rb
@@ -1,7 +1,7 @@
 ##
 # Relatively simple utility class to render the status of a request.
 # The status can either be pending, a user error, or return the list of items,
-# that have either been requested sucessfully or have returned with an error.
+# that have either been requested successfully or have returned with an error.
 class RequestApprovalStatus
   include ActionView::Context
   include ActionView::Helpers::TagHelper

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -66,6 +66,10 @@ class MediatedPage < Request
     )[:email]
   end
 
+  def send_confirmation!
+    ConfirmationMailer.request_confirmation(self).deliver_later if notification_email_address.present?
+  end
+
   def self.mark_all_archived_as_complete!
     archived.find_each do |mediated_page|
       if mediated_page.all_approved?

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -70,6 +70,10 @@ class MediatedPage < Request
     ConfirmationMailer.request_confirmation(self).deliver_later if notification_email_address.present?
   end
 
+  def send_approval_status!
+    true
+  end
+
   def self.mark_all_archived_as_complete!
     archived.find_each do |mediated_page|
       if mediated_page.all_approved?

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -33,6 +33,10 @@ class Scan < Request
     ConfirmationMailer.request_confirmation(self).deliver_later if notification_email_address.present?
   end
 
+  def send_approval_status!
+    true
+  end
+
   private
 
   def scannable_validator

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -30,10 +30,6 @@ class Scan < Request
   end
 
   def send_confirmation!
-    ConfirmationMailer.request_confirmation(self).deliver_later if notification_email_address.present?
-  end
-
-  def send_approval_status!
     true
   end
 

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -29,6 +29,10 @@ class Scan < Request
     send_to_symphony_now!
   end
 
+  def send_confirmation!
+    ConfirmationMailer.request_confirmation(self).deliver_later if notification_email_address.present?
+  end
+
   private
 
   def scannable_validator

--- a/app/views/approval_status_mailer/request_approval_status.text.erb
+++ b/app/views/approval_status_mailer/request_approval_status.text.erb
@@ -1,0 +1,47 @@
+On <%= l @request.created_at.to_date, format: :long %>, you requested:
+
+<%= @request.item_title %>
+
+<% if @request.symphony_response.success? -%>
+The items listed below have been processed:
+<% elsif @request.symphony_response.usererr_code.present? -%>
+Items:
+<% else -%>
+There were problems with one or more of the items listed below:
+<% end -%>
+
+  <%= @request.holdings.map(&:callnumber).join("\n  ") -%>
+  <%= @request.ad_hoc_items.join("\n  ") if @request.ad_hoc_items.present? -%>
+
+<%= @request.data_to_email_s -%>
+
+<% if @request.symphony_response.success? -%>
+  <% if @request.needed_date.present? -%>
+<%= "#{@request.class.human_attribute_name(:needed_date)}: #{l @request.needed_date, format: :long}" %>
+
+  <% end -%>
+Any further updates will be posted on the status page at <%= @status_url %>
+<% if @request.appears_in_myaccount? %>You can also see the status at http://library.stanford.edu/myaccount<% end %>
+<% else -%>
+<%= t("approval_status_email.request_status.failure.code_#{@request.symphony_response.usererr_code}", default: '')%>
+
+What can you do now?
+
+  Request assistance by replying to this email, or
+  <% if @request.symphony_response.usererr_code.blank? -%>
+  try your request again, at https://searchworks.stanford.edu/view/<%= @request.item_id %>
+  <% else -%>
+  check MyAccount (http://library.stanford.edu/myaccount) for more information.
+  <% end -%>
+<% end -%>
+
+<% if @request.symphony_response.usererr_code.present? -%>
+Just need a chapter or article?
+     Even though your status is blocked, you are eligible for Scan to PDF.
+     You can request a single article or chapter, up to 50 pages.
+     https://searchworks.stanford.edu/view/<%= @request.item_id %>
+<% end -%>
+
+Questions about your request?
+Contact:
+<%= @contact_info %>

--- a/app/views/approval_status_mailer/request_approval_status.text.erb
+++ b/app/views/approval_status_mailer/request_approval_status.text.erb
@@ -10,7 +10,7 @@ Items:
 There were problems with one or more of the items listed below:
 <% end -%>
 
-  <%= @request.holdings.map(&:callnumber).join("\n  ") -%>
+  <%= RequestApprovalStatus.new(request: @request).to_text %>
   <%= @request.ad_hoc_items.join("\n  ") if @request.ad_hoc_items.present? -%>
 
 <%= @request.data_to_email_s -%>

--- a/app/views/scans/success.html.erb
+++ b/app/views/scans/success.html.erb
@@ -1,9 +1,13 @@
 <div class='<%= dialog_column_class %> success-page'>
+  <h1 id='dialogTitle'>
+    <span class="sul-i-check-2" aria-hidden="true"></span> Request complete
+  </h1>
+
   <%= render 'searchworks_item_information' %>
   <%= render 'shared/request_status_information' %>
 
   <% if current_request.symphony_response.success? %>
-    <dl class='dl-horizontal dl-invert'>
+    <dl class='dl-horizontal dl-invert user-contact-information'>
       <dt class='sr-only'><%= current_request.class.human_attribute_name :user %></dt>
       <% unless current_request.user.library_id_user? %>
         <dd>
@@ -14,16 +18,16 @@
       <% if current_request.proxy? %>
         <dd>
           <p>Shared with your proxy group</p>
-          <p class='help-block'><%= t('.email_notification.proxy') %></p>
+          <p class='help-block'><%= t('requests.success.synchronous_email_notification.proxy') %></p>
         </dd>
       <% elsif current_user.sponsor? %>
         <dd>
           <p>Individual Request</p>
-          <p class='help-block'><%= t('.email_notification.default') %></p>
+          <p class='help-block'><%= t('requests.success.synchronous_email_notification.default') %></p>
         </dd>
       <% elsif current_request.notification_email_address.present? %>
         <dd>
-          <p class='help-block'><%= t('.email_notification.default') %></p>
+          <p class='help-block'><%= t('requests.success.synchronous_email_notification.default') %></p>
         </dd>
       <% end %>
     </dl>

--- a/app/views/shared/_request_status_information.html.erb
+++ b/app/views/shared/_request_status_information.html.erb
@@ -13,12 +13,13 @@
     <% end %>
   <% end %>
 
-  <% if current_request.destination.present? %>
+  <% destination_name = LibraryLocation.library_name_by_code(current_request.destination) %>
+  <% if destination_name.present? %>
     <dt>
       <%= label_for_pickup_libraries_dropdown(current_request.library_location.pickup_libraries) %>
     </dt>
     <dd>
-      <%= LibraryLocation.library_name_by_code(current_request.destination) %>
+      <%= destination_name %>
     </dd>
   <% end %>
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -59,3 +59,4 @@ before 'deploy:restart', 'shared_configs:update'
 # Sidekiq configuration (run one process with ten threads)
 set :sidekiq_processes, 1
 set :sidekiq_concurrency, 10
+set :sidekiq_queue, ['default', 'mailers']

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   #config.lograge.enabled = true
 
   # Use the Sidekiq adapter for Active Job if configured in settings
-  if Settings.background_jobs.enabled == true
+  if Settings.background_jobs && Settings.background_jobs.enabled == true
     config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # put IP at beginning of log messages
   config.log_tags = [ :remote_ip ]
   # reduce noise in logs
-  config.lograge.enabled = true
+  #config.lograge.enabled = true
 
   # Use the Sidekiq adapter for Active Job if configured in settings
   if Settings.background_jobs.enabled == true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   # put IP at beginning of log messages
   config.log_tags = [ :remote_ip ]
   # reduce noise in logs
-  config.lograge.enabled = true
+  #config.lograge.enabled = true
 
   # Use the Sidekiq adapter for Active Job if configured in settings
   if Settings.background_jobs == true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
   #config.lograge.enabled = true
 
   # Use the Sidekiq adapter for Active Job if configured in settings
-  if Settings.background_jobs == true
+  if Settings.background_jobs && Settings.background_jobs.enabled == true
     config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.lograge.enabled = true
 
   # Use the Sidekiq adapter for Active Job if configured in settings
-  if Settings.background_jobs == true
+  if Settings.background_jobs && Settings.background_jobs.enabled == true
     config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,9 +72,9 @@ en:
       extra_note: 'Items are typically approved 1-3 days before your scheduled visit.'
   confirmation_email:
     request:
-      subject: 'Item(s) requested (%{title})'
+      subject: 'Item(s) requested ("%{title}")'
     scan:
-      subject: "Scan to PDF requested (%{title})"
+      subject: "Scan to PDF requested (\"%{title}\")"
     mediated_page:
       mediator_subject: 'New request needs mediation'
   date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,16 @@ en:
       extra_note: 'Items are typically approved 1-3 days before your scheduled visit.'
     spec_coll:
       extra_note: 'Items are typically approved 1-3 days before your scheduled visit.'
+  approval_status_email:
+    request:
+      subject:
+        success: "Your request has been processed (\"%{title}\")"
+        failure: "Attention needed: Your request could not be processed (\"%{title}\")"
+    request_status:
+      failure:
+        code_U003: 'Your request could not be processed because your user privileges are blocked.'
+        code_U004: 'Your request could not be processed because your user privileges have expired.'
+
   confirmation_email:
     request:
       subject: 'Item(s) requested ("%{title}")'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,8 @@ en:
     mediated_page:
       pending: 'Waiting for approval.'
       success: '%{item} has been approved.'
+    scan:
+      success: '%{item} has been paged for scanning.'
     rumseymap:
       extra_note: 'Items are typically approved 1-3 days before your scheduled visit.'
     spec_coll:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,9 @@ en:
       email_notification:
         proxy: "We'll send an email to you and to the designated notification address when processing is complete."
         default: "We'll send you an email when processing is complete."
+      synchronous_email_notification:
+        proxy: "(We've sent a copy of this request to your email and to the designated notification address.)"
+        default: "(We've sent a copy of this request to your email.)"
   status_text:
     paged: Paged
     hold: Item is on-site - hold for patron

--- a/spec/controllers/hold_recall_controller_spec.rb
+++ b/spec/controllers/hold_recall_controller_spec.rb
@@ -99,13 +99,13 @@ describe HoldRecallsController do
         expect(HoldRecall.last.needed_date).to eq Time.zone.today + 1.month
       end
 
-      it 'sends an confirmation email' do
+      it 'does not send a confirmation email' do
         stub_symphony_response(build(:symphony_page_with_single_item))
         expect(
           lambda do
             put :create, request: normal_params
           end
-        ).to change { ConfirmationMailer.deliveries.count }.by(1)
+        ).not_to change { ConfirmationMailer.deliveries.count }
       end
     end
     describe 'invalid requests' do

--- a/spec/controllers/hold_recall_controller_spec.rb
+++ b/spec/controllers/hold_recall_controller_spec.rb
@@ -107,6 +107,8 @@ describe HoldRecallsController do
           end
         ).not_to change { ConfirmationMailer.deliveries.count }
       end
+
+      # Note:  cannot trigger activejob from this spec to check ApprovalStatusMailer
     end
     describe 'invalid requests' do
       let(:user) { create(:webauth_user) }

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -134,7 +134,7 @@ describe MediatedPagesController do
         expect(MediatedPage.last.user).to eq user
       end
 
-      it 'sends a confirmation email to the user and to the mediator' do
+      it 'sends a confirmation email to the user' do
         expect(
           lambda do
             put :create, request: {
@@ -145,7 +145,7 @@ describe MediatedPagesController do
               needed_date: Time.zone.today + 1.year
             }
           end
-        ).to change { ConfirmationMailer.deliveries.count }.by(2)
+        ).to change { ConfirmationMailer.deliveries.count { |x| x.subject != 'New request needs mediation' } }.by(1)
       end
 
       it 'sends an email to the mediator' do

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -134,6 +134,23 @@ describe MediatedPagesController do
         expect(MediatedPage.last.user).to eq user
       end
 
+      it 'does not send an approval status email' do
+        stub_symphony_response(build(:symphony_page_with_single_item))
+        expect(
+          lambda do
+            put :create, request: {
+              item_id: '1234',
+              origin: 'SPEC-COLL',
+              origin_location: 'STACKS',
+              destination: 'SPEC-COLL',
+              needed_date: Time.zone.today + 1.year
+            }
+          end
+        ).not_to change {
+          ApprovalStatusMailer.deliveries.count { |x| x.subject =~ /Your request/ }
+        }
+      end
+
       it 'sends a confirmation email to the user' do
         expect(
           lambda do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -174,18 +174,7 @@ describe PagesController do
         ).not_to change { ConfirmationMailer.deliveries.count }
       end
 
-      it 'does not send a confirmation email if the symphony request is not successful' do
-        expect(
-          lambda do
-            put :create, request: {
-              item_id: '1234',
-              origin: 'GREEN',
-              origin_location: 'STACKS',
-              destination: 'BIOLOGY'
-            }
-          end
-        ).not_to change { ConfirmationMailer.deliveries.count }
-      end
+      # Note:  cannot trigger activejob from this spec to check ApprovalStatusMailer
 
       context 'create/update' do
         it 'raises an error when the honey-pot email field is filled in on create' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -160,7 +160,7 @@ describe PagesController do
         expect(Page.last.user.library_id).to eq '5432123'
       end
 
-      it 'sends an confirmation email' do
+      it 'does not send a confirmation email' do
         stub_symphony_response(build(:symphony_page_with_single_item))
         expect(
           lambda do
@@ -171,7 +171,7 @@ describe PagesController do
               destination: 'BIOLOGY'
             }
           end
-        ).to change { ConfirmationMailer.deliveries.count }.by(1)
+        ).not_to change { ConfirmationMailer.deliveries.count }
       end
 
       it 'does not send a confirmation email if the symphony request is not successful' do

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -134,25 +134,10 @@ describe ScansController do
               section_title: 'Some really important chapter'
             }
           end
-        ).to change { ConfirmationMailer.deliveries.count }.by(1)
+        ).not_to change { ConfirmationMailer.deliveries.count }
       end
 
-      it 'does not send an approval status email' do
-        stub_symphony_response(build(:symphony_page_with_single_item))
-        expect(
-          lambda do
-            post :create, illiad_success: true, request: {
-              item_id: '12345',
-              origin: 'SAL3',
-              origin_location: 'STACKS',
-              barcodes: ['12345678'],
-              section_title: 'Some really important chapter'
-            }
-          end
-        ).not_to change {
-          ApprovalStatusMailer.deliveries.count { |x| x.subject =~ /Your request/ }
-        }
-      end
+      # Note:  cannot trigger activejob from this spec to check ApprovalStatusMailer
 
       it 'submits the request to symphony' do
         expect(SubmitSymphonyRequestJob).to receive(:perform_now)

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -137,6 +137,23 @@ describe ScansController do
         ).to change { ConfirmationMailer.deliveries.count }.by(1)
       end
 
+      it 'does not send an approval status email' do
+        stub_symphony_response(build(:symphony_page_with_single_item))
+        expect(
+          lambda do
+            post :create, illiad_success: true, request: {
+              item_id: '12345',
+              origin: 'SAL3',
+              origin_location: 'STACKS',
+              barcodes: ['12345678'],
+              section_title: 'Some really important chapter'
+            }
+          end
+        ).not_to change {
+          ApprovalStatusMailer.deliveries.count { |x| x.subject =~ /Your request/ }
+        }
+      end
+
       it 'submits the request to symphony' do
         expect(SubmitSymphonyRequestJob).to receive(:perform_now)
 

--- a/spec/factories/symphony_api_response_json.rb
+++ b/spec/factories/symphony_api_response_json.rb
@@ -1,4 +1,22 @@
 FactoryGirl.define do
+  factory :symphony_scan_success, class: Hash do
+    req_type 'SCAN'
+    confirm_email 'jlathrop@stanford.edu'
+    requested_items [
+      {
+        'barcode' => '36105212920537',
+        'msgcode' => 'S001',
+        'text' => 'Scan submitted'
+      }
+    ]
+
+    initialize_with do
+      attributes.map do |k, h|
+        [k.to_s, h]
+      end.to_h
+    end
+  end
+
   factory :symphony_scan_with_multiple_items, class: Hash do
     req_type 'SCAN'
     confirm_email 'jlathrop@stanford.edu'

--- a/spec/factories/symphony_api_response_json.rb
+++ b/spec/factories/symphony_api_response_json.rb
@@ -116,7 +116,20 @@ FactoryGirl.define do
     end
   end
 
-  factory :symphony_page_with_user_error, class: Hash do
+  factory :symphony_page_with_blocked_user, class: Hash do
+    req_type 'PAGE'
+    confirm_email 'jlathrop@stanford.edu'
+    usererr_code 'U003'
+    requested_items []
+
+    initialize_with do
+      attributes.map do |k, h|
+        [k.to_s, h]
+      end.to_h
+    end
+  end
+
+  factory :symphony_page_with_expired_user, class: Hash do
     req_type 'PAGE'
     confirm_email 'jlathrop@stanford.edu'
     usererr_code 'U004'

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
         expect(page.symphony_response.req_type).to eq 'PAGE'
       end
 
+      it 'calls send_approval_status! on the request object' do
+        expect_any_instance_of(page.class).to receive(:send_approval_status!)
+        subject.perform(page.id)
+      end
+
       it 'notifies Honeybadger when the request is not found' do
         expect_any_instance_of(Honeybadger).to receive(:notify).once.with(
           'Attempted to call Symphony for Request with ID -1, but no such Request was found.'

--- a/spec/mailers/approval_status_mailer_spec.rb
+++ b/spec/mailers/approval_status_mailer_spec.rb
@@ -1,0 +1,199 @@
+require 'rails_helper'
+
+describe ApprovalStatusMailer do
+  describe '#request_approval_status' do
+    let(:user) { build(:non_webauth_user) }
+    let(:request) { create(:page, user: user) }
+    let(:mail) { ApprovalStatusMailer.request_approval_status(request) }
+
+    describe 'to' do
+      it 'is the user email address' do
+        expect(mail.to).to eq ['jstanford@stanford.edu']
+      end
+    end
+
+    describe 'from' do
+      describe 'default' do
+        it 'is the configured default' do
+          expect(mail.from).to eq ['greencirc@stanford.edu']
+        end
+      end
+
+      describe 'destination specific' do
+        let(:request) { create(:scan, user: user) }
+        it 'is the configured from address for the origin' do
+          expect(mail.from).to eq ['scan-and-deliver@stanford.edu']
+        end
+      end
+
+      describe 'origin specific' do
+        let(:request) { create(:mediated_page, user: user) }
+        it 'is the configured from address for the origin' do
+          expect(mail.from).to eq ['specialcollections@stanford.edu']
+        end
+      end
+
+      describe 'location specific' do
+        let(:request) { create(:page_mp_mediated_page, user: user) }
+        it 'is the configured from address for the origin' do
+          expect(mail.from).to eq ['brannerlibrary@stanford.edu']
+        end
+      end
+    end
+
+    describe 'subject' do
+      describe 'success' do
+        it '"request has been processed"' do
+          expect(mail.subject).to eq "Your request has been processed (\"#{request.item_title}\")"
+        end
+      end
+      describe 'failure' do
+        before do
+          allow(request.symphony_response).to receive(:success?).and_return false
+        end
+        it '"Attention needed ... request could not be processed"' do
+          fail_mail = ApprovalStatusMailer.request_approval_status(request)
+          expect(fail_mail.subject).to eq "Attention needed: Your request could not be processed (\"#{request.item_title}\")"
+        end
+      end
+      describe 'user blocked' do
+        let(:blocked_request) { create(:page_with_holdings, barcodes: ['3610512345678'], user: user) }
+        let(:blocked_mail) { ApprovalStatusMailer.request_approval_status(blocked_request) }
+        before do
+          stub_symphony_response(build(:symphony_page_with_blocked_user))
+        end
+        it '"Attention needed ... request could not be processed"' do
+          expect(blocked_mail.subject).to eq "Attention needed: Your request could not be processed (\"#{blocked_request.item_title}\")"
+        end
+      end
+    end
+
+    describe 'body' do
+      before do
+        allow(request.symphony_response).to receive(:success?).and_return true
+      end
+      let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], ad_hoc_items: ['ZZZ 123'], user: user) }
+      let(:body) { mail.body.to_s }
+      it 'has the date' do
+        expect(body).to match(/On #{request.created_at.strftime('%A, %b %-d %Y')}, you requested:/)
+      end
+
+      it 'has the title' do
+        expect(body).to include(request.item_title)
+      end
+
+      it 'has items processed' do
+        expect(body).to include('ABC 123')
+      end
+
+      it 'has ad hoc items' do
+        expect(body).to include('ZZZ 123')
+      end
+
+      describe 'success' do
+        it 'has items processed line' do
+          expect(body).to include('The items listed below have been processed:')
+        end
+
+        it 'has a not needed after date if present' do
+          my_request = create(:page, needed_date: '2066-06-06', user: user)
+          mailer = ApprovalStatusMailer.request_approval_status(my_request)
+          h = my_request.class.human_attribute_name(:needed_date)
+          expect(mailer.body.to_s).to include "#{h}: #{I18n.l my_request.needed_date, format: :long}"
+        end
+
+        it 'has a link to the status page' do
+          expect(body).to match(%r{Any further updates will be posted on the status page at .*\/pages\/#{request.id}\/status\?token})
+        end
+
+        it 'does not have scan suggestion' do
+          expect(body).not_to include 'Even though your status is blocked, you are eligible for Scan to PDF.'
+        end
+
+        context 'with a webauth user' do
+          let(:user) { build(:webauth_user) }
+
+          it 'has a link to myaccount' do
+            expect(body).to include 'You can also see the status at http://library.stanford.edu/myaccount'
+          end
+        end
+      end
+
+      describe 'failure' do
+        before do
+          allow(request.symphony_response).to receive(:success?).and_return false
+          request = create(:page_with_holdings, barcodes: ['3610512345678'], user: user)
+          fail_mail = ApprovalStatusMailer.request_approval_status(request)
+          @fail_body = fail_mail.body.to_s
+        end
+        it 'has item status line' do
+          expect(@fail_body).to include('There were problems with one or more of the items listed below:')
+        end
+
+        it 'has what can you do now section' do
+          expect(@fail_body).to include 'What can you do now?'
+          expect(@fail_body).to include 'Request assistance by replying to this email, or'
+        end
+
+        describe 'user not blocked' do
+          it 'has searchworks link' do
+            sw_url = "https://searchworks.stanford.edu/view/#{request.id}"
+            expect(@fail_body).to include "try your request again, at #{sw_url}"
+          end
+          it 'does not have scan suggestion' do
+            expect(@fail_body).not_to include 'Even though your status is blocked, you are eligible for Scan to PDF.'
+          end
+        end
+
+        describe 'user blocked' do
+          let(:blocked_request) { create(:page_with_holdings, barcodes: ['3610512345678'], user: user) }
+          let(:blocked_mail) { ApprovalStatusMailer.request_approval_status(blocked_request) }
+          let(:blocked_body) { blocked_mail.body.to_s }
+          before do
+            stub_symphony_response(build(:symphony_page_with_blocked_user))
+          end
+          it 'has item header line' do
+            expect(blocked_body).to include('Items:')
+          end
+          it 'has item status line' do
+            expect(blocked_body).to include('Your request could not be processed because your user privileges are blocked.')
+          end
+          it 'has myaccount link' do
+            line = 'check MyAccount (http://library.stanford.edu/myaccount) for more information.'
+            expect(blocked_body).to include line
+          end
+          it 'has scan suggestion' do
+            expect(blocked_body).to include 'Just need a chapter or article?'
+            expect(blocked_body).to include 'Even though your status is blocked, you are eligible for Scan to PDF.'
+            expect(blocked_body).to include 'You can request a single article or chapter, up to 50 pages.'
+            expect(blocked_body).to include "https://searchworks.stanford.edu/view/#{blocked_request.item_id}"
+          end
+        end
+        describe 'user expired' do
+          let(:expired_request) { create(:page_with_holdings, barcodes: ['3610512345678'], user: user) }
+          let(:expired_mail) { ApprovalStatusMailer.request_approval_status(expired_request) }
+          let(:expired_body) { expired_mail.body.to_s }
+          before do
+            stub_symphony_response(build(:symphony_page_with_expired_user))
+          end
+          it 'has item status line' do
+            expect(expired_body).to include('Your request could not be processed because your user privileges have expired.')
+          end
+        end
+      end
+    end
+
+    describe 'contact info' do
+      let(:body) { mail.body.to_s }
+      describe 'default' do
+        let(:request) { create(:page_with_holdings, user: user) }
+        it 'includes the configured contact information' do
+          expect(body).to include('Questions about your request?')
+          expect(body).to include('Contact:')
+          expect(body).to match(/\(\d{3}\) \d{3}-\d{4}/)
+          expect(body).to include('greencirc@stanford.edu')
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/approval_status_mailer_spec.rb
+++ b/spec/mailers/approval_status_mailer_spec.rb
@@ -82,8 +82,8 @@ describe ApprovalStatusMailer do
         expect(body).to include(request.item_title)
       end
 
-      it 'has items processed' do
-        expect(body).to include('ABC 123')
+      it 'includes the text provided by the RequestApprovalStatus text representation' do
+        expect(body).to include('Pending.')
       end
 
       it 'has ad hoc items' do

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -45,13 +45,13 @@ describe ConfirmationMailer do
       describe 'for Scan requests' do
         let(:request) { create(:scan_with_holdings, user: user) }
         it 'is custom' do
-          expect(mail.subject).to eq "Scan to PDF requested (#{request.item_title})"
+          expect(mail.subject).to eq "Scan to PDF requested (\"#{request.item_title}\")"
         end
       end
 
       describe 'for other requests' do
         it 'is the default' do
-          expect(mail.subject).to eq "Item(s) requested (#{request.item_title})"
+          expect(mail.subject).to eq "Item(s) requested (\"#{request.item_title}\")"
         end
       end
     end

--- a/spec/mailers/previews/approval_status_mailer_preview.rb
+++ b/spec/mailers/previews/approval_status_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/approval_status_mailer
+class ApprovalStatusMailerPreview < ActionMailer::Preview
+  def approval_status
+    ApprovalStatusMailer.request_approval_status(Request.last)
+  end
+end

--- a/spec/models/request_approval_status_spec.rb
+++ b/spec/models/request_approval_status_spec.rb
@@ -80,7 +80,7 @@ describe RequestApprovalStatus do
     let(:request) { create(:request_with_holdings) }
     let(:html) { Capybara.string(subject.to_html) }
     before do
-      stub_symphony_response(build(:symphony_page_with_user_error))
+      stub_symphony_response(build(:symphony_page_with_expired_user))
     end
 
     it 'returns a status message indicating the user error' do
@@ -88,7 +88,7 @@ describe RequestApprovalStatus do
       expect(html).to have_link('Check MyAccount for details.')
     end
 
-    it 'returns a default message if we receive an unkown user error code' do
+    it 'returns a default message if we receive an unknown user error code' do
       expect(request.symphony_response).to receive(:usererr_code).at_least(:once).and_return('unknown-code')
       expect(html).to have_css('dd', text: 'We were unable to process your request because of a system error.')
       expect(html).to have_css('dd', text: 'Please try again, or contact greencirc@stanford.edu for more assistance.')

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -508,22 +508,12 @@ describe Request do
   end
 
   describe 'send_confirmation!' do
-    describe 'for library id users' do
-      it 'does not send a confirmation email' do
-        subject.user = create(:library_id_user)
-        expect(
-          -> { subject.send_confirmation! }
-        ).to_not change { ConfirmationMailer.deliveries.count }
-      end
-    end
-
-    describe 'for everybody else' do
-      let(:subject) { create(:page, user: create(:webauth_user)) }
-      it 'sends a confirmation email' do
-        expect(
-          -> { subject.send_confirmation! }
-        ).to change { ConfirmationMailer.deliveries.count }.by(1)
-      end
+    let(:subject) { create(:page, user: create(:webauth_user)) }
+    it 'returns true (other classes can implement confirmation if they want it)' do
+      expect(
+        -> { subject.send_confirmation! }
+      ).not_to change { ConfirmationMailer.deliveries.count }
+      expect(subject.send_confirmation!).to be true
     end
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -517,6 +517,26 @@ describe Request do
     end
   end
 
+  describe 'send_approval_status!' do
+    describe 'for library id users' do
+      let(:subject) { create(:page, user: create(:library_id_user)) }
+      it 'does not send an approval status email' do
+        expect(
+          -> { subject.send_approval_status! }
+        ).to_not change { ApprovalStatusMailer.deliveries.count }
+      end
+    end
+
+    describe 'for everybody else' do
+      let(:subject) { create(:page, user: create(:webauth_user)) }
+      it 'sends an approval status email' do
+        expect(
+          -> { subject.send_approval_status! }
+        ).to change { ApprovalStatusMailer.deliveries.count }.by(1)
+      end
+    end
+  end
+
   describe '#check_remote_ip?' do
     it 'mediated pages (that are not Hopkins)' do
       expect(create(:mediated_page).check_remote_ip?).to be true

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -16,4 +16,34 @@ describe HoldRecall do
   it 'should have the properly assigned Rails STI attribute value' do
     expect(subject.type).to eq 'HoldRecall'
   end
+
+  describe 'send_confirmation!' do
+    let(:subject) { create(:hold_recall, user: create(:webauth_user)) }
+    it 'returns true' do
+      expect(
+        -> { subject.send_confirmation! }
+      ).not_to change { ConfirmationMailer.deliveries.count }
+      expect(subject.send_confirmation!).to be true
+    end
+  end
+
+  describe 'send_approval_status!' do
+    describe 'for library id users' do
+      let(:subject) { create(:hold_recall, user: create(:library_id_user)) }
+      it 'does not send an approval status email' do
+        expect(
+          -> { subject.send_approval_status! }
+        ).to_not change { ApprovalStatusMailer.deliveries.count }
+      end
+    end
+
+    describe 'for everybody else' do
+      let(:subject) { create(:hold_recall, user: create(:webauth_user)) }
+      it 'sends an approval status email' do
+        expect(
+          -> { subject.send_approval_status! }
+        ).to change { ApprovalStatusMailer.deliveries.count }.by(1)
+      end
+    end
+  end
 end

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -186,6 +186,37 @@ describe MediatedPage do
     end
   end
 
+  describe '#send_confirmation!' do
+    describe 'for library id users' do
+      let!(:subject) { create(:mediated_page) }
+      it 'does not send a confirmation email' do
+        subject.user = create(:library_id_user)
+        expect(
+          -> { subject.send_confirmation! }
+        ).to_not change { ConfirmationMailer.deliveries.count }
+      end
+    end
+
+    describe 'for everybody else' do
+      let!(:subject) { create(:mediated_page) }
+      it 'sends a confirmation email' do
+        expect(
+          -> { subject.send_confirmation! }
+        ).to change { ConfirmationMailer.deliveries.count }.by(1)
+      end
+    end
+  end
+
+  describe 'send_approval_status!' do
+    let!(:subject) { create(:mediated_page) }
+    it 'returns true' do
+      expect(
+        -> { subject.send_approval_status! }
+      ).not_to change { ApprovalStatusMailer.deliveries.count }
+      expect(subject.send_approval_status!).to be true
+    end
+  end
+
   describe '#mediator_notification_email_address' do
     it 'fetches email addresses for origin libraires' do
       subject.origin = 'SPEC-COLL'

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -35,4 +35,34 @@ describe Page do
   it 'should have the properly assigned Rails STI attribute value' do
     expect(subject.type).to eq 'Page'
   end
+
+  describe 'send_confirmation!' do
+    let(:subject) { create(:page, user: create(:webauth_user)) }
+    it 'returns true' do
+      expect(
+        -> { subject.send_confirmation! }
+      ).not_to change { ConfirmationMailer.deliveries.count }
+      expect(subject.send_confirmation!).to be true
+    end
+  end
+
+  describe 'send_approval_status!' do
+    describe 'for library id users' do
+      let(:subject) { create(:page, user: create(:library_id_user)) }
+      it 'does not send an approval status email' do
+        expect(
+          -> { subject.send_approval_status! }
+        ).to_not change { ApprovalStatusMailer.deliveries.count }
+      end
+    end
+
+    describe 'for everybody else' do
+      let(:subject) { create(:page, user: create(:webauth_user)) }
+      it 'sends an approval status email' do
+        expect(
+          -> { subject.send_approval_status! }
+        ).to change { ApprovalStatusMailer.deliveries.count }.by(1)
+      end
+    end
+  end
 end

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -46,4 +46,13 @@ describe Scan do
       subject.submit!
     end
   end
+
+  describe 'send_confirmation!' do
+    let(:subject) { create(:scan, user: create(:webauth_user)) }
+    it 'sends a confirmation email' do
+      expect(
+        -> { subject.send_confirmation! }
+      ).to change { ConfirmationMailer.deliveries.count }.by(1)
+    end
+  end
 end

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -48,32 +48,32 @@ describe Scan do
   end
 
   describe 'send_confirmation!' do
+    let(:subject) { create(:scan, user: create(:webauth_user)) }
+    it 'returns true' do
+      expect(
+        -> { subject.send_confirmation! }
+      ).not_to change { ConfirmationMailer.deliveries.count }
+      expect(subject.send_confirmation!).to be true
+    end
+  end
+
+  describe 'send_approval_status!' do
     describe 'for library id users' do
       let(:subject) { create(:scan, user: create(:library_id_user)) }
-      it 'does not send a confirmation email' do
+      it 'does not send an approval status email' do
         expect(
-          -> { subject.send_confirmation! }
-        ).to_not change { ConfirmationMailer.deliveries.count }
+          -> { subject.send_approval_status! }
+        ).to_not change { ApprovalStatusMailer.deliveries.count }
       end
     end
 
     describe 'for everybody else' do
       let(:subject) { create(:scan, user: create(:webauth_user)) }
-      it 'sends a confirmation email' do
+      it 'sends an approval status email' do
         expect(
-          -> { subject.send_confirmation! }
-        ).to change { ConfirmationMailer.deliveries.count }.by(1)
+          -> { subject.send_approval_status! }
+        ).to change { ApprovalStatusMailer.deliveries.count }.by(1)
       end
-    end
-  end
-
-  describe 'send_approval_status!' do
-    let(:subject) { create(:scan, user: create(:webauth_user)) }
-    it 'returns true' do
-      expect(
-        -> { subject.send_approval_status! }
-      ).not_to change { ApprovalStatusMailer.deliveries.count }
-      expect(subject.send_approval_status!).to be true
     end
   end
 end

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -48,11 +48,32 @@ describe Scan do
   end
 
   describe 'send_confirmation!' do
+    describe 'for library id users' do
+      let(:subject) { create(:scan, user: create(:library_id_user)) }
+      it 'does not send a confirmation email' do
+        expect(
+          -> { subject.send_confirmation! }
+        ).to_not change { ConfirmationMailer.deliveries.count }
+      end
+    end
+
+    describe 'for everybody else' do
+      let(:subject) { create(:scan, user: create(:webauth_user)) }
+      it 'sends a confirmation email' do
+        expect(
+          -> { subject.send_confirmation! }
+        ).to change { ConfirmationMailer.deliveries.count }.by(1)
+      end
+    end
+  end
+
+  describe 'send_approval_status!' do
     let(:subject) { create(:scan, user: create(:webauth_user)) }
-    it 'sends a confirmation email' do
+    it 'returns true' do
       expect(
-        -> { subject.send_confirmation! }
-      ).to change { ConfirmationMailer.deliveries.count }.by(1)
+        -> { subject.send_approval_status! }
+      ).not_to change { ApprovalStatusMailer.deliveries.count }
+      expect(subject.send_approval_status!).to be true
     end
   end
 end

--- a/spec/views/scans/success.html.erb_spec.rb
+++ b/spec/views/scans/success.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'scans/success.html.erb' do
+  let(:user) { create(:webauth_user) }
+  let(:request) { create(:scan, user: user) }
+
+  before do
+    allow(view).to receive_messages(current_request: request)
+    allow(view).to receive_messages(current_user: user)
+    stub_template 'scans/_searchworks_item_information.html.erb' => ''
+  end
+
+  describe 'symphony contacted' do
+    it 'has completion text and icon for completed requests' do
+      render
+      expect(rendered).to have_css('.sul-i-check-2')
+      expect(rendered).to have_css('h1', text: /Request complete/)
+    end
+
+    it 'omits the user contact info if the symphony response failed to indicate success' do
+      render
+      expect(rendered).not_to have_css('dl.user-contact-information span.requested-by')
+    end
+  end
+
+  describe 'successful symphony response' do
+    let(:symphony_response) { build(:symphony_scan_success) }
+    let(:request) { create(:scan, user: user, symphony_response_data: symphony_response) }
+
+    it 'has correctly styled user email address and explanation text' do
+      help_block_text = "(We've sent a copy of this request to your email.)"
+
+      render
+      expect(rendered).to have_css('dl.user-contact-information span.requested-by', text: user.to_email_string)
+      expect(rendered).to have_css('dl.user-contact-information p.help-block', text: help_block_text)
+    end
+  end
+end

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'shared/_request_status_information.html.erb' do
+  let(:user) { create(:webauth_user) }
+  let(:request) { create(:scan, user: user) }
+
+  before do
+    allow(view).to receive_messages(current_request: request)
+  end
+
+  describe 'display request destination' do
+    context 'when there is no delivery destination' do
+      it "doesn't display the 'Deliver to' field" do
+        render
+        expect(rendered).to_not have_content('Will be delivered to')
+      end
+    end
+
+    context 'when there is a delivery destination' do
+      let(:request) { create(:page_mp_mediated_page, user: user) }
+      it "displays the 'Deliver to' field" do
+        render
+        expect(rendered).to have_content('Will be delivered to')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For pages and hold/recalls, we will send an email to the user about their request after the asynchronous call to symphony returns. (For scans and mediated pages, we will stick with the existing mailer as the information (scans need a user's authenticated browser to redirect thru illiad; mediated pages need the approval process to work as is-- the user request for a mediated page doesn't hit symphony)

warning:  shameless green!

Per ticket #586, also tweaks the existing synchronous confirmation mailer slightly

connects to #586