### PR TITLE
Changes for Media Microtext as a pageable library

### DIFF
--- a/app/helpers/pickup_libraries_helper.rb
+++ b/app/helpers/pickup_libraries_helper.rb
@@ -24,15 +24,20 @@ module PickupLibrariesHelper
       pickup_libraries_array(form, pickup_libraries),
       {
         label: label_for_pickup_libraries_dropdown(pickup_libraries),
-        selected: form.object.destination || default_pickup_library
+        selected: form.object.destination || default_pickup_library(form.object.origin)
       },
       aria: { controls: 'scheduler-text' },
       data: { 'paging-schedule-updater' => 'true', 'text-selector' => "[data-text-object='#{form.object.object_id}']" }
     )
   end
 
-  def default_pickup_library
-    SULRequests::Application.config.default_pickup_library
+  def default_pickup_library(origin)
+    pickup_library_for_origin(origin) || SULRequests::Application.config.default_pickup_library
+  end
+
+  def pickup_library_for_origin(origin)
+    return unless SULRequests::Application.config.self_in_library_list_is_selected.include?(origin)
+    origin
   end
 
   def single_library_markup(form, library)

--- a/app/helpers/pickup_libraries_helper.rb
+++ b/app/helpers/pickup_libraries_helper.rb
@@ -21,7 +21,7 @@ module PickupLibrariesHelper
     return unless pickup_libraries.keys.length > 1
     form.select(
       :destination,
-      pickup_libraries_array(pickup_libraries),
+      pickup_libraries_array(form, pickup_libraries),
       {
         label: label_for_pickup_libraries_dropdown(pickup_libraries),
         selected: form.object.destination || default_pickup_library
@@ -49,9 +49,16 @@ module PickupLibrariesHelper
     HTML
   end
 
-  def pickup_libraries_array(pickup_libraries)
-    pickup_libraries.map do |k, v|
+  def pickup_libraries_array(form, pickup_libraries)
+    libraries = pickup_libraries.merge(additional_pickup_libraries(form)).sort
+    libraries.map do |k, v|
       [v, k]
     end
+  end
+
+  def additional_pickup_libraries(form)
+    origin = form.object.origin
+    return {} unless SULRequests::Application.config.include_self_in_library_list.include?(origin)
+    SULRequests::Application.config.libraries.select { |k, _| k == origin }
   end
 end

--- a/app/models/library_location.rb
+++ b/app/models/library_location.rb
@@ -74,7 +74,12 @@ class LibraryLocation
   def pickup_libraries_for(collection)
     all_libraries.select do |k, _|
       collection.include?(k)
-    end
+    end.merge(additional_pickup_libraries)
+  end
+
+  def additional_pickup_libraries
+    return {} unless SULRequests::Application.config.include_self_in_library_list.include?(@library)
+    all_libraries.select { |k, _| k == @library }
   end
 
   def library_specific_pickup_libraries

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -2,6 +2,7 @@
 #  Request class for making simple page requests
 ###
 class Page < Request
+  REQUESTALBE_BY_SUNET_OR_LIBRARY_ONLY = ['MEDIA-MTXT'].freeze
   validate :page_validator
   validates :destination, presence: true
   validate :destination_is_a_pickup_library
@@ -13,7 +14,13 @@ class Page < Request
   end
 
   def requestable_by_all?
+    return false if REQUESTALBE_BY_SUNET_OR_LIBRARY_ONLY.include?(origin)
     true
+  end
+
+  def requestable_with_library_id?
+    return true if REQUESTALBE_BY_SUNET_OR_LIBRARY_ONLY.include?(origin)
+    super
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,8 @@ module SULRequests
 
     config.default_pickup_library = 'GREEN'
 
+    config.include_self_in_library_list = ['MEDIA-MTXT']
+
     config.pickup_libraries = [
       'ART',
       'BIOLOGY',
@@ -88,7 +90,6 @@ module SULRequests
       'ARS' => ['ARS'],
       'HV-ARCHIVE' => ['HV-ARCHIVE'],
       'LAW' => ['LAW'],
-      'MEDIA-MTXT' => ['MEDIA-MTXT'],
       'RUMSEYMAP' => ['RUMSEYMAP'],
       'SPEC-COLL' => ['SPEC-COLL']
     }

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,7 @@ module SULRequests
     config.default_pickup_library = 'GREEN'
 
     config.include_self_in_library_list = ['MEDIA-MTXT']
+    config.self_in_library_list_is_selected = ['MEDIA-MTXT']
 
     config.pickup_libraries = [
       'ART',

--- a/config/initializers/paging_schedule.rb
+++ b/config/initializers/paging_schedule.rb
@@ -131,4 +131,57 @@ PagingSchedule.configure do
     will_arrive after: '1:00pm'
     business_days_later 2
   end
+
+  # Media Microtext
+  when_paging from: 'MEDIA-MTXT', to: 'MEDIA-MTXT', before: '10:00am' do
+    will_arrive after: '11:00am'
+    business_days_later 0
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'MEDIA-MTXT', before: '2:00pm' do
+    will_arrive after: '3:00pm'
+    business_days_later 0
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'MEDIA-MTXT', before: '5:00pm' do
+    will_arrive after: '6:00pm'
+    business_days_later 0
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'MEDIA-MTXT', after: '5:00pm' do
+    will_arrive after: '11:00am'
+    business_days_later 1
+  end
+
+  when_paging from: 'MEDIA-MTXT', to: 'GREEN', before: '10:00am' do
+    will_arrive after: '11:00am'
+    business_days_later 0
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'GREEN', before: '2:00pm' do
+    will_arrive after: '3:00pm'
+    business_days_later 0
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'GREEN', before: '6:30pm' do
+    will_arrive after: '7:30pm'
+    business_days_later 0
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'GREEN', after: '6:30pm' do
+    will_arrive after: '11:00am'
+    business_days_later 1
+  end
+
+  when_paging from: 'MEDIA-MTXT', to: 'HOPKINS', before: '10:00am' do
+    will_arrive after: '1:00pm'
+    business_days_later 1
+  end
+  when_paging from: 'MEDIA-MTXT', to: 'HOPKINS', after: '10:00am' do
+    will_arrive after: '1:00pm'
+    business_days_later 2
+  end
+
+  when_paging from: 'MEDIA-MTXT', to: :anywhere, before: '3:00pm' do
+    will_arrive after: '12:00pm'
+    business_days_later 1
+  end
+  when_paging from: 'MEDIA-MTXT', to: :anywhere, after: '3:00pm' do
+    will_arrive after: '12:00pm'
+    business_days_later 2
+  end
 end

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -19,4 +19,24 @@ describe 'Pickup Libraries Dropdown' do
       expect(page).to have_css('.form-group .input-like-text', text: 'Archive of Recorded Sound')
     end
   end
+
+  describe 'libraries that should include themself in the pickup list' do
+    context 'a standard library' do
+      it 'does not include the configured library in the drop down' do
+        visit new_request_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
+
+        expect(page).to have_css('#request_destination option', count: 14)
+        expect(page).not_to have_css('option', text: 'Media Microtext')
+      end
+    end
+
+    context 'libraries that are configured' do
+      it 'appear in the drop down' do
+        visit new_request_path(item_id: '1234', origin: 'MEDIA-MTXT', origin_location: 'MM-STACKS')
+
+        expect(page).to have_css('#request_destination option', count: 15)
+        expect(page).to have_css('option', text: 'Media Microtext')
+      end
+    end
+  end
 end

--- a/spec/models/library_location_spec.rb
+++ b/spec/models/library_location_spec.rb
@@ -45,6 +45,12 @@ describe LibraryLocation do
       request.origin_location = 'PAGE-MU'
       expect(LibraryLocation.new(request).pickup_libraries).to eq('MUSIC' => 'Music Library')
     end
+
+    it 'should return pickup libraries that include itself (when configured)' do
+      request.origin = 'MEDIA-MTXT'
+      request.origin_location = 'MM-STACKS'
+      expect(LibraryLocation.new(request).pickup_libraries.keys).to include('MEDIA-MTXT')
+    end
   end
   describe '#library_name_by_code' do
     it 'should return the configured library\'s name' do

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -26,10 +26,20 @@ describe Page do
   end
 
   describe 'requestable' do
-    it { is_expected.to be_requestable_by_all }
-    it { is_expected.to be_requestable_with_library_id }
-    it { is_expected.not_to be_requestable_with_sunet_only }
-    it { is_expected.to be_requires_additional_user_validation }
+    context 'Media Microtext' do
+      before { subject.origin = 'MEDIA-MTXT' }
+      it { is_expected.not_to be_requestable_by_all }
+      it { is_expected.to be_requestable_with_library_id }
+      it { is_expected.not_to be_requestable_with_sunet_only }
+      it { is_expected.not_to be_requires_additional_user_validation }
+    end
+
+    context 'other libraries' do
+      it { is_expected.to be_requestable_by_all }
+      it { is_expected.to be_requestable_with_library_id }
+      it { is_expected.not_to be_requestable_with_sunet_only }
+      it { is_expected.to be_requires_additional_user_validation }
+    end
   end
 
   it 'should have the properly assigned Rails STI attribute value' do


### PR DESCRIPTION
_**[WIP]** Until we get this and the SW PR vetted_

Closes #538 (in conjunction with sul-dlss/SearchWorks#1294)

`/requests/new?item_id=11744802&origin=MEDIA-MTXT&origin_location=MM-STACKS`
## Pickup list
_Note: This includes Media Microtext where no other pickup library lists will._
<img width="512" alt="media-pickup-list" src="https://cloud.githubusercontent.com/assets/96776/20782905/f9443d0a-b744-11e6-9d17-0f85b5d4bb3f.png">

## Login options
<img width="498" alt="media-login-options" src="https://cloud.githubusercontent.com/assets/96776/20782906/f944ef70-b744-11e6-8f91-e327ac69cab8.png">

## Paging Schedule
<img width="593" alt="media-mtxt-paging-schedule" src="https://cloud.githubusercontent.com/assets/96776/20813970/a016fb18-b7cc-11e6-9c7d-7462acc050b8.png">
