### PR TITLE
fix display problems for success and status pages for scans (#679)

### DIFF
--- a/app/assets/stylesheets/modules/success.scss
+++ b/app/assets/stylesheets/modules/success.scss
@@ -8,6 +8,13 @@
   .requested-by {
     font-size: 1.6em;
   }
+
+  .user-contact-information {
+    .requested-by {
+      color: $alert-red;
+      font-weight: 300;
+    }
+  }
 }
 
 .approval-error {

--- a/app/views/scans/success.html.erb
+++ b/app/views/scans/success.html.erb
@@ -1,9 +1,13 @@
 <div class='<%= dialog_column_class %> success-page'>
+  <h1 id='dialogTitle'>
+    <span class="sul-i-check-2" aria-hidden="true"></span> Request complete
+  </h1>
+
   <%= render 'searchworks_item_information' %>
   <%= render 'shared/request_status_information' %>
 
   <% if current_request.symphony_response.success? %>
-    <dl class='dl-horizontal dl-invert'>
+    <dl class='dl-horizontal dl-invert user-contact-information'>
       <dt class='sr-only'><%= current_request.class.human_attribute_name :user %></dt>
       <% unless current_request.user.library_id_user? %>
         <dd>
@@ -14,16 +18,16 @@
       <% if current_request.proxy? %>
         <dd>
           <p>Shared with your proxy group</p>
-          <p class='help-block'><%= t('.email_notification.proxy') %></p>
+          <p class='help-block'><%= t('requests.success.synchronous_email_notification.proxy') %></p>
         </dd>
       <% elsif current_user.sponsor? %>
         <dd>
           <p>Individual Request</p>
-          <p class='help-block'><%= t('.email_notification.default') %></p>
+          <p class='help-block'><%= t('requests.success.synchronous_email_notification.default') %></p>
         </dd>
       <% elsif current_request.notification_email_address.present? %>
         <dd>
-          <p class='help-block'><%= t('.email_notification.default') %></p>
+          <p class='help-block'><%= t('requests.success.synchronous_email_notification.default') %></p>
         </dd>
       <% end %>
     </dl>

--- a/app/views/shared/_request_status_information.html.erb
+++ b/app/views/shared/_request_status_information.html.erb
@@ -13,12 +13,13 @@
     <% end %>
   <% end %>
 
-  <% if current_request.destination.present? %>
+  <% destination_name = LibraryLocation.library_name_by_code(current_request.destination) %>
+  <% if destination_name.present? %>
     <dt>
       <%= label_for_pickup_libraries_dropdown(current_request.library_location.pickup_libraries) %>
     </dt>
     <dd>
-      <%= LibraryLocation.library_name_by_code(current_request.destination) %>
+      <%= destination_name %>
     </dd>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,9 @@ en:
       email_notification:
         proxy: "We'll send an email to you and to the designated notification address when processing is complete."
         default: "We'll send you an email when processing is complete."
+      synchronous_email_notification:
+        proxy: "(We've sent a copy of this request to your email and to the designated notification address.)"
+        default: "(We've sent a copy of this request to your email.)"
   status_text:
     paged: Paged
     hold: Item is on-site - hold for patron

--- a/spec/factories/symphony_api_response_json.rb
+++ b/spec/factories/symphony_api_response_json.rb
@@ -1,4 +1,22 @@
 FactoryGirl.define do
+  factory :symphony_scan_success, class: Hash do
+    req_type 'SCAN'
+    confirm_email 'jlathrop@stanford.edu'
+    requested_items [
+      {
+        'barcode' => '36105212920537',
+        'msgcode' => 'S001',
+        'text' => 'Scan submitted'
+      }
+    ]
+
+    initialize_with do
+      attributes.map do |k, h|
+        [k.to_s, h]
+      end.to_h
+    end
+  end
+
   factory :symphony_scan_with_multiple_items, class: Hash do
     req_type 'SCAN'
     confirm_email 'jlathrop@stanford.edu'

--- a/spec/views/scans/success.html.erb_spec.rb
+++ b/spec/views/scans/success.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'scans/success.html.erb' do
+  let(:user) { create(:webauth_user) }
+  let(:request) { create(:scan, user: user) }
+
+  before do
+    allow(view).to receive_messages(current_request: request)
+    allow(view).to receive_messages(current_user: user)
+    stub_template 'scans/_searchworks_item_information.html.erb' => ''
+  end
+
+  describe 'symphony contacted' do
+    it 'has completion text and icon for completed requests' do
+      render
+      expect(rendered).to have_css('.sul-i-check-2')
+      expect(rendered).to have_css('h1', text: /Request complete/)
+    end
+
+    it 'omits the user contact info if the symphony response failed to indicate success' do
+      render
+      expect(rendered).not_to have_css('dl.user-contact-information span.requested-by')
+    end
+  end
+
+  describe 'successful symphony response' do
+    let(:symphony_response) { build(:symphony_scan_success) }
+    let(:request) { create(:scan, user: user, symphony_response_data: symphony_response) }
+
+    it 'has correctly styled user email address and explanation text' do
+      help_block_text = "(We've sent a copy of this request to your email.)"
+
+      render
+      expect(rendered).to have_css('dl.user-contact-information span.requested-by', text: user.to_email_string)
+      expect(rendered).to have_css('dl.user-contact-information p.help-block', text: help_block_text)
+    end
+  end
+end

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'shared/_request_status_information.html.erb' do
+  let(:user) { create(:webauth_user) }
+  let(:request) { create(:scan, user: user) }
+
+  before do
+    allow(view).to receive_messages(current_request: request)
+  end
+
+  describe 'display request destination' do
+    context 'when there is no delivery destination' do
+      it "doesn't display the 'Deliver to' field" do
+        render
+        expect(rendered).to_not have_content('Will be delivered to')
+      end
+    end
+
+    context 'when there is a delivery destination' do
+      let(:request) { create(:page_mp_mediated_page, user: user) }
+      it "displays the 'Deliver to' field" do
+        render
+        expect(rendered).to have_content('Will be delivered to')
+      end
+    end
+  end
+end


### PR DESCRIPTION
* success.scss: styling for user contact info
* success.html.erb: header indicating that the request has been completed, add user-contact-information class to style email address, fix content keys to be absolute instead of relative to path
* _request_status_information.html.erb: only display request destination when there's a real destination that has a user-facing name.
* en.yml: new content for synchronous request email notifications
* symphony_api_response_json.rb: fixture for successful single item scan request
* spec/views/scans/success.html.erb_spec.rb: tests for scan request success view
* spec/views/shared/_request_status_information.html.erb_spec.rb: tests for request status partial

![screen shot 2016-12-01 at 12 19 36 pm](https://cloud.githubusercontent.com/assets/7741604/20810906/84e3c44a-b7c0-11e6-9d00-b8ca0d09b206.png)
![screen shot 2016-12-01 at 12 19 49 pm](https://cloud.githubusercontent.com/assets/7741604/20810910/878785a6-b7c0-11e6-8461-479c0d3949a9.png)

note:  the screenshots don't display the email address styling fix, though it's there.

closes #679