### PR TITLE
[WIP] Address overwriting request status during item approval

### DIFF
--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -12,9 +12,10 @@ class SubmitSymphonyRequestJob < ActiveJob::Base
     Sidekiq::Logging.logger.info("Started SubmitSymphonyRequestJob for request #{request_id}")
     response = Command.new(request, options).execute!
 
-    Sidekiq::Logging.logger.debug("Symphony response string: #{response}")
-    request.merge_symphony_response_data(response.with_indifferent_access)
-    request.save
+    request.with_lock do
+      request.merge_symphony_response_data(response.with_indifferent_access)
+      request.save
+    end
     request.send_approval_status!
     Sidekiq::Logging.logger.info("Completed SubmitSymphonyRequestJob for request #{request_id}")
   end

--- a/app/models/searchworks_item.rb
+++ b/app/models/searchworks_item.rb
@@ -3,6 +3,7 @@
 #  The API URI is configured using rails_config: Settings.searchworks_api
 ###
 class SearchworksItem
+  include ActiveSupport::Benchmarkable
   attr_reader :request, :live_lookup
   def initialize(request, live_lookup = true)
     @request = request
@@ -40,10 +41,16 @@ class SearchworksItem
 
   def response
     @response ||= begin
-      Faraday.get(url)
+      benchmark "GET #{url}" do
+        Faraday.get(url)
+      end
     rescue Faraday::Error::ConnectionFailed
       NullResponse.new
     end
+  end
+
+  def logger
+    Rails.logger
   end
 
   def json

--- a/spec/models/item_status_spec.rb
+++ b/spec/models/item_status_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 def update_symphony_data_and_save(request, symphony_data)
   r = Request.find(request.id)
   r.symphony_response_data = symphony_data
-  r.save!
+  r.save
 end
 
 describe ItemStatus do
@@ -22,7 +22,7 @@ describe ItemStatus do
     end
 
     it 'is updated when the item is approved' do
-      expect(request).to receive(:save!)
+      expect(request).to receive(:save)
       subject.approve!('jstanford')
       expect(subject.send(:status_object)['approved']).to be true
       expect(subject.send(:status_object)['approver']).to eq 'jstanford'
@@ -32,7 +32,7 @@ describe ItemStatus do
 
   describe '#approve!' do
     it 'persists the status to the request' do
-      expect(request).to receive(:save!)
+      expect(request).to receive(:save)
       subject.approve!('jstanford')
 
       status = request.request_status_data[barcode]
@@ -43,7 +43,7 @@ describe ItemStatus do
     end
 
     it 'triggers a request to symphony when an item is approved' do
-      expect(request).to receive(:save!)
+      expect(request).to receive(:save)
       expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, barcodes: [barcode])
       subject.approve!('jstanford')
     end
@@ -87,7 +87,7 @@ describe ItemStatus do
       let(:request) { create(:request_with_holdings) }
       it 'does not persist any changes if the symphony response is not successful' do
         stub_symphony_response(build(:symphony_request_with_all_errored_items))
-        expect(request).not_to receive(:save!)
+        expect(request).not_to receive(:save)
         expect(subject.approve!('jstanford')).to be nil
       end
     end


### PR DESCRIPTION
Potentially addresses #681 

We have initially come up with two potential solutions for this problem:

1. This is the simplest (and most likely least performant) solution which is to lock the row when updating the item approval and symphony request status.  Since the row is being locked for update, it does cause the record to no be able to be update asynchronously (and if something were to run very long could cause lock timeout errors).

1. The other (read: correct) approach would be to refactor the serialized data structors that hold the symphony response and the item approval status into their own active record classes.  The affect that this will have will be that instead of needing to lock the request row in the database for updating, we'll instead be simply adding new rows to another table (thus not requiring any locking and being able to be completely asynchronous).

Approach 1 is what this PR does (and appears to work as expected with a few requests in stage).  Approach 2 will be more performant, and is clearly the correct way to structure this kind of information for clarity and performance.

Let's chat about this before we merge it in.