### PR TITLE
Prevent autocomplete on request form inputs

### DIFF
--- a/app/views/requests/_hidden_form_fields.html.erb
+++ b/app/views/requests/_hidden_form_fields.html.erb
@@ -1,4 +1,4 @@
-<%= f.hidden_field :item_id %>
+<%= f.hidden_field :item_id  %>
 <%= f.hidden_field :origin %>
 <%= f.hidden_field :origin_location %>
 <%= hidden_field_tag(:modal, params[:modal]) if params[:modal] %>

--- a/app/views/requests/_no_sunet_form.html.erb
+++ b/app/views/requests/_no_sunet_form.html.erb
@@ -8,7 +8,8 @@
             <%= uf.text_field_without_bootstrap(
                   :library_id,
                   class: 'form-control',
-                  data: { behavior: 'single-user-field' }
+                  data: { behavior: 'single-user-field' },
+                  autocomplete: 'off'
                 )
             %>
           </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'capybara/poltergeist'
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 30
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Closes #705 / [searchworks#1318](https://github.com/sul-dlss/SearchWorks/issues/1318) 

Prevents autocompletion in the following request input fields:

- request[user_attributes][library_id]
- request[item_id]
- request[origin]
- request[origin_location]
- request[needed_date]