### PR TITLE
Open request status link in parent window

### DIFF
--- a/app/views/requests/success.html.erb
+++ b/app/views/requests/success.html.erb
@@ -17,7 +17,7 @@
         (This may take a few minutes.)
       </p>
     <% end %>
-    <p>You can <%= link_to('check the status of your request', status_page_url_for_request(current_request)) %> at any time.</p>
+    <p>You can <%= link_to('check the status of your request', status_page_url_for_request(current_request), target: "_parent") %> at any time.</p>
   </div>
 
   <%= render 'searchworks_item_information' %>


### PR DESCRIPTION
Closes #709 

Changes `check the status of your request` link so it opens in the parent window instead of in the modal

## Before

![screen shot 2017-06-13 at 11 13 28 am](https://user-images.githubusercontent.com/5402927/27103613-1a75963a-503e-11e7-8edc-f3a5814b87b5.png)

![screen shot 2017-06-13 at 11 15 26 am](https://user-images.githubusercontent.com/5402927/27103619-1fc1c546-503e-11e7-9653-b3d2ff029cd2.png)


## After

![screen shot 2017-06-13 at 11 16 23 am](https://user-images.githubusercontent.com/5402927/27103630-262a51f0-503e-11e7-990b-b3a6c5127da0.png)
