### PR TITLE
Change request success page message

### DIFF
--- a/app/assets/stylesheets/modules/success.scss
+++ b/app/assets/stylesheets/modules/success.scss
@@ -1,7 +1,12 @@
 .success-page {
-  h1 {
-    .glyphicon-ok {
-      color: $dark-cyan;
+
+  .request-info {
+    color: $gray-base;
+
+    h2 {
+      color: inherit;
+      font-size: 1.6em;
+      margin-top: 0;
     }
   }
 

--- a/app/views/requests/success.html.erb
+++ b/app/views/requests/success.html.erb
@@ -1,20 +1,14 @@
 <div class='<%= dialog_column_class %> success-page'>
-  <h1 id='dialogTitle'>
-    <span class="sul-i-check-2" aria-hidden="true"></span> We've received your request
-  </h1>
-
-  <div class='alert alert-info'>
+  <h1 id='dialogTitle'>We're working on it...</h1>
+  <div class='alert alert-warning request-info'>
+    <h2>Processing your request may take a few minutes.</h2>
     <% if current_request.notification_email_address.present? %>
-      <% if current_request.user.to_email_string.present? %>
-        <span class='requested-by'><%= current_request.user.to_email_string %></span>
-      <% end %>
       <p>
         <% if current_request.proxy? %>
-          <%= t('.email_notification.proxy') %>
+          <%= t('.email_notification.proxy', email: current_request.notification_email_address).html_safe %>
         <% else %>
-          <%= t('.email_notification.default') %>
+          <%= t('.email_notification.default', email: current_request.notification_email_address).html_safe %>
         <% end %>
-        (This may take a few minutes.)
       </p>
     <% end %>
     <p>You can <%= link_to('check the status of your request', status_page_url_for_request(current_request)) %> at any time.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,9 +122,10 @@ en:
       PAGE-MP: 'Request delivery to campus library'
   requests:
     success:
+      
       email_notification:
-        proxy: "We'll send an email to you and to the designated notification address when processing is complete."
-        default: "We'll send you an email when processing is complete."
+        proxy: "We'll send an email to you at <strong>%{email}</strong> and to the designated notification address when processing is complete."
+        default: "We'll send you an email at <strong>%{email}</strong> when processing is complete."
       synchronous_email_notification:
         proxy: "(We've sent a copy of this request to your email and to the designated notification address.)"
         default: "(We've sent a copy of this request to your email.)"

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -103,7 +103,9 @@ describe 'Creating a page request' do
 
       expect(current_url).to eq successful_page_url(Page.last)
       expect_to_be_on_success_page
-      expect(page).to have_content "We'll send you an email when processing is complete."
+      expect(page).to have_content(
+        'We\'ll send you an email at some-webauth-user@stanford.edu when processing is complete.'
+      )
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -110,5 +110,5 @@ def stub_symphony_response(response)
 end
 
 def expect_to_be_on_success_page
-  expect(page).to have_css('h1#dialogTitle', text: /We've received your request/)
+  expect(page).to have_css('h1#dialogTitle', text: /We\'re working on it/)
 end

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -9,10 +9,9 @@ describe 'requests/success.html.erb' do
   end
 
   describe 'symphony success' do
-    it 'has success text and icon for successful requests' do
+    it 'has success text for successful requests' do
       render
-      expect(rendered).to have_css('.sul-i-check-2')
-      expect(rendered).to have_css('h1', text: /We've received your request/)
+      expect(rendered).to have_css('h1#dialogTitle', text: /We're working on it/)
     end
   end
 
@@ -47,14 +46,14 @@ describe 'requests/success.html.erb' do
       let(:user) { create(:webauth_user) }
       it 'gives their stanford-email address' do
         render
-        expect(rendered).to have_css('.requested-by', text: 'some-webauth-user@stanford.edu')
+        expect(rendered).to have_content('some-webauth-user@stanford.edu')
       end
     end
     describe 'for non-webauth useres' do
       let(:user) { create(:non_webauth_user) }
-      it 'gives their name and email (in parens)' do
+      it 'gives their email' do
         render
-        expect(rendered).to have_css('.requested-by', text: 'Jane Stanford (jstanford@stanford.edu)')
+        expect(rendered).to have_content('jstanford@stanford.edu')
       end
     end
   end
@@ -69,7 +68,7 @@ describe 'requests/success.html.erb' do
 
       it 'is displayed as an individual request' do
         render
-        expect(rendered).to include 'We&#39;ll send you an email when processing is complete.'
+        expect(rendered).to include 'We\'ll send you an email'
       end
     end
 
@@ -82,9 +81,9 @@ describe 'requests/success.html.erb' do
 
       it 'is shared with the proxy group' do
         render
-        expect(rendered).to include <<-EOS.strip
-          We&#39;ll send an email to you and to the designated notification address when processing is complete.
-        EOS
+        expect(rendered).to include(
+          'We\'ll send an email to you at <strong>some-address@example.com</strong> and to the designated notification'
+        )
       end
     end
 
@@ -93,8 +92,10 @@ describe 'requests/success.html.erb' do
 
       it 'indicates an email will be sent' do
         render
-        expect(rendered).to include user.to_email_string
-        expect(rendered).to include 'We&#39;ll send you an email when processing is complete.'
+        expect(rendered).to include user.email_address
+        expect(rendered).to include(
+          'We\'ll send you an email at <strong>some-webauth-user@stanford.edu</strong> when processing is complete.'
+        )
       end
     end
 
@@ -103,8 +104,10 @@ describe 'requests/success.html.erb' do
 
       it 'indicates an email will be sent' do
         render
-        expect(rendered).to include user.to_email_string
-        expect(rendered).to include 'We&#39;ll send you an email when processing is complete.'
+        expect(rendered).to include user.email_address
+        expect(rendered).to include(
+          'We\'ll send you an email at <strong>jstanford@stanford.edu</strong> when processing is complete.'
+        )
       end
     end
   end


### PR DESCRIPTION
Closes #711

- Changes text and styles for the request success page
- Subsequent changes to feature tests

## Before
![d9055f26-cd42-48b4-89ff-09c144091c4a](https://user-images.githubusercontent.com/5402927/27109505-3154befc-5058-11e7-922c-4db9b79f754b.png)

## After

### with email

![request_success_email](https://user-images.githubusercontent.com/5402927/27109664-1da640a0-5059-11e7-939a-a2539bc8d430.png)

### without email

![request_success_no_email](https://user-images.githubusercontent.com/5402927/27109688-323bbe6e-5059-11e7-9630-df5621628d19.png)
