### PR TITLE
remove explicit honeybadger_env which is the default

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,8 +44,6 @@ set :linked_dirs, fetch(:linked_dirs, []).push(
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
-set :honeybadger_env, fetch(:stage)
-
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 


### PR DESCRIPTION
honeybadger_env already defaults to the cap stage.

See http://docs.honeybadger.io/ruby/getting-started/tracking-deployments.html

