### PR TITLE
Fix unstable send request button spec

### DIFF
--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -25,17 +25,18 @@ describe 'Send Request Buttons' do
 
       click_button 'Send request'
       expect(current_url).to include '/pages/new?' # checks that the current url is still the new page form
+      within '#new_request' do
+        fill_in 'Library ID', with: '12345'
+        expect(page).not_to have_css('input[value="Send request"].disabled')
 
-      fill_in 'Library ID', with: '12345'
-      expect(page).not_to have_css('input[value="Send request"].disabled')
+        fill_in 'Library ID', with: ''
+        expect(page).to have_css('input[value="Send request"].disabled')
 
-      fill_in 'Library ID', with: ''
-      expect(page).to have_css('input[value="Send request"].disabled')
-
-      fill_in 'Name', with: 'Jane Stanford'
-      expect(page).to have_css('input[value="Send request"].disabled')
-      fill_in 'Email', with: 'jstanford@stanford.edu'
-      expect(page).not_to have_css('input[value="Send request"].disabled')
+        fill_in 'Name', with: 'Jane Stanford'
+        expect(page).to have_css('input[value="Send request"].disabled')
+        fill_in 'Email', with: 'jstanford@stanford.edu'
+        expect(page).not_to have_css('input[value="Send request"].disabled')
+      end
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require 'capybara/poltergeist'
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 30
+Capybara.default_max_wait_time = ENV['TRAVIS'] ? 120 : 10
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Closes #722 

Another attempt at fixing the test / Poltergeist issues that have been failing Travis builds. I've had 3 consecutive successful builds and I want to try cry tears of joy. 😭

**Hypothesis:** after `click_button 'Send request'`, the browser is focused on the first empty required field. When attempting to fill out the next field (`fill_in 'Library ID', with: '12345'`), an error is raised (`TypeError: null is not an object`) because Capybara's context has changed. 

**Fix:** redirect Capybara to a larger context with a `within` statement