### PR TITLE
Fix request button tooltip preventing non-SUNet requests

### DIFF
--- a/app/assets/javascripts/additional_form_validation.js
+++ b/app/assets/javascripts/additional_form_validation.js
@@ -22,8 +22,8 @@ var additionalFormValidation = (function() {
     options: {},
 
     enableButton: function() {
-      this.removeTooltip();
       this.submitButtons().removeClass('disabled');
+      this.submitButtons().removeAttr('disabled');
       this.submitButtons().closest('form').unbind('submit.disabled-button');
     },
 

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe 'Send Request Buttons' do
   before { stub_searchworks_api_json(build(:single_holding)) }
-  describe 'by anonymous user' do
-    it 'should be possible to toggle between login and name-email form', js: true do
+  describe 'by anonymous user', js: true do
+    it 'should be possible to toggle between login and name-email form' do
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
       click_link 'I don\'t have a SUNet ID'
 
@@ -16,7 +16,6 @@ describe 'Send Request Buttons' do
     end
 
     it 'disables the submit button (and adds a tooltip) when additional user validation is needed' do
-      skip('Bootstrap 3 tooltip errors') if ENV['CI']
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
       click_link 'I don\'t have a SUNet ID'
 


### PR DESCRIPTION
Closes #724 

## Behavior
- User attempts to send request with invalid input
- Request button is disabled and tooltip appears
- The tooltip persists after users enter valid input
- Request button is enabled and user can submit request 

## Example
![fixed_tooltip](https://user-images.githubusercontent.com/5402927/27500550-c5ed9bb6-581d-11e7-8d07-1df508dbfd90.gif)
