### PR TITLE
Adds origin_location of scan to illiad_open_url for reference

### DIFF
--- a/app/models/illiad_openurl.rb
+++ b/app/models/illiad_openurl.rb
@@ -14,6 +14,7 @@ class IlliadOpenurl
 
   def item_data
     { 'rft.location': @scan.origin,
+      'rft.reference': @scan.origin_location,
       'rft.call_number': first_holding.try(:callnumber),
       'rft.ill_number': first_holding.try(:barcode),
       'rft.item': first_holding.try(:barcode) }


### PR DESCRIPTION
Fixes #734 

This addition to the IlliadOpenUrl model produces a request url like this:

`https://sulils-test.stanford.edu/st2/illiad.dll?Action=10&Form=30&rft.atitle=Section+Title+for+Scan+12345&rft.au=&rft.call_number=ABC+123&rft.genre=scananddeliver&rft.ill_number=12345678&rft.item=12345678&rft.jtitle=SAL3+Item+Title&rft.location=SAL3&rft.pages=&rft.reference=STACKS&scan_referrer=`

The ILL client will be able to see `rft.reference=STACKS` and correctly route items with specific locations into the necessary queues.