### PR TITLE
Change location we redirect to on logout to the Shibboleth logout page.

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -9,6 +9,6 @@ class AuthenticationController < ApplicationController
 
   def logout
     flash[:notice] = 'You have been successfully logged out.'
-    redirect_to params[:referrer] || :back
+    redirect_to '/Shibboleth.sso/Logout'
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,8 +23,7 @@ set :log_level, :info
 set :linked_files, fetch(:linked_files, []).push(
   'config/database.yml',
   'config/honeybadger.yml',
-  'config/secrets.yml',
-  'public/.htaccess'
+  'config/secrets.yml'
 )
 
 # Default value for linked_dirs is []

--- a/spec/controllers/authentication_controller_spec.rb
+++ b/spec/controllers/authentication_controller_spec.rb
@@ -19,13 +19,9 @@ describe AuthenticationController do
     end
   end
   describe 'logout' do
-    it 'should redirect back to the provided referrer' do
-      get :logout, referrer: '/'
-      expect(response).to redirect_to('/')
-    end
-    it 'should redirect back when there is no provided referrer' do
+    it 'should redirect to the Shibboleth logout page' do
       get :logout
-      expect(response).to redirect_to('https://example.com')
+      expect(response).to redirect_to('/Shibboleth.sso/Logout')
     end
     it 'should have a flash notice message informing the user they logged out' do
       get :logout

--- a/spec/features/authorization_spec.rb
+++ b/spec/features/authorization_spec.rb
@@ -14,12 +14,11 @@ describe 'User Authorization' do
     before do
       stub_current_user(create(:webauth_user))
     end
-    it 'is present in the home page and redirects with message' do
+
+    it 'is present in the home page' do
       visit root_path
-      click_link 'some-webauth-user: Logout'
-      within('.flashes') do
-        expect(page).to have_css('.alert-info', text: 'You have been successfully logged out.')
-      end
+      expect(page).to have_link 'some-webauth-user: Logout'
+      # We don't test clicking on the link because Shibboleth provides the logout page
     end
   end
 end


### PR DESCRIPTION
Also stops symlinking the `.htaccess` file.

