### PR TITLE
Delimit request data with HTML safe line breaks

### DIFF
--- a/app/views/approval_status_mailer/approval_status_for_scan.html.erb
+++ b/app/views/approval_status_mailer/approval_status_for_scan.html.erb
@@ -21,7 +21,9 @@
     <% end %>
 
     <p>
-      <%= @request.data_to_email.join('<br/>') %>
+      <% @request.data_to_email.each do |data| %>
+        <%= data %><br/>
+      <% end %>
     </p>
 
     <p>Request was placed: <%= l(@request.created_at, format: :formal) %></p>

--- a/spec/mailers/approval_status_mailer_spec.rb
+++ b/spec/mailers/approval_status_mailer_spec.rb
@@ -74,11 +74,17 @@ describe ApprovalStatusMailer do
 
     describe '#approval_status_for_scan' do
       let(:mailer_method) { :approval_status_for_scan }
-      let(:request) { create(:scan, user: user) }
+      let(:request) { create(:scan, user: user, page_range: '1-2', section_title: 'Chapter2') }
 
       it 'renders the correct email' do
         expect(mail.body.to_s).to include(
           "We'll email you again when your request is ready for download."
+        )
+      end
+
+      it 'delimits request data with HTML safe line breaks' do
+        expect(mail.body.to_s).not_to include(
+          '&lt;br/&gt;'
         )
       end
     end


### PR DESCRIPTION
Co-Authored-By: Jessie Keck <jkeck@stanford.edu>

Fixes #813
This bug can only be replicated by filling in multiple Scan request fields.

## Before
```
We'll email you again when your request is ready for download.

The following items have been queued for scanning:
Title: Journal des actes du Conseil économique et social

Call number(s):

HC1045 .A1 C654 F 1996:SESSION ORD.2
Estimated delivery: Thursday, Dec 20 2018, after 12:00pm

Page range: test<br/>Title of article or chapter: test with a linebreak<br/>Author(s): test

Request was placed: Tuesday, Dec 18 2018 at 1:33p
```