### PR TITLE
Pass a special NO_BARCODE value so that the hidden field representing…

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -119,6 +119,7 @@ class RequestsController < ApplicationController
   def barcode_array_or_selected_hash
     barcodes = params.dig(:request, :barcodes)
     return barcodes if barcodes.is_a?(Array)
+    return [] if barcodes.keys == ['NO_BARCODE']
 
     barcodes.select { |_, v| v.to_s == '1' }
   end
@@ -149,6 +150,7 @@ class RequestsController < ApplicationController
   def item_selector_checkboxes_or_radios_as_array
     barcodes = params[:request][:barcodes]
     return barcodes if barcodes.is_a?(Array)
+    return [] if barcodes.keys == ['NO_BARCODE']
 
     barcodes.select { |_, checked| checked == '1' }.keys
   end

--- a/app/views/shared/_item_selector.html.erb
+++ b/app/views/shared/_item_selector.html.erb
@@ -10,7 +10,7 @@
           </p>
         </div>
       </div>
-      <%= barcode.hidden_field single_item.barcode, value: 1 %>
+      <%= barcode.hidden_field single_item.barcode.present? ? single_item.barcode : 'NO_BARCODE', value: 1 %>
     <% elsif f.object.all_holdings.many? %>
       <div id='selected-items-filter' data-behavior='item-selector' data-limit-reached-message="<%= t('sul_requests.limit_reached_message', limit: f.object.item_limit) %>">
         <% if f.object.all_holdings.length >= 10 %>

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -136,6 +136,18 @@ describe RequestsController do
         'barcodes' => ['abc']
       )
     end
+
+    it 'handles the special NO_BARCODE value' do
+      expect(subject).to receive(:params).at_least(:once).and_return(
+        ActionController::Parameters.new(
+          request: { 'barcodes': { 'NO_BARCODE' => '1' } }
+        )
+      )
+
+      expect(controller.send(:request_params_without_user_attrs_or_unselected_barcodes).to_unsafe_h).to eq(
+        'barcodes' => []
+      )
+    end
   end
 
   describe 'layout setting' do


### PR DESCRIPTION
… a single item request is not interpreted as an array (e.g. ["1"])

Fixes #829 

¯\\_(ツ)_/¯ it's a simple fix that doesn't go into a ton of refactoring.

@saseestone has tested this in stage and it resolved the issue.