### PR TITLE
Access Services requests more detail about type of request we are "Sorry" about

### DIFF
--- a/app/controllers/sorry_controller.rb
+++ b/app/controllers/sorry_controller.rb
@@ -5,6 +5,7 @@
 class SorryController < ApplicationController
   def unable
     @please_contact = please_contact
+    @request_type = request_type
     render status: :internal_server_error
   end
 
@@ -21,5 +22,9 @@ class SorryController < ApplicationController
   def please_contact
     "Please contact the circulation desk in Green Library at
     #{contact_info[:email]} or #{contact_info[:phone]}."
+  end
+
+  def request_type
+    params.permit(:request_type)[:request_type]
   end
 end

--- a/app/views/sorry/unable.html.erb
+++ b/app/views/sorry/unable.html.erb
@@ -6,7 +6,7 @@
 
 <div>
   <p>
-    We're unable to complete your request right now.
+    We're unable to complete your <%= sanitize @request_type %> request right now.
   </p>
 </div>
 

--- a/spec/controllers/sorry_controller_spec.rb
+++ b/spec/controllers/sorry_controller_spec.rb
@@ -7,5 +7,11 @@ describe SorryController, type: :controller do
       get :unable
       expect(response).to have_http_status(:internal_server_error)
     end
+
+    it 'gets the request type from the parameter' do
+      get :unable, params: { request_type: 'scan' }
+      request_type = assigns(:request_type)
+      expect(request_type).to eq 'scan'
+    end
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -12,10 +12,8 @@ RSpec.configure do |config|
       factory.name =~ /_holdings?$/ || factory.name =~ /_searchworks_item$/ || factory.name =~ /^symphony_/
     end
 
-    begin
-      FactoryBot.lint factories_to_lint unless config.files_to_run.one?
-    ensure
-      DatabaseCleaner.clean
-    end
+    FactoryBot.lint factories_to_lint unless config.files_to_run.one?
+  ensure
+    DatabaseCleaner.clean
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -12,8 +12,11 @@ RSpec.configure do |config|
       factory.name =~ /_holdings?$/ || factory.name =~ /_searchworks_item$/ || factory.name =~ /^symphony_/
     end
 
-    FactoryBot.lint factories_to_lint unless config.files_to_run.one?
-  ensure
-    DatabaseCleaner.clean
+    begin
+      FactoryBot.lint factories_to_lint unless config.files_to_run.one?
+    ensure
+      DatabaseCleaner.clean
+    end
   end
+
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -18,5 +18,4 @@ RSpec.configure do |config|
       DatabaseCleaner.clean
     end
   end
-
 end


### PR DESCRIPTION
Per Sarah Seestone at out Circ/LibSys meeting, they need the user to have more info on the page about the kind of request when they get to the `sorry/unable` page. Currently the page renders:

![screen shot 2019-02-20 at 5 14 35 pm](https://user-images.githubusercontent.com/3093850/53136220-11d09f80-3533-11e9-89eb-4adfdf13e017.png)


This PR allows Sorry controller to accept a param that will display the request type on the rendered page.

AFAIKT Scans are the only type of request that end up calling `sorry/unable` (via ILLiad) so maybe this is a bit overkill, but if we ever use it for other kinds of requests, it might come in handy. The idea is to send the redirect back from ILLiad as `sorry/unable?request_type=scan` if the request fails in ILLiad. Then the page would render:

![screen shot 2019-02-20 at 5 03 45 pm](https://user-images.githubusercontent.com/3093850/53135812-830f5300-3531-11e9-9213-6393c9818d95.png)
