### PR TITLE
Update the contact info and information on the sorry/unable page

### DIFF
--- a/app/controllers/sorry_controller.rb
+++ b/app/controllers/sorry_controller.rb
@@ -15,11 +15,11 @@ class SorryController < ApplicationController
   end
 
   def contact_info
-    contact_info_config['default']
+    contact_info_config['SCAN']
   end
 
   def please_contact
-    "Please contact the circulation desk in Green Library at
+    "Please contact the scan processing team at
     #{contact_info[:email]} or #{contact_info[:phone]}."
   end
 end

--- a/app/views/sorry/unable.html.erb
+++ b/app/views/sorry/unable.html.erb
@@ -6,7 +6,7 @@
 
 <div>
   <p>
-    We're unable to complete your request right now.
+    We're unable to complete your scan request right now.
   </p>
 </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -134,7 +134,7 @@ module SULRequests
 
     config.contact_info = {
       'SCAN' => {
-        phone: '(650) 723-1493',
+        phone: '(650) 723-3278',
         email: 'scan-and-deliver@stanford.edu'
       },
       'HOOVER' => {

--- a/spec/features/sorry_page_spec.rb
+++ b/spec/features/sorry_page_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Viewing sorry page' do
   it 'displays some text' do
     visit sorry_unable_path
-    expect(page).to have_css('p', text: 'greencirc@stanford.edu')
-    expect(page).to have_css('p', text: '(650) 723-1493')
+    expect(page).to have_css('p', text: 'scan-and-deliver@stanford.edu')
+    expect(page).to have_css('p', text: '(650) 723-3278')
   end
 end


### PR DESCRIPTION
The scans processing team should be the contact point for failed scans. Right now the only type of requests that use the sorry/unable page are scans.