### PR TITLE
Remove therubyracer dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'coffee-rails', '~> 4.2', '>= 4.2.1'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 2.7.2'
-# JS Runtime. See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'therubyracer'
 # Common styles for SUL
 gem 'sul_styles', '>= 0.5.0'
 # A gem for simple rails invornment specific config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ GEM
     kaminari-core (1.2.0)
     kaminari_bootstrap_paginator (0.1.0)
       rails
-    libv8 (3.16.14.19)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -287,7 +286,6 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.0)
     redis (4.1.3)
-    ref (2.0.0)
     regexp_parser (1.7.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -370,9 +368,6 @@ GEM
       railties (>= 3.2.5)
     teaspoon-jasmine (2.3.4)
       teaspoon (>= 1.0.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -456,7 +451,6 @@ DEPENDENCIES
   sqlite3
   sul_styles (>= 0.5.0)
   teaspoon-jasmine
-  therubyracer
   turbolinks (~> 5.0)
   uglifier (>= 2.7.2)
   web-console


### PR DESCRIPTION
We have node installed on all of our rails VMs now and that can handle the asset pre-compilation