### PR TITLE
Render the messages partial on the status and success pages.

### DIFF
--- a/app/views/requests/status.html.erb
+++ b/app/views/requests/status.html.erb
@@ -1,5 +1,8 @@
 <% content_for :page_title do %>Request status: <%= current_request.item_title %><% end %>
+
 <div class="<%= dialog_column_class %>">
+  <%= render 'messages' %>
+
   <h1>Status of your request</h1>
   <hr />
   <dl class='dl-horizontal dl-invert'>

--- a/app/views/requests/success.html.erb
+++ b/app/views/requests/success.html.erb
@@ -1,4 +1,6 @@
 <div class='<%= dialog_column_class %> success-page'>
+  <%= render 'messages' %>
+
   <h1 id='dialogTitle'>We're working on it...</h1>
   <div class='alert alert-warning request-info'>
     <h2>Processing your request may take a few minutes.</h2>


### PR DESCRIPTION
Closes #934

## Success Page
<img width="759" alt="success" src="https://user-images.githubusercontent.com/96776/76477320-314a9c80-63c2-11ea-9e30-cdf61a5be75a.png">

## Status Page
<img width="765" alt="status" src="https://user-images.githubusercontent.com/96776/76477381-62c36800-63c2-11ea-8d47-25c1abb1e1b4.png">

@jvine / @saseestone does this look okay (local message content withstanding)?  Also, this will not be present on status/success message fo Scan requests. 
