### PR TITLE
Deal w/ "duplicate heading"  issue

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -25,4 +25,16 @@ module MessagesHelper
                     edit-message
                     glyphicon glyphicon-pencil'
   end
+
+  def link_to_delete_message(message)
+    link_to ' Delete message',
+            message,
+            method: :delete,
+            class: 'btn
+                    btn-sm
+                    btn-default
+                    edit-message
+                    glyphicon
+                    glyphicon-trash'
+  end
 end

--- a/app/views/messages/_messages_for_library.html.erb
+++ b/app/views/messages/_messages_for_library.html.erb
@@ -11,6 +11,7 @@
   <% messages.each do |message| %>
     <h2><%= message.title %></h2>
     <%= link_to_edit_message(message) %>
+    <%= link_to_delete_message(message) %>
 
     <div class="message">
       <% if message.scheduled? %>

--- a/app/views/messages/_messages_for_library.html.erb
+++ b/app/views/messages/_messages_for_library.html.erb
@@ -3,18 +3,14 @@
   <% messages = @messages.select { |m| m.library == library_code && m.request_type == request_type } %>
   <% library = LibraryLocation.library_name_by_code(library_code).to_s %>
 
-  <% if messages.none? %>
+  <div>
     <h2><%= request_type.titleize + " from #{library.presence || 'anywhere'}" %></h2>
     <%= link_to_add_message(library_code, request_type) %>
-  <% end %>
+  </div>
 
   <% messages.each do |message| %>
     <h2><%= message.title %></h2>
-    <% if message.text.length > 0 %>
-      <%= link_to_edit_message(message) %>
-    <% else %>
-      <%= link_to_add_message(library_code, request_type) %>
-    <% end %>
+    <%= link_to_edit_message(message) %>
 
     <div class="message">
       <% if message.scheduled? %>

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -105,6 +105,28 @@ describe 'Viewing all requests' do
     end
   end
 
+  describe 'destroy' do
+    before do
+      create(:message, library: 'SAL3')
+    end
+
+    describe 'by a superadmin user' do
+      before do
+        stub_current_user(create(:superadmin_user))
+      end
+
+      it 'messages can be destroyed' do
+        visit messages_path
+
+        expect(Message.count).to be 1
+        expect(page).to have_css('.text.alert', text: 'MyText')
+        click_link 'Delete message'
+        expect(page).not_to have_css('.text.alert', text: 'MyText')
+        expect(Message.count).to be_zero
+      end
+    end
+  end
+
   describe 'displays on a request page' do
     let(:message) { create(:message) }
 


### PR DESCRIPTION
This is an approach to handling the issue / confusion reported in #932 

## One Message (before)
<img width="785" alt="one-message-after" src="https://user-images.githubusercontent.com/96776/76483130-74f9d200-63d3-11ea-815d-ea445217f995.png">

## One Message (after)
<img width="775" alt="one-message-before" src="https://user-images.githubusercontent.com/96776/76483135-775c2c00-63d3-11ea-95bf-347463b5211d.png">

## Empty Messages (before)
<img width="763" alt="empty-message-before" src="https://user-images.githubusercontent.com/96776/76483153-7f1bd080-63d3-11ea-97c9-17145d775278.png">

## Empty Messages (after)
<img width="681" alt="empty-message-after" src="https://user-images.githubusercontent.com/96776/76483137-77f4c280-63d3-11ea-9d6b-bbda4be43c54.png">

## Another Example 
Trying to avoid this scenario where a user cannot edit or remove these messages (only add more)

<img width="529" alt="cannot-delete" src="https://user-images.githubusercontent.com/96776/76483350-108b4280-63d4-11ea-9364-29405a839d77.png">
