### PR TITLE
Update URL path by removing v1

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -22,7 +22,7 @@ symphony_web_services:
   enabled: false
   # trailing slashes expected unless it's the end of the URI path
   base_url: 'http://example.com/symws/'
-  curr_loc_path: 'v1/catalog/item/barcode/'
+  curr_loc_path: 'catalog/item/barcode/'
 
 background_jobs:
   enabled: false


### PR DESCRIPTION
The `v1` part of the SymWS URL is deprecated and will be removed in the next version of SymWS.