### PR TITLE
Update URL path by removing v1

### DIFF
--- a/spec/models/symphony_curr_loc_request_spec.rb
+++ b/spec/models/symphony_curr_loc_request_spec.rb
@@ -81,7 +81,7 @@ describe SymphonyCurrLocRequest do
   end
 
   it 'BASE_URL is concatenation of web services url and current_loc_path' do
-    expect(SymphonyCurrLocRequest::BASE_URL).to eq 'http://example.com/symws/v1/catalog/item/barcode/'
+    expect(SymphonyCurrLocRequest::BASE_URL).to eq 'http://example.com/symws/catalog/item/barcode/'
   end
 
   it 'the barcode is URL excaped (so we don\'t get invalid URL errors)' do


### PR DESCRIPTION
The `v1` part of the SymWS URL is deprecated and will be removed in the next version of SymWS.