### PR TITLE
Update symphony web services paths by removing deprecated v1

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,7 +46,7 @@ symphony_web_services:
   # trailing slashes expected unless it's the end of the URI path
   base_url: 'http://symphony-endpoint.example.com/'
   # lookup current location of an item by barcode
-  curr_loc_path: 'v1/catalog/item/barcode/'
+  curr_loc_path: 'catalog/item/barcode/'
 
 mailer_host: <%= `echo $HOSTNAME` %>
 searchworks_api: 'https://searchworks.stanford.edu'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -22,7 +22,7 @@ symphony_web_services:
   enabled: false
   # trailing slashes expected unless it's the end of the URI path
   base_url: 'http://example.com/symws/'
-  curr_loc_path: 'v1/catalog/item/barcode/'
+  curr_loc_path: 'catalog/item/barcode/'
 
 background_jobs:
   enabled: false

--- a/spec/models/symphony_curr_loc_request_spec.rb
+++ b/spec/models/symphony_curr_loc_request_spec.rb
@@ -81,7 +81,7 @@ describe SymphonyCurrLocRequest do
   end
 
   it 'BASE_URL is concatenation of web services url and current_loc_path' do
-    expect(SymphonyCurrLocRequest::BASE_URL).to eq 'http://example.com/symws/v1/catalog/item/barcode/'
+    expect(SymphonyCurrLocRequest::BASE_URL).to eq 'http://example.com/symws/catalog/item/barcode/'
   end
 
   it 'the barcode is URL excaped (so we don\'t get invalid URL errors)' do


### PR DESCRIPTION
The `v1` part of the SymWS URL is deprecated and will be removed in the next version of SymWS.

See: https://symphony-webservices-prod.stanford.edu/symws/sdk.html