### PR TITLE
Clear out configs that try to add/select different pickup libraries …

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -65,8 +65,13 @@ module SULRequests
 
     config.default_pickup_library = 'GREEN'
 
-    config.include_self_in_library_list = ['MEDIA-MTXT']
-    config.self_in_library_list_is_selected = ['LAW', 'MEDIA-MTXT']
+    if Rails.env.test?
+      config.include_self_in_library_list = ['MEDIA-MTXT']
+      config.self_in_library_list_is_selected = ['LAW', 'MEDIA-MTXT']
+    else
+      config.include_self_in_library_list = []
+      config.self_in_library_list_is_selected = []
+    end
 
     if Rails.env.test?
       config.pickup_libraries = [


### PR DESCRIPTION
…based on origin library

This is so that Media Microtext does not show up for when requesting from Media Microtext (which was the previous behavior).  Media will open up along with Green in phase 1, but will need to have the material delivered "curb-side" at Green proper.

<img width="541" alt="Screen Shot 2020-05-29 at 12 25 37 PM" src="https://user-images.githubusercontent.com/96776/83297516-92a33000-a1a7-11ea-9883-eaf0a6b815bb.png">
