### PR TITLE
Render some content in emails conditionally

### DIFF
--- a/app/views/approval_status_mailer/approval_status_for_holdrecall.html.erb
+++ b/app/views/approval_status_mailer/approval_status_for_holdrecall.html.erb
@@ -23,7 +23,9 @@
 
     <p>
       Request was placed: <%= l(@request.created_at, format: :formal) %><br/>
-      Request will be canceled if it cannot be fulfilled before: <%= l(@request.needed_date, format: :long) %>
+      <% if @request.needed_date.present? %>
+        Request will be canceled if it cannot be fulfilled before: <%= l(@request.needed_date, format: :long) %>
+      <% end %>
     </p>
 
     <p>

--- a/app/views/approval_status_mailer/approval_status_for_page.html.erb
+++ b/app/views/approval_status_mailer/approval_status_for_page.html.erb
@@ -17,9 +17,11 @@
       <% end %>
     </ul>
 
-    <p>
-      Earliest delivery: <%= @request.estimated_delivery %>
-    </p>
+    <% if @request.estimated_delivery.present? %>
+      <p>
+        Earliest delivery: <%= @request.estimated_delivery %>
+      </p>
+    <% end %>
 
     <p>Request was placed: <%= l(@request.created_at, format: :formal) %></p>
 

--- a/app/views/approval_status_mailer/approval_status_for_u002.html.erb
+++ b/app/views/approval_status_mailer/approval_status_for_u002.html.erb
@@ -20,9 +20,11 @@
       <%= @request.data_to_email.join('<br/>') %>
     </p>
 
-    <p>
-      Try your request again using just your name and email: <%= link_to("#{Settings.searchworks_link}/#{@request.item_id}", "#{Settings.searchworks_link}/#{@request.item_id}") %>
-    </p>
+    <% if @request.requestable_by_all? %>
+      <p>
+        Try your request again using just your name and email: <%= link_to("#{Settings.searchworks_link}/#{@request.item_id}", "#{Settings.searchworks_link}/#{@request.item_id}") %>
+      </p>
+    <% end %>
 
     <p>Request was placed: <%= l(@request.created_at, format: :formal) %></p>
 


### PR DESCRIPTION
This should hopefully help w/ some of the content that we won't want to be in emails as we roll out the re-opening paging service.

* Renders needed_date and estimated_delivery label/value only if present.
* Renders the instructions to retry a request w/ name+email only when that is a valid method of requesting that item.