### PR TITLE
Update how we dynamically re-size the modal to use the body's scroll …

### DIFF
--- a/app/assets/javascripts/postMessage.js
+++ b/app/assets/javascripts/postMessage.js
@@ -6,7 +6,7 @@ var iframePostMessage = (function() {
         if (top != self) {
           setInterval(function(){
             _this.sendMessage({
-              contentHeight: $('html').outerHeight(true),
+              contentHeight: $('body')[0].scrollHeight,
               successPage: $('.success-page').length > 0
             });
           }, 1000);

--- a/app/assets/stylesheets/modules/confirmation-overlay.scss
+++ b/app/assets/stylesheets/modules/confirmation-overlay.scss
@@ -12,14 +12,3 @@
     text-align: center;
   }
 }
-
-.modal-body {
-  // We only want a really tall overlay
-  // (with overflow hidden) when we're
-  // being displayed in a modal. Otherwise
-  // the normal page flow should be fine
-  .confirmation-overlay {
-    min-height: 10000px;
-    overflow: hidden;
-  }
-}


### PR DESCRIPTION
…height instead of the html outer height.

This seems to account for absolutely positioned overlays when present.

We'll want to keep an eye to ensure longer request forms are covered by the overlay (and may end up doing something different like seeing if an overlay is present and sending that element's height to the modal instead of the html's).