### PR TITLE
Add an eligibility overlay for mediated pages

### DIFF
--- a/app/views/mediated_pages/_SPEC-COLL_eligibility_confirmation.html.erb
+++ b/app/views/mediated_pages/_SPEC-COLL_eligibility_confirmation.html.erb
@@ -1,0 +1,26 @@
+<div id="eligibility-confirm-overlay" class='confirmation-overlay'>
+  <div class='modal-body'>
+    <h1>Special Collections access</h1>
+    <p>This item can be viewed only in the Field Reading Room of Green Library.</p>
+
+    <h2 class="h3">Who can visit the Reading Room?</h2>
+    <p>Stanford faculty (including emeriti), graduate students, and post docs are eligible.</p>
+    <p>To maintain social distancing, the Reading Room will admit one researcher per table in 2-hour blocks.</p>
+
+    <h2 class="h3">How does it work?</h2>
+    <ol>
+      <li>Request the item.</li>
+      <li>When it's ready for use, we'll send you an email with instructions to schedule your visit.</li>
+      <li>Follow the required health and safety protocols and Special Collections policies when you arrive for your visit.</li>
+    </ol>
+
+    <p>
+      <i class="sul-i-navigation-next-4"></i> <%= link_to('Use of materials in the Field Room', 'https://library.stanford.edu/spc/use-materials-field-room', target: '_blank') %>
+    </p>
+
+    <div class='overlay-options'>
+      <%= button_tag('Continue', class: 'btn btn-success', data: { behavior: 'close-overlay', 'close-target' => '#eligibility-confirm-overlay' }) %>
+      <%= link_to('Cancel', "#{Settings.searchworks_link}/#{current_request.item_id}", class: 'btn btn-link', data: { behavior: 'close-parent-modal' }) %>
+    </div>
+  </div>
+</div>

--- a/app/views/mediated_pages/_eligibility_confirmation.html.erb
+++ b/app/views/mediated_pages/_eligibility_confirmation.html.erb
@@ -1,0 +1,3 @@
+<% if SULRequests::Application.config.confirm_eligibility_libraries.include?(current_request.origin) %>
+  <%= render "#{current_request.origin}_eligibility_confirmation" %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,8 @@ module SULRequests
 
     config.default_pickup_library = 'GREEN'
 
+    config.confirm_eligibility_libraries = ['SPEC-COLL']
+
     if Rails.env.test?
       config.include_self_in_library_list = ['MEDIA-MTXT']
       config.self_in_library_list_is_selected = ['LAW', 'MEDIA-MTXT']

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,7 +67,7 @@ borrow_direct:
 features:
   confirm_eligibility: true
   estimate_delivery: false
-  remote_ip_check: true
+  remote_ip_check: false
   hold_recall_via_borrow_direct: true
   scan_service: false
   special_spec_note: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -30,4 +30,5 @@ background_jobs:
 features:
   confirm_eligibility: false
   estimate_delivery: true
+  remote_ip_check: true
   scan_service: true

--- a/spec/features/elibility_confirmation_spec.rb
+++ b/spec/features/elibility_confirmation_spec.rb
@@ -20,4 +20,18 @@ describe 'Eligibility Confirmation' do
       expect(page).to have_css('#new_request', visible: true)
     end
   end
+
+  context 'for mediated page requests' do
+    it 'shows an eligibility confiration overlay that can be cleared to reveal the form' do
+      visit new_mediated_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'RARE-BOOKS')
+
+      expect(page).to have_css('#new_request', visible: false)
+      expect(page).to have_css('#eligibility-confirm-overlay', visible: true)
+
+      click_button 'Continue'
+
+      expect(page).to have_css('#eligibility-confirm-overlay', visible: false)
+      expect(page).to have_css('#new_request', visible: true)
+    end
+  end
 end


### PR DESCRIPTION
Closes #971

This is in draft currently until a question around if this should be library specific or not (or if we should just worry about that when we need to re-enable other mediatable locations).

Most pressing might be Rumsey (as it is in Green), but this will also come up for Hopkins, Hoover, and PAGE-MP in SAL3.

<img width="687" alt="Screen Shot 2020-06-01 at 6 37 26 PM" src="https://user-images.githubusercontent.com/96776/83470424-00b15680-a437-11ea-8cfb-66f0957e6caf.png">
