### PR TITLE
Remove the link to the Request status page on the Success page …

### DIFF
--- a/app/views/requests/success.html.erb
+++ b/app/views/requests/success.html.erb
@@ -13,7 +13,6 @@
         <% end %>
       </p>
     <% end %>
-    <p>You can <%= link_to('check the status of your request', status_page_url_for_request(current_request), target: "_parent") %> at any time.</p>
   </div>
 
   <%= render 'searchworks_item_information' %>


### PR DESCRIPTION
…(the user will receive an email w/ this info they need).

Closes #972 