### PR TITLE
Configure requests from BUSINESS to be picked up at BUSINESS only.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -107,6 +107,7 @@ module SULRequests
       }
     else
       config.library_specific_pickup_libraries = {
+        'BUSINESS' => ['BUSINESS'],
         'RUMSEYMAP' => ['SPEC-COLL'],
         'SPEC-COLL' => ['SPEC-COLL']
       }


### PR DESCRIPTION
This can be shipped anytime as it won't be useful until we start generating request links for these materials.