### PR TITLE
Update content to choose between scan or page for re-opening the scan…

### DIFF
--- a/app/assets/stylesheets/modules/scan-or-deliver.scss
+++ b/app/assets/stylesheets/modules/scan-or-deliver.scss
@@ -12,37 +12,8 @@
     text-align: left;
   }
 
-  .separator {
-    text-align: center;
-
-    h2 {
-      background: $sul-request-form-separator-h2-bg;
-      border: 0;
-      display: inline-block;
-      margin: 0 0 0.5em;
-      padding: 0 10px;
-      text-align: center;
-    }
-  }
-
   .scan-to-pdf {
-    border-top: 1px solid $sul-request-form-scan-border-color;
-    margin-top: -1.7em;
     padding-top: 2.5em;
-  }
-
-  .service-description {
-    color: $color-cardinal-red;
-  }
-}
-
-@media only screen and (max-width : 480px) {
-  #scan-or-deliver {
-    .separator {
-      h2 {
-        font-size: 1.7em;
-      }
-    }
   }
 }
 

--- a/app/views/requests/_form_choice.html.erb
+++ b/app/views/requests/_form_choice.html.erb
@@ -1,35 +1,41 @@
 <div id="scan-or-deliver" data-scheduler-lookup-url='<%= paging_schedule_path(origin: current_request.origin) %>'>
   <div class="row">
-    <div class="col-xs-12 col-sm-6 buttons">
-      <%= link_to('<i class="sul-i-truck-1" aria-hidden="true"></i> Deliver to campus library'.html_safe, delegated_new_request_path(current_request), class: 'btn btn-md btn-primary', 'aria-describedby' => 'deliveryDescription') %>
+    <div class="col-xs-12 buttons">
+      <%= link_to('Request & pickup', delegated_new_request_path(current_request), class: 'btn btn-md btn-primary', 'aria-describedby' => 'deliveryDescription') %>
     </div>
-    <div class="col-xs-12 col-sm-6 content">
-      <dl id="deliveryDescription">
-        <dt>Earliest delivery</dt>
-        <dd data-single-library-value='<%= SULRequests::Application.config.default_pickup_library unless current_request.holdings_object.single_checked_out_item? %>'>
-          <span data-scheduler-text='true' aria-live='polite'></span>
-        </dd>
-      </dl>
+    <div id="deliveryDescription" class="col-xs-12 content">
+      <p>Pickup by appointment at selected libraries.</p>
+      <p>Available to faculty (including emeriti), staff, students, post-docs, fellows, and Stanford Visiting Scholars, with a current Stanford ID card.</p>
+      <% if Settings.features.estimate_delivery %>
+        <dl>
+          <dt>Earliest delivery</dt>
+          <dd data-single-library-value='<%= SULRequests::Application.config.default_pickup_library unless current_request.holdings_object.single_checked_out_item? %>'>
+            <span data-scheduler-text='true' aria-live='polite'></span>
+          </dd>
+        </dl>
+      <% else %>
+        <p>No delivery esimate.</p>
+      <% end %>
     </div>
   </div>
-  <div class="separator">
-    <h2>Just need a chapter or article?</h2>
-  </div>
+
   <div class="row scan-to-pdf">
-    <div class="col-xs-12 col-sm-6 buttons">
-      <%= link_to('Scan to PDF<span class="btn-sub-text">requires SUNet login</span>'.html_safe, new_scan_path(current_request, request_params), class: 'btn btn-md btn-default', 'aria-describedby' => 'scanDescription') %>
+    <div class="col-xs-12 buttons">
+      <%= link_to('Scan to PDF', new_scan_path(current_request, request_params), class: 'btn btn-md btn-default', 'aria-describedby' => 'scanDescription') %>
     </div>
-    <div class="col-xs-12 col-sm-6 content">
-      <dl id="scanDescription">
-        <dt>Earliest delivery</dt>
-        <dd data-single-library-value='<%= 'SCAN' unless current_request.holdings_object.single_checked_out_item? %>'>
-          <span data-scheduler-text='true' aria-live='polite'></span>
-        </dd>
-        <dt>Copyright limit</dt>
-        <dd>One article or chapter; maximum 50 pages.</dd>
-        <dt class="service-description">Eligibility</dt>
-        <dd class="service-description">Available to faculty and staff, students, fellows, postdocs, and visiting scholars.</dd>
-      </dl>
+    <div id="scanDescription" class="col-xs-12 content">
+      <p>Limited to one article or chapter; maximum 50 pages.</p>
+      <p>Available to faculty, staff, students, post-docs, fellows and visiting scholars.</p>
+      <% if Settings.features.estimate_delivery %>
+        <dl>
+          <dt>Earliest delivery</dt>
+          <dd data-single-library-value='<%= 'SCAN' unless current_request.holdings_object.single_checked_out_item? %>'>
+            <span data-scheduler-text='true' aria-live='polite'></span>
+          </dd>
+        </dl>
+      <% else %>
+        <p>No delivery esimate.</p>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/requests/_header.html.erb
+++ b/app/views/requests/_header.html.erb
@@ -1,1 +1,1 @@
-<h1 id='dialogTitle'>Request</h1>
+<h1 id='dialogTitle'>Request options</h1>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -2,9 +2,8 @@
   <%= render 'header' %>
   <%= render 'form_flashes' %>
 
-  <%= render 'searchworks_item_information' %>
-
   <% if delegated_request? %>
+    <%= render 'searchworks_item_information' %>
     <%= render 'remote_user_check' if render_remote_user_check? %>
     <%= render 'eligibility_confirmation' if Settings.features.confirm_eligibility %>
     <%= render 'form' %>

--- a/spec/features/modal_layout_spec.rb
+++ b/spec/features/modal_layout_spec.rb
@@ -17,7 +17,7 @@ describe 'Modal Layout' do
 
     expect(page).not_to have_css('#su-wrap')
 
-    click_link 'Deliver to campus library'
+    click_link 'Request & pickup'
 
     expect(page).not_to have_css('#su-wrap')
     expect(current_url).to match(/modal=true/)

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -29,12 +29,11 @@ describe 'Requests Delegation' do
     it 'is given the opportunity to request a scan or delivery' do
       visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
 
-      expect(page).to have_css('h1#dialogTitle', text: 'Request')
-      expect(page).to have_css('h2', text: 'SAL3 Item Title')
+      expect(page).to have_css('h1#dialogTitle', text: 'Request options')
 
       within('#scan-or-deliver') do
-        expect(page).to have_css('a', text: 'Deliver to campus library')
-        expect(page).to have_css('a', text: /Scan to PDF.*requires SUNet login/)
+        expect(page).to have_css('a', text: 'Request & pickup')
+        expect(page).to have_css('a', text: 'Scan to PDF')
       end
     end
   end


### PR DESCRIPTION
… service.

Closes #1026 

This can be shipped now since this form is only visible when scanning is an option (which it will not be until we turn the service back on via feature flag)

## Before
<img width="592" alt="before" src="https://user-images.githubusercontent.com/96776/88604235-ddb4b480-d02b-11ea-903a-bffeea125b72.png">

## After
<img width="582" alt="after" src="https://user-images.githubusercontent.com/96776/88604237-de4d4b00-d02b-11ea-9ac2-bb2e5b747afc.png">
