### PR TITLE
Co-opt the bootstrap info button for buttons to choose between scan …

### DIFF
--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -6,6 +6,7 @@ $grayish-yellow: #d5d5d3;
 $green: #008000;
 $light-grayish-orange: #f0eeea;
 $light-grayish-yellow: #f7f7f4;
+$bright-blue: #006cb8;
 $pure-yellow: #ff0;
 $white: #fff;
 $dark-cyan: #007c5d;
@@ -38,6 +39,11 @@ $sul-unavailable-icon-color: $color-cardinal-red;
 $btn-beige-color: $color-black;
 $btn-beige-bg: $color-beige-30;
 $btn-beige-border: darken($btn-beige-bg, 9.8%);
+
+$btn-blue-color: $white;
+$btn-blue-bg: $bright-blue;
+$btn-blue-border: darken($bright-blue, 9.8%);
+
 $sul-shadow-color: rgba(0, 0, 0, 0.2);
 
 // Item Selector

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -7,6 +7,10 @@ $btn-default-color: $btn-beige-color;
 $btn-default-bg: $btn-beige-bg;
 $btn-default-border: $btn-beige-border;
 
+$btn-info-color: $btn-blue-color;
+$btn-info-bg: $btn-blue-bg;
+$btn-info-border: $btn-blue-border;
+
 $headings-font-weight: 300;
 
 // Sizes

--- a/app/views/requests/_form_choice.html.erb
+++ b/app/views/requests/_form_choice.html.erb
@@ -1,7 +1,7 @@
 <div id="scan-or-deliver" data-scheduler-lookup-url='<%= paging_schedule_path(origin: current_request.origin) %>'>
   <div class="row">
     <div class="col-xs-12 buttons">
-      <%= link_to('Request & pickup', delegated_new_request_path(current_request), class: 'btn btn-md btn-primary', 'aria-describedby' => 'deliveryDescription') %>
+      <%= link_to('Request & pickup', delegated_new_request_path(current_request), class: 'btn btn-md btn-info', 'aria-describedby' => 'deliveryDescription') %>
     </div>
     <div id="deliveryDescription" class="col-xs-12 content">
       <p>Pickup by appointment at selected libraries.</p>
@@ -21,7 +21,7 @@
 
   <div class="row scan-to-pdf">
     <div class="col-xs-12 buttons">
-      <%= link_to('Scan to PDF', new_scan_path(current_request, request_params), class: 'btn btn-md btn-default', 'aria-describedby' => 'scanDescription') %>
+      <%= link_to('Scan to PDF', new_scan_path(current_request, request_params), class: 'btn btn-md btn-info', 'aria-describedby' => 'scanDescription') %>
     </div>
     <div id="scanDescription" class="col-xs-12 content">
       <p>Limited to one article or chapter; maximum 50 pages.</p>


### PR DESCRIPTION
…and page.

Closes #1033 

<img width="597" alt="Screen Shot 2020-08-06 at 9 32 09 AM" src="https://user-images.githubusercontent.com/96776/89557697-12610280-d7c8-11ea-9ebe-d7c5dd7912ba.png">
