### PR TITLE
Add the ability for scannable items to be non-pageable.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Layout/LineLength:
 Metrics/BlockLength:
   Exclude:
     - 'spec/models/request_spec.rb'
+    - 'spec/factories/**/*'
 
 Metrics/ClassLength:
   Max: 120

--- a/app/models/concerns/request_validations.rb
+++ b/app/models/concerns/request_validations.rb
@@ -9,7 +9,10 @@ module RequestValidations
   included do
     validates :item_id, :origin, :origin_location, presence: true
     validates :item_comment, presence: true, if: :item_commentable?
-    validate :requested_holdings_exist, :requested_item_is_not_temporary_access, on: :create
+    validate :requested_holdings_exist,
+             :requested_item_is_not_temporary_access,
+             :requested_item_is_not_scannable_only,
+             on: :create
     validate :needed_date_is_not_in_the_past, on: :create, if: :needed_date
     validate :library_id_exists, on: :create, if: :validate_library_id?
   end
@@ -28,6 +31,15 @@ module RequestValidations
     errors.add(
       :base,
       'This item is available online via Hathi Trust ETAS. The physical copy is not available for Request & pickup.'
+    )
+  end
+
+  def requested_item_is_not_scannable_only
+    return unless library_location.scannable_only?
+
+    errors.add(
+      :base,
+      'This item is for in-library use and not available for Request & pickup.'
     )
   end
 

--- a/app/models/concerns/scannable.rb
+++ b/app/models/concerns/scannable.rb
@@ -15,13 +15,26 @@ module Scannable
     ),
     'SAL3' => %w(BUS-STACKS PAGE-GR STACKS)
   }.freeze
+  SCANNABLE_ONLY_LOCATIONS = {
+    'SAL' => %w(SAL-TEMP UNCAT)
+  }.freeze
+  SCANNABLE_ONLY_ITEM_TYPES = {
+    'SAL' => %w(NONCIRC)
+  }.freeze
 
   def scannable?
     return false unless Settings.features.scan_service
+    return true if scannable_only?
 
     scannable_library? &&
       scannable_location? &&
       includes_scannable_item?
+  end
+
+  def scannable_only?
+    scannable_library? &&
+      scannable_only_location? &&
+      includes_scannable_only_items?
   end
 
   private
@@ -51,5 +64,15 @@ module Scannable
 
   def page_gr_scannable_item_types
     %w(NEWSPAPER NH-INHOUSE).concat(ITEM_TYPES)
+  end
+
+  def scannable_only_location?
+    SCANNABLE_ONLY_LOCATIONS[library]&.include?(location)
+  end
+
+  def includes_scannable_only_items?
+    request.holdings.any? do |item|
+      SCANNABLE_ONLY_ITEM_TYPES[library]&.include?(item.type)
+    end
   end
 end

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -41,6 +41,10 @@ class Scan < Request
     # leave blank so temp access validations are not run for scans
   end
 
+  def requested_item_is_not_scannable_only
+    # leave blank so scannable only validations are not run for scans
+  end
+
   def scannable_validator
     errors.add(:base, 'This item is not scannable') unless scannable?
   end

--- a/app/views/requests/_form_choice.html.erb
+++ b/app/views/requests/_form_choice.html.erb
@@ -1,11 +1,13 @@
 <div id="scan-or-deliver" data-scheduler-lookup-url='<%= paging_schedule_path(origin: current_request.origin) %>'>
   <div class="row">
     <div class="col-xs-12 buttons">
-      <%= link_to('Request & pickup', delegated_new_request_path(current_request), class: "btn btn-md btn-info #{'disabled' if current_request.searchworks_item.temporary_access?}", 'aria-describedby' => 'deliveryDescription') %>
+      <%= link_to('Request & pickup', delegated_new_request_path(current_request), class: "btn btn-md btn-info #{'disabled' if current_request.searchworks_item.temporary_access? || current_request.library_location.scannable_only?}", 'aria-describedby' => 'deliveryDescription') %>
     </div>
     <div id="deliveryDescription" class="col-xs-12 content">
       <% if current_request.searchworks_item.temporary_access? %>
         <p>This item is available online via Hathi Trust ETAS. The physical copy is not available for Request & pickup.</p>
+      <% elsif current_request.library_location.scannable_only? %>
+        <p>This item is for in-library use and not available for Request & pickup.</p>
       <% else %>
         <p>Pickup by appointment at selected libraries.</p>
         <p>Available to faculty (including emeriti), staff, students, post-docs, fellows, and Stanford Visiting Scholars, with a current Stanford ID card.</p>

--- a/spec/factories/searchworks_api_json.rb
+++ b/spec/factories/searchworks_api_json.rb
@@ -112,6 +112,33 @@ FactoryBot.define do
     end
   end
 
+  factory :scannable_only_holdings, class: 'Hash' do
+    title { 'Item Title' }
+
+    format { ['Book'] }
+
+    holdings do
+      [
+        { 'code' => 'SAL',
+          'locations' => [
+            { 'code' => 'SAL-TEMP',
+              'items' => [
+                { 'barcode' => '12345678',
+                  'callnumber' => 'ABC 123',
+                  'type' => 'NONCIRC'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    end
+
+    initialize_with do
+      attributes.transform_keys(&:to_s).to_h
+    end
+  end
+
   factory :sal_newark_holding, class: 'Hash' do
     title { 'Item Title' }
 

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -35,7 +35,7 @@ describe 'Requests Delegation' do
       end
     end
 
-    context 'when an item is avaialble via temporary access', js: true do
+    context 'when an item is avaialble via temporary access' do
       before { stub_searchworks_api_json(build(:temporary_access_holdings)) }
 
       it 'disables the request option' do
@@ -47,6 +47,19 @@ describe 'Requests Delegation' do
           expect(page).to have_css('a.disabled', text: 'Request & pickup')
           expect(page).to have_content('The physical copy is not available for Request & pickup.')
         end
+      end
+    end
+  end
+
+  describe 'scannable only material' do
+    before { stub_searchworks_api_json(build(:scannable_only_holdings)) }
+
+    it 'disables the link to page the item' do
+      visit new_request_path(item_id: '12345', origin: 'SAL', origin_location: 'SAL-TEMP')
+
+      within('#scan-or-deliver') do
+        expect(page).to have_css('a.disabled', text: 'Request & pickup')
+        expect(page).to have_content('This item is for in-library use and not available for Request & pickup.')
       end
     end
   end

--- a/spec/models/concerns/scannable_spec.rb
+++ b/spec/models/concerns/scannable_spec.rb
@@ -91,4 +91,30 @@ describe Scannable do
       end
     end
   end
+
+  describe '#scannable_only?' do
+    it 'is true a scannable only library/location has scannable only items' do
+      subject.library = 'SAL'
+      subject.location = 'SAL-TEMP'
+      subject.request = double('request', holdings: [double(type: 'NONCIRC')])
+
+      expect(subject).to be_scannable_only
+    end
+
+    it 'is false when not scannable only library/location' do
+      subject.library = 'SAL'
+      subject.location = 'STACKS'
+      subject.request = double('request', holdings: [double(type: 'NONCIRC')])
+
+      expect(subject).not_to be_scannable_only
+    end
+
+    it 'is false when a circulating item is in the scannable only library/location' do
+      subject.library = 'SAL'
+      subject.location = 'SAL-TEMP'
+      subject.request = double('request', holdings: [double(type: 'STKS')])
+
+      expect(subject).not_to be_scannable_only
+    end
+  end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -65,6 +65,21 @@ describe Request do
         'The physical copy is not available for Request & pickup.'
       )
     end
+
+    it 'requires that an item is not scannable only' do
+      stub_searchworks_api_json(build(:scannable_only_holdings))
+
+      expect do
+        described_class.create!(
+          item_id: '123456',
+          origin: 'SAL',
+          origin_location: 'SAL-TEMP'
+        )
+      end.to raise_error(
+        ActiveRecord::RecordInvalid,
+        'Validation failed: This item is for in-library use and not available for Request & pickup.'
+      )
+    end
   end
 
   describe 'scopes' do

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -31,6 +31,19 @@ describe Scan do
     end.not_to raise_error
   end
 
+  it 'allows scannabe only materials to be requested for scan' do
+    stub_searchworks_api_json(build(:scannable_only_holdings))
+
+    expect do
+      described_class.create!(
+        item_id: '123456',
+        origin: 'SAL',
+        origin_location: 'SAL-TEMP',
+        section_title: 'Chapter 1'
+      )
+    end.not_to raise_error
+  end
+
   describe 'requestable' do
     it { is_expected.not_to be_requestable_by_all }
     it { is_expected.not_to be_requestable_with_library_id }


### PR DESCRIPTION
Connected to sul-dlss/SearchWorks#2535 (this PR should be shipped before the SearchWorks one)

We aren't putting request links on these items from SearchWorks yet, but I you can get to this in a requests app by `/requests/new?item_id=386132&origin=SAL&origin_location=SAL-TEMP`

<img width="537" alt="Screen Shot 2020-08-21 at 4 26 39 PM" src="https://user-images.githubusercontent.com/96776/90942556-22cdcb80-e3cb-11ea-8896-208d4fb32b8f.png">
