### PR TITLE
Use the library key 'SPEC-DESK' instead of 'SPEC-COLL'

### DIFF
--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -294,7 +294,7 @@ class SubmitSymphonyRequestJob < ApplicationJob
     def generic_request
       {
         fill_by_date: request.needed_date,
-        key: request.destination,
+        key: request.destination == 'SPEC-COLL' ? 'SPEC-DESK' : request.destination,
         recall_status: patron.fee_borrower? ? 'NO' : 'STANDARD',
         patron_barcode: patron_barcode,
         comment: comment,

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -226,6 +226,17 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
         subject.execute!
       end
 
+      context 'for a SPEC-COLL request' do
+        let(:request) { create(:mediated_page) }
+
+        it 'actually sets the pickup library to SPEC-DESK' do
+          allow(subject.user).to receive(:patron).and_return(Patron.new({}))
+          allow(mock_client).to receive(:bib_info).and_return({})
+          expect(mock_client).to receive(:place_hold).with(hash_including(key: 'SPEC-DESK')).and_return({})
+          subject.execute!
+        end
+      end
+
       context 'without barcodes' do
         let(:scan) { create(:scan, user: user) }
 


### PR DESCRIPTION
This "fixes" #1063, although maybe we want to use SPEC-DESK as the pickup library more consistently?