### PR TITLE
Remove old Symphony Web Services Config & Adapter

### DIFF
--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -3,6 +3,8 @@
 ##
 # Rails Job to submit a Scan request to Symphony for processing
 class SubmitSymphonyRequestJob < ApplicationJob
+  class SymphonyWebServiceAdapterError < StandardError; end
+
   queue_as :default
 
   # we pass the ActiveRecord identifier to our job, rather than the ActiveRecord reference.
@@ -215,6 +217,10 @@ class SubmitSymphonyRequestJob < ApplicationJob
           .merge(scan_destinations(barcode))
       end
     end
+  end
+
+  unless Settings.symphony_api.adapter.to_s == 'symws'
+    raise SymphonyWebServiceAdapterError, "#{Settings.symphony_api.adapter} is not a known Symphony Web Services Adapter"
   end
 
   Command = SubmitSymphonyRequestJob::SymWsCommand

--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -37,104 +37,6 @@ class SubmitSymphonyRequestJob < ApplicationJob
     Settings.symphony_api.enabled && Settings.symphony_api.url.present?
   end
 
-  ##
-  # Command to submit a Scan request to Symphony for processing
-  class StoredProcedureCommand
-    include ActiveSupport::Benchmarkable
-
-    attr_reader :request, :options
-
-    delegate :user, to: :request
-
-    def initialize(request, options = {})
-      @request = request
-      @options = options
-    end
-
-    def execute!
-      benchmark "Sending func_request_webservice_new.make_request with #{request_params.inspect}" do
-        response = client.get('func_request_webservice_new.make_request', request_params)
-        JSON.parse(response.body)['request_response'] || {}
-      end
-    end
-
-    def request_params
-      # NOTE:  any changes to params (new ones, key name changes) must be coordinated with
-      # Symphony programmers
-      patron_from_request.merge(items_from_request).merge(
-        req_type: req_type
-      ).reject { |_, v| v.blank? }
-    end
-
-    private
-
-    def req_type
-      case request
-      when Scan
-        'SCAN'
-      when HoldRecall
-        'HOLD'
-      when Page, MediatedPage
-        'PAGE'
-      end
-    end
-
-    # rubocop:disable Metrics/AbcSize
-    def patron_from_request
-      {
-        sunet_id: (user.webauth if user.webauth_user?),
-        library_id: user.library_id,
-        patron_name: (user.name if user.library_id.blank?),
-        patron_email: (user.email_address if user.library_id.blank?),
-        proxy_group: (user.patron&.group&.name if request.proxy?)
-      }
-    end
-
-    def items_from_request
-      {
-        ckey: request.item_id,
-        items: barcodes.join('^') + '^',
-        copy_note: (copy_notes.join('^') + '^' if copy_notes.present?),
-        home_lib: request.origin,
-        item_comments: request.item_comment,
-        req_comment: request.request_comment,
-        requested_date: request.created_at.strftime('%m/%d/%Y'),
-        pickup_lib: (request.destination unless request.is_a? Scan),
-        not_needed_after: request.needed_date&.strftime('%m/%d/%Y')
-      }
-    end
-    # rubocop:enable Metrics/AbcSize
-
-    def barcodes
-      items = options[:barcodes]
-      items ||= request.barcodes.reject(&:blank?)
-      items = ['NO_ITEMS'] if items.blank?
-      items
-    end
-
-    def copy_notes
-      return if request.public_notes.blank?
-
-      result = []
-      request.public_notes.each do |barcode, note|
-        result << "#{barcode}:#{note}" if barcodes.include? barcode
-      end
-      result
-    end
-
-    def client
-      @client ||= Faraday.new(url: base_url)
-    end
-
-    def base_url
-      Settings.symphony_api.url
-    end
-
-    def logger
-      Rails.logger
-    end
-  end
-
   # Submit requests using Symws
   class SymWsCommand
     attr_reader :request, :options
@@ -315,13 +217,5 @@ class SubmitSymphonyRequestJob < ApplicationJob
     end
   end
 
-  # rubocop:disable Naming/ConstantName
-  Command = begin
-    if Settings.symphony_api.adapter == 'symws'
-      SubmitSymphonyRequestJob::SymWsCommand
-    else
-      SubmitSymphonyRequestJob::StoredProcedureCommand
-    end
-  end
-  # rubocop:enable Naming/ConstantName
+  Command = SubmitSymphonyRequestJob::SymWsCommand
 end

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -164,7 +164,7 @@ class SymphonyClient
   end
 
   def base_url
-    Settings.symws.url || Settings.symphony_web_services&.base_url
+    Settings.symws.url
   end
 
   def default_headers

--- a/app/views/requests/status.html.erb
+++ b/app/views/requests/status.html.erb
@@ -27,8 +27,6 @@
       <pre class="well"><%= JSON.pretty_generate(current_request.borrow_direct_response_data || {}) %></pre>
     <% else %>
       <h4>Symphony Request</h4>
-      <h5>Stored Procedures Request</h5>
-      <pre class="well"><%= JSON.pretty_generate(current_request.symphony_request(SubmitSymphonyRequestJob::StoredProcedureCommand).request_params) %></pre>
       <h5>Web Services Request</h5>
       <pre class="well"><%= JSON.pretty_generate(current_request.symphony_request(SubmitSymphonyRequestJob::SymWsCommand).request_params) %></pre>
       <h4>Symphony Response</h4>

--- a/app/views/scans/status.html.erb
+++ b/app/views/scans/status.html.erb
@@ -16,8 +16,6 @@
   <% if can? :debug, current_request %>
     <hr />
     <h4>Symphony Request</h4>
-    <h5>Stored Procedures Request</h5>
-    <pre class="well"><%= JSON.pretty_generate(current_request.symphony_request(SubmitSymphonyRequestJob::StoredProcedureCommand).request_params) %></pre>
     <h5>Web Services Request</h5>
     <pre class="well"><%= JSON.pretty_generate(current_request.symphony_request(SubmitSymphonyRequestJob::SymWsCommand).request_params) %></pre>
     <h4>Symphony Response</h4>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,7 +82,7 @@ token_encrypt:
 symphony_api:
   enabled: true
   url: ''
-  adapter: :stored_procedures
+  adapter: :symws
 
 symphony:
   override: PASSWORD

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -3,16 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe SubmitSymphonyRequestJob, type: :job do
-  let(:test_client) do
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.get('/func_request_webservice_new.make_request') do |_|
-          [200, {}, { request_response: { req_type: 'PAGE' } }.to_json]
-        end
-      end
-    end
-  end
-
   before do
     allow(Settings.symphony_api).to receive(:url).and_return('http://illiad.ill.example.com/')
   end
@@ -20,25 +10,23 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
   context 'with a stubbed HTTP client' do
     before do
       Sidekiq.logger.level = Logger::UNKNOWN
-      allow_any_instance_of(SubmitSymphonyRequestJob::Command).to receive(:client).and_return(test_client)
     end
 
     let(:user) { build(:non_webauth_user) }
-    let(:page) { create(:page_with_holdings, user: user) }
+    let(:request) { create(:page_with_holdings, user: user) }
 
     describe '#perform' do
-      it 'merges response information with the existing request data' do
-        expect_any_instance_of(page.class).to receive(:merge_symphony_response_data).with(
-          hash_including(req_type: 'PAGE')
-        ).and_call_original
-        subject.perform(page.id)
-        page.reload
-        expect(page.symphony_response.req_type).to eq 'PAGE'
+      let(:mock_client) { instance_double(SymphonyClient) }
+
+      before do
+        allow(mock_client).to receive(:place_hold).and_return({})
+        allow(mock_client).to receive(:bib_info).and_return({})
+        allow_any_instance_of(SubmitSymphonyRequestJob::Command).to receive(:symphony_client).and_return(mock_client)
       end
 
       it 'calls send_approval_status! on the request object' do
-        expect_any_instance_of(page.class).to receive(:send_approval_status!)
-        subject.perform(page.id)
+        expect_any_instance_of(request.class).to receive(:send_approval_status!)
+        subject.perform(request.id)
       end
 
       it 'notifies Honeybadger when the request is not found' do
@@ -46,151 +34,6 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
           'Attempted to call Symphony for Request with ID -1, but no such Request was found.'
         )
         subject.perform(-1)
-      end
-    end
-  end
-
-  describe SubmitSymphonyRequestJob::Command do
-    subject { described_class.new(request) }
-
-    let(:user) { build(:non_webauth_user) }
-    let(:request) { scan }
-    let(:scan) { create(:scan_with_holdings, user: user) }
-    let(:hold) { create(:hold_recall_with_holdings, user: user) }
-    let(:page) { create(:page_with_holdings, user: user) }
-
-    describe '#client' do
-      it 'provides an HTTP client for the given base URL' do
-        expect(subject.send(:client).url_prefix.to_s).to eq Settings.symphony_api.url
-      end
-    end
-
-    describe '#request_params' do
-      before do
-        allow(subject).to receive(:client).and_return(test_client)
-      end
-
-      context 'with a scan' do
-        let(:request) { scan }
-
-        it 'req_type is the request type' do
-          expect(subject.request_params).to include req_type: 'SCAN'
-        end
-      end
-
-      context 'with a hold' do
-        let(:request) { hold }
-
-        it 'req_type is the request type' do
-          expect(subject.request_params).to include req_type: 'HOLD'
-        end
-      end
-
-      context 'with a page' do
-        let(:request) { page }
-
-        it 'req_type is the request type' do
-          expect(subject.request_params).to include req_type: 'PAGE'
-        end
-      end
-
-      context 'with item comment' do
-        let(:request) { page.tap { |x| x.update(item_comment: 'Item Comment') } }
-
-        it 'item_comments is the item comments' do
-          expect(subject.request_params).to include item_comments: 'Item Comment'
-        end
-      end
-
-      context 'with request comment' do
-        let(:request) { page.tap { |x| x.update(request_comment: 'Request Comment') } }
-
-        it 'req_comment is the request comment' do
-          expect(subject.request_params).to include req_comment: 'Request Comment'
-        end
-      end
-
-      context 'with public (copy) notes' do
-        let(:request) do
-          page.tap do |x|
-            x.update(public_notes: { '111' => 'note for 111', '222' => 'note for 222' })
-            x.update(barcodes: %w(111 222))
-          end
-        end
-
-        it 'copy_note is the public_notes reformatted' do
-          expect(subject.request_params).to include(copy_note: '111:note for 111^222:note for 222^')
-        end
-      end
-
-      it 'contains the request information' do
-        expect(subject.request_params).to include ckey: '12345', home_lib: 'SAL3'
-        expect(subject.request_params).to include requested_date: %r(\d{2}/\d{2}/\d{4}$)
-      end
-
-      context 'with a non-webauth user' do
-        it 'contains the patron information' do
-          expect(subject.request_params).to include patron_name: user.name, patron_email: user.email
-        end
-      end
-
-      context 'with a library id user' do
-        let(:user) { build(:non_webauth_user, library_id: '12345') }
-
-        it 'contains the patron information' do
-          expect(subject.request_params).to include library_id: '12345'
-        end
-      end
-
-      context 'with a webauth user' do
-        let(:user) { build(:webauth_user, library_id: '98765') }
-
-        it 'contains the patron information' do
-          expect(subject.request_params).to include library_id: user.library_id, sunet_id: user.webauth
-        end
-      end
-
-      context 'without requested items' do
-        it 'items is NO_ITEMS placeholder' do
-          expect(subject.request_params).to include items: 'NO_ITEMS^'
-        end
-
-        it 'items is NO_ITEMS placeholder when the only barcode is blank' do
-          request.barcodes = ['']
-          expect(subject.request_params).to include items: 'NO_ITEMS^'
-        end
-      end
-
-      context 'with requested barcodes' do
-        let(:scan) { create(:scan_with_holdings_barcodes, user: user) }
-
-        it 'items is the item barcodes separated by ^' do
-          expect(subject.request_params).to include items: '12345678^87654321^'
-        end
-      end
-    end
-
-    describe '#copy_notes' do
-      it 'returns Array of Strings of format barcode:note' do
-        subject.request.update(public_notes: { '111' => 'note for 111', '222' => 'note for 222' })
-        subject.request.update(barcodes: %w(111 222))
-        expect(subject.send(:copy_notes)).to eq ['111:note for 111', '222:note for 222']
-      end
-
-      it 'only includes notes when they are for an included barcode' do
-        subject.request.update(public_notes: { '111' => 'note for 111', '222' => 'note for 222' })
-        subject.request.update(barcodes: ['111'])
-        expect(subject.send(:copy_notes)).to eq ['111:note for 111']
-      end
-
-      it 'is empty Array if no barcodes' do
-        subject.request.update(public_notes: { '111' => 'note for 111', '222' => 'note for 222' })
-        expect(subject.send(:copy_notes)).to eq []
-      end
-
-      it 'is nil if no public_notes' do
-        subject.request.update(barcodes: %w(111 222))
-        expect(subject.send(:copy_notes)).to be_nil
       end
     end
   end


### PR DESCRIPTION
Closes #1080

This goes a bit further and removes the old adapter as well, if we want this hanging around for awhile we can, but it seems like we're unlikely to roll back to the old adapter at this point.  Keeping the adapter seam because it could be useful down the road and seems to have little overhead. 