### PR TITLE
Handle symphony errors for CDL checkout + checkin with background job

### DIFF
--- a/app/jobs/submit_cdl_checkin_job.rb
+++ b/app/jobs/submit_cdl_checkin_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+##
+# Rails Job to submit a CDL checkin to Symphony for processing
+class SubmitCdlCheckinJob < ApplicationJob
+  queue_as :default
+  retry_on Exceptions::SymphonyError
+
+  def perform(user, hold_record_key)
+    CdlCheckout.new(nil, user).process_checkin(hold_record_key)
+  end
+end

--- a/app/jobs/submit_cdl_checkout_job.rb
+++ b/app/jobs/submit_cdl_checkout_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+##
+# Rails Job to submit a CDL checkout request to Symphony for processing
+class SubmitCdlCheckoutJob < ApplicationJob
+  queue_as :default
+  retry_on Exceptions::SymphonyError
+
+  def perform(user, druid, barcode)
+    response = CdlCheckout.new(druid, user).process_checkout(barcode)
+
+    # the checkout request gave us a token, but our user is long-gone. Send them a next-up email
+    # as if they were actually on the waitlist (they have no way to know they weren't, so :shrug:)
+    CdlWaitlistMailer.youre_up(response[:hold], response[:hold].circ_record).deliver_later if response[:token]
+  end
+end

--- a/app/services/cdl_checkout.rb
+++ b/app/services/cdl_checkout.rb
@@ -10,6 +10,9 @@ class CdlCheckout
   # @return [Hash] token payload
   def self.checkout(barcode, druid, user)
     new(druid, user).process_checkout(barcode)
+  rescue Exceptions::SymphonyError
+    SubmitCdlCheckoutJob.perform_later(user, druid, barcode)
+    {}
   end
 
   # @param hold_record_key [String] Symphony hold record key
@@ -17,6 +20,8 @@ class CdlCheckout
   # @return [Boolean]
   def self.checkin(hold_record_key, user)
     new(nil, user).process_checkin(hold_record_key)
+  rescue Exceptions::SymphonyError
+    SubmitCdlCheckinJob.perform_later(user, hold_record_key)
   end
 
   # @param barcode [String] item barcode

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,5 +46,5 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :test
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ module DisallowAPIs
   end
 end
 
+ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
When adding user-friendly errors in #1100, it seemed like we could handle checkout + in asynchronously.

- checkin: the users done with the thing and we're expiring their token... they don't care about the symphony processing
- checkout: this is probably no worse than ending up on the waitlist (although we can't know how deep the queue is.. but they'll be able to find out from mylibrary if/when the request succeeds, 🤷‍♂️ )
- (renewal: not appropriate; it's time-sensitive and requires us to update the cookie etc)


Part of ##1098?