### PR TITLE
Adds validation that page_range can only be up to 30 characrters

### DIFF
--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -6,6 +6,7 @@
 class Scan < Request
   validate :scannable_validator
   validates :section_title, presence: true
+  validates :page_range, length: { maximum: 30 }
 
   def requestable_with_sunet_only?
     true

--- a/app/views/scans/_form_additional.html.erb
+++ b/app/views/scans/_form_additional.html.erb
@@ -2,7 +2,7 @@
   <%= f.label :page_range, class: "#{label_column_class} control-label" %>
   <div class='<%= content_column_class %>'>
     <%= f.text_field_without_bootstrap :page_range, class: 'form-control', aria: { describedby: 'page_range_help_block' } %>
-    <span class="help-block" id="page_range_help_block">Examples: '1-15, 25-30' or '249-275, index'</span>
+    <span class="help-block" id="page_range_help_block">Examples: '1-15, 25-30' or '249-275, index'; Up to 30 characters.</span>
   </div>
 </div>
 <%= f.text_area :section_title, rows: '3', required: true %>

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -9,12 +9,27 @@ describe Scan do
 
   it 'validates based on if the item is scannable or not' do
     expect do
-      described_class.create!(item_id: '1234',
+      described_class.create!(item_id: '123',
                               origin: 'GREEN',
                               origin_location: 'STACKS',
                               section_title: 'Some chapter title')
     end.to raise_error(
       ActiveRecord::RecordInvalid, 'Validation failed: This item is not scannable'
+    )
+  end
+
+  it 'validates that the page range length is 30 charachters or less' do
+    expect do
+      described_class.create!(
+        item_id: '1234',
+        origin: 'SAL3',
+        origin_location: 'STACKS',
+        section_title: 'Some chapter title',
+        page_range: 'pages 1-30 and then some long comment describing something more specific about the specified range.'
+      )
+    end.to raise_error(
+      ActiveRecord::RecordInvalid,
+      'Validation failed: This item is not scannable, Page range is too long (maximum is 30 characters)'
     )
   end
 
@@ -39,7 +54,8 @@ describe Scan do
         item_id: '123456',
         origin: 'SAL',
         origin_location: 'SAL-TEMP',
-        section_title: 'Chapter 1'
+        section_title: 'Chapter 1',
+        page_range: 'pages 1-30'
       )
     end.not_to raise_error
   end


### PR DESCRIPTION
The illiad database record field length for PhotoJournalInclusivePages can currently only handle up to 30 chars. They will be fixing this sometime in the near-ish future, but in the meantime this will prevent failed illiad api transaction requests and the email being sent to ILB.

N.b. If we are OK with just getting the occasional (but sometimes daily) error we can consider foregoing this change, as we might then want to back it out when Atlas fixes the field length in the next version upgrade. I have no idea how long it will be before they release a new version upgrade. 