### PR TITLE
Update CdlWaitlistMailer.youre_up to receive the key not the object

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,8 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     okcomputer (1.18.2)
@@ -453,6 +455,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/app/jobs/submit_cdl_checkout_job.rb
+++ b/app/jobs/submit_cdl_checkout_job.rb
@@ -11,6 +11,6 @@ class SubmitCdlCheckoutJob < ApplicationJob
 
     # the checkout request gave us a token, but our user is long-gone. Send them a next-up email
     # as if they were actually on the waitlist (they have no way to know they weren't, so :shrug:)
-    CdlWaitlistMailer.youre_up(response[:hold], response[:hold].circ_record).deliver_later if response[:token]
+    CdlWaitlistMailer.youre_up(response[:hold].key).deliver_later if response[:token]
   end
 end

--- a/app/mailers/cdl_waitlist_mailer.rb
+++ b/app/mailers/cdl_waitlist_mailer.rb
@@ -4,9 +4,9 @@
 class CdlWaitlistMailer < ApplicationMailer
   helper CdlHelper
 
-  def youre_up(hold_record, circ_record)
-    @hold_record = hold_record
-    @circ_record = circ_record
+  def youre_up(hold_record_key)
+    @hold_record = HoldRecord.find(hold_record_key)
+    @circ_record = @hold_record.circ_record
 
     mail(
       to: @hold_record.patron.email,

--- a/spec/mailers/cdl_waitlist_mailer_spec.rb
+++ b/spec/mailers/cdl_waitlist_mailer_spec.rb
@@ -7,13 +7,17 @@ describe CdlWaitlistMailer do
   let(:patron) do
     instance_double(Patron, email: 'someone@example.com')
   end
+  let(:hold_record_key) { 'key' }
 
   before do
     allow(Patron).to receive(:find_by).with(patron_key: patron_key).and_return(patron)
+    allow(HoldRecord).to receive(:find).with(hold_record_key).and_return(hold_record)
   end
 
   describe '.youre_up' do
-    subject(:mail) { described_class.youre_up(hold_record, circ_record) }
+    subject(:mail) { described_class.youre_up(hold_record_key) }
+
+    let(:hold_record_key) { 'key' }
 
     let(:hold_record) do
       HoldRecord.new({
@@ -35,11 +39,15 @@ describe CdlWaitlistMailer do
         }
       }.with_indifferent_access)
     end
-
     let(:checkout_date) { Time.zone.parse('2020-09-15T11:12:13') }
     let(:circ_record) do
       instance_double(CircRecord, due_date: Time.zone.parse('2020-09-16T01:02:03'),
                                   checkout_date: checkout_date)
+    end
+
+    before do
+      allow(hold_record).to receive(:patron).and_return(patron)
+      allow(hold_record).to receive(:circ_record).and_return(circ_record)
     end
 
     describe 'to' do
@@ -65,7 +73,6 @@ describe CdlWaitlistMailer do
   describe '.hold_expired' do
     subject(:mail) { described_class.hold_expired(hold_record_key) }
 
-    let(:hold_record_key) { 'key' }
     let(:hold_record) do
       HoldRecord.new({
         key: 'xyz',
@@ -85,10 +92,6 @@ describe CdlWaitlistMailer do
           }
         }
       }.with_indifferent_access)
-    end
-
-    before do
-      allow(HoldRecord).to receive(:find).with(hold_record_key).and_return(hold_record)
     end
 
     describe 'to' do
@@ -113,7 +116,6 @@ describe CdlWaitlistMailer do
   describe '.on_waitlist' do
     subject(:mail) { described_class.on_waitlist(hold_record_key) }
 
-    let(:hold_record_key) { 'key' }
     let(:hold_record) do
       HoldRecord.new({
         key: 'xyz',
@@ -134,10 +136,6 @@ describe CdlWaitlistMailer do
           }
         }
       }.with_indifferent_access)
-    end
-
-    before do
-      allow(HoldRecord).to receive(:find).with(hold_record_key).and_return(hold_record)
     end
 
     describe 'to' do

--- a/spec/services/cdl_checkout_spec_spec.rb
+++ b/spec/services/cdl_checkout_spec_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe CdlCheckout do
       end
 
       it 'sends the user a next-up email if the background checkout succeeds' do
-        hold = instance_double(HoldRecord, circ_record: instance_double(CircRecord))
+        hold = instance_double(HoldRecord, key: 'x', circ_record: instance_double(CircRecord))
         expect(subject).to receive(:process_checkout).with('12345').and_raise(Exceptions::SymphonyError).ordered
         expect(subject).to receive(:process_checkout).with('12345').and_return({ hold: hold, token: 'xyz' }).ordered
 
         mailer = double(deliver_later: true)
-        expect(CdlWaitlistMailer).to receive(:youre_up).with(hold, hold.circ_record).and_return(mailer)
+        expect(CdlWaitlistMailer).to receive(:youre_up).with(hold.key).and_return(mailer)
 
         expect { described_class.checkout('12345', 'druid', user) }.to raise_exception(Exceptions::SymphonyError)
         expect(mailer).to have_received :deliver_later


### PR DESCRIPTION
…both for consistency and so it works in Rails 6.1 (which wants to serialize things even if they aren't being performed later, it seems?)