### PR TITLE
Pass through the circ record key to the CdlWaitlistMailer

### DIFF
--- a/app/controllers/cdl_controller.rb
+++ b/app/controllers/cdl_controller.rb
@@ -70,6 +70,8 @@ class CdlController < ApplicationController
   end
 
   def handle_cdl_error(exception)
+    Honeybadger.notify(exception)
+
     respond_to do |format|
       format.json { render json: { error: exception.message }.to_json, status: :bad_request }
       format.html { render 'cdl_error' }
@@ -77,6 +79,8 @@ class CdlController < ApplicationController
   end
 
   def handle_symphony_error(exception)
+    Honeybadger.notify(exception)
+
     @exception = exception
 
     status = exception.privileges_error? ? :unauthorized : :internal_server_error

--- a/app/jobs/submit_cdl_checkout_job.rb
+++ b/app/jobs/submit_cdl_checkout_job.rb
@@ -11,6 +11,6 @@ class SubmitCdlCheckoutJob < ApplicationJob
 
     # the checkout request gave us a token, but our user is long-gone. Send them a next-up email
     # as if they were actually on the waitlist (they have no way to know they weren't, so :shrug:)
-    CdlWaitlistMailer.youre_up(response[:hold].key).deliver_later if response[:token]
+    CdlWaitlistMailer.youre_up(response[:hold].key, response[:hold].circ_record_key).deliver_later if response[:token]
   end
 end

--- a/spec/services/cdl_checkout_spec_spec.rb
+++ b/spec/services/cdl_checkout_spec_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe CdlCheckout do
       end
 
       it 'sends the user a next-up email if the background checkout succeeds' do
-        hold = instance_double(HoldRecord, key: 'x', circ_record: instance_double(CircRecord))
+        hold = instance_double(HoldRecord, key: 'x', circ_record_key: 'y', circ_record: instance_double(CircRecord))
         expect(subject).to receive(:process_checkout).with('12345').and_raise(Exceptions::SymphonyError).ordered
         expect(subject).to receive(:process_checkout).with('12345').and_return({ hold: hold, token: 'xyz' }).ordered
 
         mailer = double(deliver_later: true)
-        expect(CdlWaitlistMailer).to receive(:youre_up).with(hold.key).and_return(mailer)
+        expect(CdlWaitlistMailer).to receive(:youre_up).with(hold.key, hold.circ_record_key).and_return(mailer)
 
         expect { described_class.checkout('12345', 'druid', user) }.to raise_exception(Exceptions::SymphonyError)
         expect(mailer).to have_received :deliver_later


### PR DESCRIPTION
Also make sure we notify honeybadger if we run into CDL errors