### PR TITLE
Fix rake task that removes obsolete requests

### DIFF
--- a/lib/tasks/data_removal.rake
+++ b/lib/tasks/data_removal.rake
@@ -3,7 +3,7 @@
 namespace :data_removal do
   desc 'Remove old requests'
   task remove_old_requests: :environment do
-    t = Settings.data_cleanup&.age&.ago || Time.zone.at(0)
+    t = ActiveSupport::Duration.build(Settings.data_cleanup.age).ago
     raise 'Date is too recent' if t > 1.month.ago
 
     Request.obsolete(t).delete_all


### PR DESCRIPTION
This commit touches only the `data_removal.rake` file and does the following:

1. Cast an integer set in `config/settings.yml` back to an `ActiveSupport::Duration`, since integers do not respond to `#ago`
2. Remove the safe navigation operators and the nil check, since `Settings.data_cleanup` should always be set in all environments

Without the first change, this task fails when run due to `1.year` being cast from a duration to an integer because it's in a YAML file. Here is the error message:

```
rake aborted!
NoMethodError: undefined method `ago' for 31557600:Integer
/opt/app/requests/requests/shared/bundle/ruby/2.7.0/gems/whenever-1.0.0/lib/whenever/numeric.rb:10:in `method_missing'
/opt/app/requests/requests/releases/20210503174105/lib/tasks/data_removal.rake:6:in `block (2 levels) in <main>'
/opt/app/requests/requests/shared/bundle/ruby/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/opt/app/requests/requests/shared/bundle/ruby/2.7.0/bin/ruby_executable_hooks:24:in `eval'
/opt/app/requests/requests/shared/bundle/ruby/2.7.0/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => data_removal:remove_old_requests
```