### PR TITLE
Remove references to EHS COVID hygiene class

### DIFF
--- a/app/views/approval_status_mailer/_pickup_confirmation.html.erb
+++ b/app/views/approval_status_mailer/_pickup_confirmation.html.erb
@@ -1,4 +1,3 @@
 <div>
   <p>We've received your request. We'll email you again when it's ready for pickup.</p>
-  <p>If you haven't already, complete <%= link_to('COVID-19 Hygiene Best Practices, EHS-2470-WEB', 'https://starsexpress.stanford.edu/index.html?ref=LM_SS_LEARNING.LM_BROWSE_LEARNER.GBL&type=COURSE&code=EHS-2470') %> before your visit.</p>
 </div>

--- a/app/views/confirmation_mailer/request_confirmation.html.erb
+++ b/app/views/confirmation_mailer/request_confirmation.html.erb
@@ -10,8 +10,6 @@
       <li>On the day of your visit, follow the required health and safety protocols for <%= link_to 'library access', 'https://library.stanford.edu/using/access-and-privileges' %></li>
     </ol>
 
-    <p>If you haven’t already, complete <%= link_to('COVID-19 Hygiene Best Practices, EHS-2470-WEB', 'https://starsexpress.stanford.edu/index.html?ref=LM_SS_LEARNING.LM_BROWSE_LEARNER.GBL&type=COURSE&code=EHS-2470') %> before your visit.</p>
-
     <p><%= @request.item_title %></p>
 
     <p>Item(s) requested:</p>


### PR DESCRIPTION
Fixes #1237
Visitors are no longer required to take this class. Other references to this in libweb will be handled by OEG members.