### PR TITLE
Fix the notification logic guard clause

### DIFF
--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -17,7 +17,7 @@ class Page < Request
 
   # Ideally, we'll be able to drop the wildcard rule because no requests will make it here
   after_create do
-    next if location_rule&.send_honeybadger_notice_if_used
+    next unless location_rule&.send_honeybadger_notice_if_used
 
     Honeybadger.notify("WARNING: Using default location rule for page #{id} (origin: #{origin}, origin_location: #{origin_location})")
   end


### PR DESCRIPTION
We only want notifications if the location has the `send_honeybadger_notice_if_used` configuration set. 