### PR TITLE
Pin redis until sidekiq has a new release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'whenever'
 
 gem 'jwt'
 gem 'rack-attack'
-gem 'redis'
+gem 'redis', '~> 4.5.1' # 4.6.0 spews deprecation warnings out of sidekiq
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
-    redis (4.6.0)
+    redis (4.5.1)
     regexp_parser (2.2.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -495,7 +495,7 @@ DEPENDENCIES
   rails (~> 6.1)
   rails-controller-testing
   redcarpet
-  redis
+  redis (~> 4.5.1)
   rspec-rails (~> 4.0)
   rubocop
   rubocop-performance


### PR DESCRIPTION
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end

(called from /opt/app/requests/requests/shared/bundle/ruby/3.0.0/gems/sidekiq-6.4.0/lib/sidekiq/client.rb:192:in `block in raw_push'}
```