### PR TITLE
Remove outdated Hoover archives config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -415,12 +415,6 @@ pageable:
     pickup_libraries:
       - SPEC-COLL
     mediated: true
-  - library: HV-ARCHIVE
-    locations_match:
-      - "-30$"
-    pickup_libraries:
-      - HV-ARCHIVE
-    mediated: true
   # Location-specific pickup libraries
   - locations:
       - PAGE-AR

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -86,7 +86,7 @@ describe RequestsController do
     end
 
     describe 'for mediated pages' do
-      let(:request) { create(:request, origin: 'SPEC-COLL') }
+      let(:request) { create(:request, origin: 'ART', origin_location: 'ARTLCKL') }
 
       it 'delegates the request object' do
         path

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -31,11 +31,20 @@ FactoryBot.define do
     association :user, factory: :sequence_webauth_user
   end
 
-  factory :hoover_archive_mediated_page, parent: :mediated_page do
-    origin { 'HV-ARCHIVE' }
-    origin_location { 'SOMEWHERE-30' }
-    destination { 'HV-ARCHIVE' }
+  factory :art_mediated_page, class: 'MediatedPage' do
+    item_id { '1234' }
+    origin { 'ART' }
+    origin_location { 'ARTLCKL' }
+    destination { 'ART' }
+    item_title { 'Art MediatedPage' }
+    needed_date { Time.zone.today }
     association :user, factory: :sequence_webauth_user
+
+    after(:build) do |request|
+      class << request
+        def needed_date_is_valid; end
+      end
+    end
   end
 
   factory :mediated_page_with_single_holding, parent: :mediated_page do

--- a/spec/factories/searchworks_api_json.rb
+++ b/spec/factories/searchworks_api_json.rb
@@ -553,13 +553,13 @@ FactoryBot.define do
 
     holdings do
       [
-        { 'code' => 'SPEC-COLL',
+        { 'code' => 'ART',
           'library_instructions' => {
             'heading' => 'Instruction Heading',
             'text' => 'This is the library instruction'
           },
           'locations' => [
-            { 'code' => 'STACKS',
+            { 'code' => 'ARTLCKL',
               'items' => [
                 { 'barcode' => '12345678',
                   'callnumber' => 'ABC 123',

--- a/spec/factories/searchworks_items.rb
+++ b/spec/factories/searchworks_items.rb
@@ -74,7 +74,7 @@ FactoryBot.define do
   factory :library_instructions_searchworks_item, class: 'SearchworksItem' do
     initialize_with { new(request) }
 
-    request { create(:request, origin: 'SPEC-COLL', origin_location: 'STACKS') }
+    request { create(:request, origin: 'ART', origin_location: 'ARTLCKL') }
 
     after(:build) do |item|
       class << item

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -172,7 +172,7 @@ describe 'Viewing all requests' do
         stub_current_user(create(:superadmin_user))
         create(:mediated_page)
         create(:mediated_page)
-        create(:hoover_archive_mediated_page)
+        create(:art_mediated_page)
       end
 
       it 'lists all the mediated pages for the given library' do
@@ -181,9 +181,9 @@ describe 'Viewing all requests' do
         expect(page).to have_css('h2', text: 'Special Collections')
         expect(page).to have_css('table tbody tr', count: 2)
 
-        visit admin_path('HV-ARCHIVE')
+        visit admin_path('ART')
 
-        expect(page).to have_css('h2', text: 'Hoover Archive')
+        expect(page).to have_css('h2', text: 'Art & Architecture Library (Bowes)')
         expect(page).to have_css('table tbody tr', count: 1)
       end
 

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -102,7 +102,7 @@ describe 'Creating a mediated page request' do
     end
 
     it 'does not include a comments for requests that do not get them' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'HV-ARCHIVE', origin_location: 'STACKS-30')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
 
       expect(page).not_to have_field('Comments')
     end

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -6,7 +6,7 @@ describe 'Library Instructions' do
   before { stub_searchworks_api_json(build(:library_instructions_holdings)) }
 
   it 'returns the library instructions from the API' do
-    visit new_request_path(item_id: '12345', origin: 'SPEC-COLL', origin_location: 'STACKS')
+    visit new_request_path(item_id: '12345', origin: 'ART', origin_location: 'ARTLCKL')
 
     within('p.needed-date-info-block') do
       expect(page).to have_content('This is the library instruction')

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -13,11 +13,11 @@ describe 'Requests Delegation' do
   end
 
   describe 'mediated page materials' do
-    it 'automaticallies delegate to the mediated page request form' do
-      visit new_request_path(item_id: '12345', origin: 'SPEC-COLL', origin_location: 'STACKS')
+    it 'automatically delegate to the mediated page request form' do
+      visit new_request_path(item_id: '12345', origin: 'ART', origin_location: 'ARTLCKL')
 
       expect(page).to have_css('h1#dialogTitle', text: 'Request on-site access')
-      expect(current_url).to eq new_mediated_page_url(item_id: '12345', origin: 'SPEC-COLL', origin_location: 'STACKS')
+      expect(current_url).to eq new_mediated_page_url(item_id: '12345', origin: 'ART', origin_location: 'ARTLCKL')
     end
   end
 

--- a/spec/models/concerns/mediateable_spec.rb
+++ b/spec/models/concerns/mediateable_spec.rb
@@ -39,19 +39,5 @@ describe 'Mediateable' do
         expect(subject).not_to be_mediateable
       end
     end
-
-    describe 'HV-ARCHIVE' do
-      before { subject.origin = 'HV-ARCHIVE' }
-
-      it 'returns true if the item is in a *-30 location' do
-        subject.origin_location = 'SOMEWHERE-30'
-        expect(subject).to be_mediateable
-      end
-
-      it 'returns false if the item is not in a *-30 location' do
-        subject.origin_location = 'SOMEWHERE-ELSE'
-        expect(subject).not_to be_mediateable
-      end
-    end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -622,11 +622,11 @@ describe Request do
   describe 'mediateable_origins' do
     before do
       create(:mediated_page)
-      create(:hoover_archive_mediated_page)
+      create(:art_mediated_page)
     end
 
     it 'returns the subset of origin codes that are configured and mediated pages that exist in the database' do
-      expect(described_class.mediateable_origins.to_h.keys).to eq %w(HV-ARCHIVE SPEC-COLL)
+      expect(described_class.mediateable_origins.to_h.keys).to eq %w(ART SPEC-COLL)
     end
   end
 

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -77,8 +77,8 @@ describe MediatedPage do
         needed_date: Time.zone.today - 1.day
       ).save(validate: false)
 
-      create(:hoover_archive_mediated_page, user: user, needed_date: Time.zone.today)
-      create(:hoover_archive_mediated_page, user: user, needed_date: Time.zone.today + 1.day)
+      create(:art_mediated_page, user: user, needed_date: Time.zone.today)
+      create(:art_mediated_page, user: user, needed_date: Time.zone.today + 1.day)
     end
 
     describe 'archived' do
@@ -108,7 +108,7 @@ describe MediatedPage do
     describe 'for_origin' do
       it 'returns the records for a given origin' do
         expect(described_class.for_origin('SPEC-COLL').length).to eq 3
-        expect(described_class.for_origin('HV-ARCHIVE').length).to eq 2
+        expect(described_class.for_origin('ART').length).to eq 2
       end
     end
   end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -8,10 +8,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.start
     factories_to_lint = FactoryBot.factories.reject do |factory|
-      # Remove _holdings and _searchworks_item since they are not active record objects
-      factory.name =~ /_holdings?$/ ||
-        factory.name.to_s.ends_with?('_searchworks_item') ||
-        factory.name.to_s.starts_with?('symphony_')
+      # Remove non-activerecord objects (Hashes)
+      [Hash, SearchworksItem].include? factory.build_class
     end
 
     FactoryBot.lint factories_to_lint unless config.files_to_run.one?


### PR DESCRIPTION
- Remove Hoover Archives mediated paging config
- Change linting strategy for non-model factories

spun off of #1339 to make reviewing easier on that PR.
