### PR TITLE
Remove references to WebAuth

### DIFF
--- a/app/controllers/admin_comments_controller.rb
+++ b/app/controllers/admin_comments_controller.rb
@@ -23,6 +23,6 @@ class AdminCommentsController < ApplicationController
   protected
 
   def create_params
-    params.require(:admin_comment).permit(:comment).to_h.merge(commenter: current_user.webauth)
+    params.require(:admin_comment).permit(:comment).to_h.merge(commenter: current_user.sunetid)
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -38,7 +38,7 @@ class AdminController < ApplicationController
 
   def approve_item
     status = @request.item_status(params[:item])
-    status.approve!(current_user.webauth) unless status.approved?
+    status.approve!(current_user.sunetid) unless status.approved?
 
     if @request.symphony_response.success?(params[:item])
       render json: status, layout: false
@@ -137,7 +137,7 @@ class AdminController < ApplicationController
   end
 
   def rescue_can_can(*)
-    return super if webauth_user? || params[:action] == 'approve_item'
+    return super if sso_user? || params[:action] == 'approve_item'
 
     redirect_to login_path(referrer: request.original_url)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,8 +17,8 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def webauth_user?
-    current_user.webauth_user?
+  def sso_user?
+    current_user.sso_user?
   end
 
   def rescue_can_can(exception)

--- a/app/controllers/cdl_controller.rb
+++ b/app/controllers/cdl_controller.rb
@@ -92,7 +92,7 @@ class CdlController < ApplicationController
   end
 
   def rescue_can_can(*)
-    return super if webauth_user?
+    return super if sso_user?
 
     redirect_to login_path(referrer: request.original_url)
   end

--- a/app/controllers/interstitial_controller.rb
+++ b/app/controllers/interstitial_controller.rb
@@ -2,7 +2,7 @@
 
 ###
 #  This controller simply handles incoming requests (and responds immediately)
-#  then redirects the user to the requested url. This allows us to take the user from WebAuth
+#  then redirects the user to the requested url. This allows us to take the user from authentication
 #  and send them to their destination w/o allowing them to submit multiple superfluous requests
 ###
 class InterstitialController < ApplicationController

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -7,7 +7,7 @@ class ScansController < RequestsController
   protected
 
   def rescue_new_record_via_post
-    if current_user&.webauth_user?
+    if current_user&.sso_user?
       # if they are logged in, but not eligible, send the user to the appropriate page for
       redirect_to delegated_new_request_path(@request, new_request_params), flash: {
         html_safe: true,

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -70,7 +70,7 @@ module RequestsHelper
   end
 
   def status_page_url_for_request(request)
-    if !request.user.webauth_user? && request.is_a?(TokenEncryptable)
+    if !request.user.sso_user? && request.is_a?(TokenEncryptable)
       polymorphic_url([:status, request], token: request.encrypted_token)
     else
       polymorphic_url([:status, request])
@@ -121,7 +121,7 @@ module RequestsHelper
   def requester_info(user)
     return unless user
 
-    if user.webauth_user? || user.email_address.present?
+    if user.sso_user? || user.email_address.present?
       mail_to user.email_address, user.to_email_string
     elsif user.library_id_user?
       user.library_id

--- a/app/mailers/request_status_mailer.rb
+++ b/app/mailers/request_status_mailer.rb
@@ -76,7 +76,7 @@ class RequestStatusMailer < ApplicationMailer
   end
 
   def success_url
-    if !@request.user.webauth_user? && @request.is_a?(TokenEncryptable)
+    if !@request.user.sso_user? && @request.is_a?(TokenEncryptable)
       polymorphic_url([:status, @request], token: @request.encrypted_token, only_path: false, protocol: 'https')
     else
       polymorphic_url([:status, @request], only_path: false, protocol: 'https')

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,8 +16,8 @@ class Ability
     @with_a_library_id ||= Ability.new(User.new(library_id: '0000000000'))
   end
 
-  def self.webauth
-    @webauth ||= Ability.new(User.new(webauth: 'generic'))
+  def self.sso
+    @sso ||= Ability.new(User.new(sunetid: 'generic'))
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
@@ -63,7 +63,7 @@ class Ability
     can :new, Request
 
     # ... but only some types of users can actually submit the request successfully
-    if user.webauth_user? || user.library_id_user? || user.name_email_user?
+    if user.sso_user? || user.library_id_user? || user.name_email_user?
       can :create, MediatedPage
       can :create, Page
     end
@@ -73,11 +73,11 @@ class Ability
       cannot :create, Page, origin: 'MEDIA-MTXT'
     end
 
-    can :create, HoldRecall if user.library_id_user? || user.webauth_user?
+    can :create, HoldRecall if user.library_id_user? || user.sso_user?
     can :create, Scan if user.super_admin? || in_scan_pilot_group?(user)
 
     # ... and to check the status, you either need to be logged in or include a special token in the URL
-    can :read, [Request, Page, HoldRecall, Scan, MediatedPage], user_id: user.id if user.webauth_user?
+    can :read, [Request, Page, HoldRecall, Scan, MediatedPage], user_id: user.id if user.sso_user?
 
     if token
       begin
@@ -97,8 +97,8 @@ class Ability
     end
 
     if Settings.cdl.enabled
-      can :checkin, :cdl if user.webauth_user?
-      can :checkout, :cdl if user.webauth_user?
+      can :checkin, :cdl if user.sso_user?
+      can :checkout, :cdl if user.sso_user?
       can :availability, :cdl
     end
   end

--- a/app/models/concerns/request_validations.rb
+++ b/app/models/concerns/request_validations.rb
@@ -62,7 +62,7 @@ module RequestValidations
     return unless user
 
     # Ensure we don't contact symphony if we don't need to validate the library ID
-    return if user.webauth_user? || (requestable_with_name_email? && user.name_email_user?)
+    return if user.sso_user? || (requestable_with_name_email? && user.name_email_user?)
 
     # We require the library ID is on the client side when neccesary
     # required when necessary, so if it's blank here, it's not required

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -18,7 +18,7 @@ class CurrentUser
   def user_object
     @user_object ||= begin
       if user_id.present?
-        webauth_user
+        sso_user
       else
         anonymous_user
       end
@@ -27,8 +27,8 @@ class CurrentUser
 
   private
 
-  def webauth_user
-    User.find_or_create_by(webauth: user_id).tap do |user|
+  def sso_user
+    User.find_or_create_by(sunetid: user_id).tap do |user|
       update_ldap_attributes(user)
     end
   end
@@ -45,23 +45,23 @@ class CurrentUser
   end
 
   def ldap_name
-    ldap_attributes['WEBAUTH_LDAP_DISPLAYNAME'] || ldap_attributes['displayName']
+    ldap_attributes['displayName']
   end
 
   def ldap_group_string
-    ldap_attributes['WEBAUTH_LDAPPRIVGROUP'] || ldap_attributes['eduPersonEntitlement']
+    ldap_attributes['eduPersonEntitlement']
   end
 
   def ldap_sucard_number
-    ldap_attributes['WEBAUTH_LDAP_SUCARDNUMBER'] || ldap_attributes['suCardNumber']
+    ldap_attributes['suCardNumber']
   end
 
   def ldap_affiliation
-    ldap_attributes['WEBAUTH_LDAP_SUAFFILIATION'] || ldap_attributes['suAffiliation']
+    ldap_attributes['suAffiliation']
   end
 
   def ldap_student_type
-    ldap_attributes['WEBAUTH_LDAP_SUSTUDENTTYPE'] || ldap_attributes['suStudentType']
+    ldap_attributes['suStudentType']
   end
 
   def ldap_email
@@ -70,11 +70,11 @@ class CurrentUser
   end
 
   def ldap_email_attribute
-    ldap_attributes['WEBAUTH_EMAIL'] || ldap_attributes['mail']
+    ldap_attributes['mail']
   end
 
   def ldap_email_status
-    ldap_attributes['WEBAUTH_LDAP_SUEMAILSTATUS'] || ldap_attributes['suEmailStatus']
+    ldap_attributes['suEmailStatus']
   end
 
   def ldap_attributes

--- a/app/models/illiad_request.rb
+++ b/app/models/illiad_request.rb
@@ -23,7 +23,7 @@ class IlliadRequest
       'CallNumber': call_number,
       'ILLNumber': ill_number,
       'ItemNumber': item_number,
-      'Username': @scan.user.webauth
+      'Username': @scan.user.sunetid
     }.to_json
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -102,7 +102,7 @@ class Request < ActiveRecord::Base
     return unless user
 
     case
-    when user.webauth_user? then User.find_by_webauth(user.webauth)
+    when user.sso_user? then User.find_by_sunetid(user.sunetid)
     when user.library_id_user? then find_existing_library_id_user
     when user.name_email_user? then find_existing_email_user
     end

--- a/app/services/cdl_checkout.rb
+++ b/app/services/cdl_checkout.rb
@@ -144,7 +144,7 @@ class CdlCheckout
       iat: Time.zone.now.to_i,
       barcode: circ_record.item_barcode,
       aud: druid,
-      sub: user.webauth,
+      sub: user.sunetid,
       exp: circ_record.due_date.to_i,
       hold_record_id: hold_record_id
     }

--- a/app/views/ilb_mailer/ilb_notification.text.erb
+++ b/app/views/ilb_mailer/ilb_notification.text.erb
@@ -11,4 +11,4 @@ You can view the status and details of the request here:
 https://requests.stanford.edu/scans/<%= @request.id %>/status
 
 Systems will try to improve the ILLiad request process, but in the meantime please create a transaction in ILLiad manually for:
-ILLiad Username: <%= @request.user.webauth %>
+ILLiad Username: <%= @request.user.sunetid %>

--- a/app/views/requests/_no_sunet_form.html.erb
+++ b/app/views/requests/_no_sunet_form.html.erb
@@ -1,6 +1,6 @@
 <% if f.object.requestable_with_library_id? || f.object.requestable_with_name_email? %>
   <div id="no-sunetid-form" aria-hidden="false">
-    <%= f.fields_for :user, (current_request.user unless current_request.user && current_request.user.webauth_user?) || User.new do |uf| %>
+    <%= f.fields_for :user, (current_request.user unless current_request.user && current_request.user.sso_user?) || User.new do |uf| %>
       <% if f.object.requestable_with_library_id? %>
         <div class="form-group <%= "has-error" if f.object.library_id_error? %>">
           <%= uf.label :library_id, 'Stanford Library ID', class: "control-label #{label_column_class} #{'required' unless f.object.requestable_with_name_email?}" %>

--- a/app/views/requests/_no_sunet_option.html.erb
+++ b/app/views/requests/_no_sunet_option.html.erb
@@ -1,11 +1,11 @@
 <% if f.object.requestable_with_library_id? || f.object.requestable_with_name_email? %>
   <hr />
   <p class='or-divider'>
-    <% if current_user.webauth_user? %>
+    <% if current_user.sso_user? %>
       Not you?
     <% else %>
       or
     <% end %>
   </p>
-  <%= link_to current_user.webauth_user? ? 'Request with a different ID' : "I don't have a SUNet ID", '#no-sunetid-form', class: 'btn btn-md btn-default btn-full', data: { toggle: 'show', show: '#no-sunetid-form', hide: '#sunetid-form', focus: 'input[type=text]:visible:first' } %>
+  <%= link_to current_user.sso_user? ? 'Request with a different ID' : "I don't have a SUNet ID", '#no-sunetid-form', class: 'btn btn-md btn-default btn-full', data: { toggle: 'show', show: '#no-sunetid-form', hide: '#sunetid-form', focus: 'input[type=text]:visible:first' } %>
 <% end %>

--- a/app/views/requests/_sunet_form.html.erb
+++ b/app/views/requests/_sunet_form.html.erb
@@ -1,5 +1,5 @@
 <div id="sunetid-form" class='<%= content_column_class %> <%= label_column_offset_class %>'>
-  <% if current_user.webauth_user? %>
+  <% if current_user.sso_user? %>
     <h2>
       <%= render_user_information %>
     </h2>

--- a/app/views/scans/success.html.erb
+++ b/app/views/scans/success.html.erb
@@ -19,7 +19,7 @@
 
   <dl class='dl-horizontal dl-invert user-contact-information'>
     <dt class='sr-only'><%= current_request.class.human_attribute_name :user %></dt>
-    <% if current_request.user.webauth_user? || current_request.user.name_email_user? %>
+    <% if current_request.user.sso_user? || current_request.user.name_email_user? %>
       <dd>
         <span class="requested-by"><%= current_request.user.to_email_string %></span>
       </dd>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -7,8 +7,8 @@
     <% end %>
 
     <div class="header-links">
-      <% if current_user.webauth_user? %>
-        <%= link_to "#{current_user.webauth}: Logout", logout_path(referrer: root_path) %>
+      <% if current_user.sso_user? %>
+        <%= link_to "#{current_user.sunetid}: Logout", logout_path(referrer: root_path) %>
       <% else %>
         <%= link_to "Login", login_path(referrer: request.original_url) %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,8 @@ Rails.application.routes.draw do
   get 'interstitial' => 'interstitial#show', as: :interstitial
 
   # Authorization routes
-  get 'webauth/login' => 'authentication#login', as: :login
-  get 'webauth/logout' => 'authentication#logout', as: :logout
+  get 'sso/login' => 'authentication#login', as: :login
+  get 'sso/logout' => 'authentication#logout', as: :logout
 
   resources :paging_schedule, only: :index
   get 'paging_schedule/:origin(/:destination)' => 'paging_schedule#show', as: :paging_schedule

--- a/db/migrate/20220927230539_rename_webauth_to_sunetid.rb
+++ b/db/migrate/20220927230539_rename_webauth_to_sunetid.rb
@@ -1,0 +1,11 @@
+class RenameWebauthToSunetid < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :users, :webauth, :sunetid
+    rename_index :users, 'index_users_on_webauth', 'index_users_on_sunetid'
+  end
+
+  def down
+    rename_column :users, :sunetid, :webauth
+    rename_index :users, 'index_users_on_sunetid', 'index_users_on_webauth'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,35 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_04_195914) do
-
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
+ActiveRecord::Schema.define(version: 2022_09_27_230539) do
 
   create_table "admin_comments", force: :cascade do |t|
     t.string "commenter"
@@ -80,7 +52,7 @@ ActiveRecord::Schema.define(version: 2021_01_04_195914) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "webauth"
+    t.string "sunetid"
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
@@ -89,9 +61,7 @@ ActiveRecord::Schema.define(version: 2021_01_04_195914) do
     t.string "student_type"
     t.index ["email"], name: "index_users_on_email"
     t.index ["library_id"], name: "index_users_on_library_id"
-    t.index ["webauth"], name: "index_users_on_webauth"
+    t.index ["sunetid"], name: "index_users_on_sunetid"
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -26,8 +26,8 @@ describe AdminController do
       end
     end
 
-    describe 'for webauth user' do
-      let(:user) { create(:webauth_user) }
+    describe 'for sso user' do
+      let(:user) { create(:sso_user) }
 
       it 'is not accessible' do
         expect { get :index }.to raise_error(CanCan::AccessDenied)
@@ -76,7 +76,7 @@ describe AdminController do
     end
 
     describe 'for normal webuath user' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'is not be accessible' do
         expect { get :show, params: { id: 'SPEC-COLL' } }.to raise_error(CanCan::AccessDenied)
@@ -98,7 +98,7 @@ describe AdminController do
     describe 'for super admins' do
       let(:user) { create(:superadmin_user) }
       let(:mediated_page) do
-        create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+        create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
       end
 
       it 'returns the holdings table markup' do
@@ -133,11 +133,11 @@ describe AdminController do
       end
 
       it 'selects items that have approvals within a range' do
-        create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
-        b = create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+        create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
+        b = create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
         b.item_statuses.to_a.first.approve!(user, Time.zone.now - 5.days)
         b.item_statuses.to_a.last.approve!(user, Time.zone.now - 1.day)
-        c = create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+        c = create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
         c.item_statuses.first.approve!(user, Time.zone.now + 1.day)
 
         get :picklist, params: { id: 'ART', from: (Time.zone.now - 2.days).to_s, to: (Time.zone.now + 2.days).to_s }
@@ -160,7 +160,7 @@ describe AdminController do
     end
 
     describe 'for normal webuath user' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'is not be accessible' do
         expect { get :picklist, params: { id: 'SPEC-COLL' } }.to raise_error(CanCan::AccessDenied)
@@ -182,7 +182,7 @@ describe AdminController do
     before { stub_searchworks_api_json(build(:searchable_holdings)) }
 
     let(:mediated_page) do
-      create(:mediated_page_with_holdings, user: create(:webauth_user), barcodes: %w(12345678 23456789))
+      create(:mediated_page_with_holdings, user: create(:sso_user), barcodes: %w(12345678 23456789))
     end
 
     describe 'for those that can manage requests' do

--- a/spec/controllers/cdl_controller_spec.rb
+++ b/spec/controllers/cdl_controller_spec.rb
@@ -15,18 +15,18 @@ describe CdlController do
       it 'is restricted' do
         get :checkin, params: { hold_record_key: 'abc123' }
         expect(response).to redirect_to(
-          '/webauth/login?referrer=http%3A%2F%2Ftest.host%2Fcdl%2Fcheckin%3Fhold_record_key%3Dabc123'
+          '/sso/login?referrer=http%3A%2F%2Ftest.host%2Fcdl%2Fcheckin%3Fhold_record_key%3Dabc123'
         )
       end
     end
 
-    context 'webauth user' do
+    context 'sso user' do
       before do
         allow(controller).to receive_messages(current_user: user)
         allow(user).to receive_messages(patron: Patron.new(patron_record))
       end
 
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
       let(:patron_record) do
         {
           'fields' => {
@@ -57,18 +57,18 @@ describe CdlController do
       it 'is restricted' do
         get :checkout, params: { id: 'ab123cd4567', barcode: '123456' }
         expect(response).to redirect_to(
-          '/webauth/login?referrer=http%3A%2F%2Ftest.host%2Fcdl%2Fcheckout%3Fbarcode%3D123456%26id%3Dab123cd4567'
+          '/sso/login?referrer=http%3A%2F%2Ftest.host%2Fcdl%2Fcheckout%3Fbarcode%3D123456%26id%3Dab123cd4567'
         )
       end
     end
 
-    context 'webauth user' do
+    context 'sso user' do
       before do
         allow(controller).to receive_messages(current_user: user)
         allow(user).to receive_messages(patron: Patron.new(patron_record))
       end
 
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
       let(:patron_record) do
         {
           'fields' => {

--- a/spec/controllers/hold_recall_controller_spec.rb
+++ b/spec/controllers/hold_recall_controller_spec.rb
@@ -90,8 +90,8 @@ describe HoldRecallsController do
       end
     end
 
-    describe 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    describe 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'is allowed' do
         post :create, params: { request: normal_params }
@@ -113,7 +113,7 @@ describe HoldRecallsController do
     end
 
     describe 'invalid requests' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'returns an error message to the user' do
         post :create, params: { request: { item_id: '1234' } }

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -111,8 +111,8 @@ describe MediatedPagesController do
       end
     end
 
-    describe 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    describe 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'is allowed' do
         post :create, params: {
@@ -161,7 +161,7 @@ describe MediatedPagesController do
     end
 
     describe 'invalid requests' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'returns an error message to the user' do
         post :create, params: { request: { item_id: '1234' } }
@@ -205,7 +205,7 @@ describe MediatedPagesController do
     end
 
     context 'by a user who cannot manage the request (even if they created the reqeust)' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
       let!(:mediated_page) { create(:mediated_page, user: user) }
 
       it 'throws an access denied error' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -110,7 +110,7 @@ describe PagesController do
 
       context 'for faculty with a sponsored proxy group' do
         let(:user) do
-          build(:webauth_user).tap do |u|
+          build(:sso_user).tap do |u|
             allow(u).to receive(:sponsor?).and_return(true)
           end
         end
@@ -170,8 +170,8 @@ describe PagesController do
       end
     end
 
-    describe 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    describe 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'is allowed' do
         post :create, params: {
@@ -197,7 +197,7 @@ describe PagesController do
         expect(Page.last.barcodes.sort).to eq(%w(12345679 3610512345678))
       end
 
-      it 'redirects to success page with token when the WebAuth user supplies a library ID' do
+      it 'redirects to success page with token when the sso user supplies a library ID' do
         allow(Patron).to receive(:find_by).with(library_id: '5432123').and_return(
           instance_double('Patron', email: nil, exists?: true)
         )
@@ -234,7 +234,7 @@ describe PagesController do
     end
 
     describe 'invalid requests' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'returns an error message to the user' do
         post :create, params: { request: { item_id: '1234' } }
@@ -269,8 +269,8 @@ describe PagesController do
       end
     end
 
-    describe 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    describe 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'raises an error' do
         expect { put(:update, params: { id: page[:id] }) }.to raise_error(CanCan::AccessDenied)
@@ -290,8 +290,8 @@ describe PagesController do
   end
 
   describe '#success' do
-    context 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    context 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'is successful if they have the are the creator of the record' do
         page = create(:page, user: user)
@@ -308,10 +308,10 @@ describe PagesController do
     end
 
     context 'by non-webuth users' do
-      let(:user) { create(:non_webauth_user) }
+      let(:user) { create(:non_sso_user) }
 
       it 'raised an AccessDenied error' do
-        page = create(:page, user: create(:non_webauth_user, email: 'jjstanford@stanford.edu'))
+        page = create(:page, user: create(:non_sso_user, email: 'jjstanford@stanford.edu'))
         expect do
           get :success, params: { id: page[:id] }
         end.to raise_error(CanCan::AccessDenied)
@@ -320,8 +320,8 @@ describe PagesController do
   end
 
   describe '#status' do
-    context 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    context 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'is successful if they have the are the creator of the record' do
         page = create(:page, user: user)
@@ -338,10 +338,10 @@ describe PagesController do
     end
 
     context 'by non-webuth users' do
-      let(:user) { create(:non_webauth_user) }
+      let(:user) { create(:non_sso_user) }
 
-      it 'redirects the user to the webauth login with the current url' do
-        page = create(:page, user: create(:non_webauth_user, email: 'jjstanford@stanford.edu'))
+      it 'redirects the user to the sso login with the current url' do
+        page = create(:page, user: create(:non_sso_user, email: 'jjstanford@stanford.edu'))
         get :status, params: { id: page[:id] }
         expect(response).to redirect_to(
           login_path(

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -91,8 +91,8 @@ describe ScansController do
       end
     end
 
-    describe 'by non-webauth users' do
-      let(:user) { create(:non_webauth_user) }
+    describe 'by non-sso users' do
+      let(:user) { create(:non_sso_user) }
 
       it 'raises an error' do
         expect { put(:create, params: { request: { origin: 'SAL3' } }) }.to raise_error(CanCan::AccessDenied)
@@ -129,7 +129,7 @@ describe ScansController do
     describe 'by ineligible users' do
       render_views
 
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'is bounced to a page workflow' do
         params = {
@@ -165,8 +165,8 @@ describe ScansController do
       end
     end
 
-    describe 'by webauth users' do
-      let(:user) { create(:webauth_user) }
+    describe 'by sso users' do
+      let(:user) { create(:sso_user) }
 
       it 'raises an error' do
         expect { put(:update, params: { id: scan[:id] }) }.to raise_error(CanCan::AccessDenied)

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     destination { 'ART' }
     item_title { 'Title of MediatedPage 1234' }
     needed_date { Time.zone.today }
-    association :user, factory: :sequence_webauth_user
+    association :user, factory: :sequence_sso_user
 
     after(:build) do |request|
       class << request
@@ -28,7 +28,7 @@ FactoryBot.define do
     destination { 'EARTH-SCI' }
     item_title { 'Title of MediatedPage 1234' }
     needed_date { Time.zone.today }
-    association :user, factory: :sequence_webauth_user
+    association :user, factory: :sequence_sso_user
   end
 
   factory :mediated_page_with_single_holding, parent: :mediated_page do
@@ -38,7 +38,7 @@ FactoryBot.define do
     destination { 'ART' }
     needed_date { Time.zone.today }
     request_comment { long_comment }
-    association :user, factory: :sequence_webauth_user
+    association :user, factory: :sequence_sso_user
 
     after(:build) do |request|
       class << request
@@ -56,7 +56,7 @@ FactoryBot.define do
     destination { 'ART' }
     needed_date { Time.zone.today }
     request_comment { long_comment }
-    association :user, factory: :sequence_webauth_user
+    association :user, factory: :sequence_sso_user
 
     after(:build) do |request|
       class << request
@@ -72,7 +72,7 @@ FactoryBot.define do
     origin_location { 'ARTLCKL' }
     destination { 'ART' }
     needed_date { Time.zone.today }
-    association :user, factory: :sequence_webauth_user
+    association :user, factory: :sequence_sso_user
 
     after(:build) do |request|
       class << request

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :superadmin_user, class: 'User' do
-    webauth { 'super-admin' }
+    sunetid { 'super-admin' }
     email { 'super-admin@stanford.edu' }
     after(:build) do |user|
       user.ldap_group_string = 'FAKE-TEST-SUPER-ADMIN-GROUP'
@@ -10,38 +10,38 @@ FactoryBot.define do
   end
 
   factory :site_admin_user, class: 'User' do
-    webauth { 'site-admin' }
+    sunetid { 'site-admin' }
     after(:build) do |user|
       user.ldap_group_string = 'FAKE-TEST-SITE-ADMIN-GROUP'
     end
   end
 
   factory :art_origin_admin_user, class: 'User' do
-    webauth { 'art-admin' }
+    sunetid { 'art-admin' }
     after(:build) do |user|
       user.ldap_group_string = 'ART-TEST-LDAP-GROUP'
     end
   end
 
   factory :page_mp_origin_admin_user, class: 'User' do
-    webauth { 'page-mp-admin' }
+    sunetid { 'page-mp-admin' }
     after(:build) do |user|
       user.ldap_group_string = 'PAGE-MP-TEST-LDAP-GROUP'
     end
   end
 
-  factory :webauth_user, class: 'User' do
-    webauth { 'some-webauth-user' }
-    email { 'some-webauth-user@stanford.edu' }
+  factory :sso_user, class: 'User' do
+    sunetid { 'some-sso-user' }
+    email { 'some-sso-user@stanford.edu' }
   end
 
-  factory :sequence_webauth_user, class: 'User' do
-    sequence(:webauth) { |n| "some-webauth-user-#{n}" }
-    sequence(:email) { |n| "some-webauth-user-#{n}@stanford.edu" }
+  factory :sequence_sso_user, class: 'User' do
+    sequence(:sunetid) { |n| "some-sso-user-#{n}" }
+    sequence(:email) { |n| "some-sso-user-#{n}@stanford.edu" }
   end
 
   factory :scan_eligible_user, class: 'User' do
-    webauth { 'some-eligible-user' }
+    sunetid { 'some-eligible-user' }
     email { 'some-eligible-user@stanford.edu' }
 
     after(:build) do |user|
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
   end
 
-  factory :non_webauth_user, class: 'User' do
+  factory :non_sso_user, class: 'User' do
     name { 'Jane Stanford' }
     email { 'jstanford@stanford.edu' }
   end

--- a/spec/features/admin_comment_spec.rb
+++ b/spec/features/admin_comment_spec.rb
@@ -10,7 +10,7 @@ describe 'Admin Comments', js: true do
     stub_current_user(user)
     create(
       :mediated_page_with_holdings,
-      user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+      user: create(:non_sso_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
       barcodes: %w(34567890),
       ad_hoc_items: ['ABC 123'],
       created_at: Time.zone.now + 1.day

--- a/spec/features/admin_requests_spec.rb
+++ b/spec/features/admin_requests_spec.rb
@@ -8,7 +8,7 @@ describe 'Viewing all requests' do
       before do
         stub_current_user(create(:superadmin_user))
         create(:page, item_id: 2345, item_title: 'Fourth symphony. [Op. 51].',
-                      user: User.create(webauth: 'jstanford', email: 'jstanford@stanford.edu'))
+                      user: User.create(sunetid: 'jstanford', email: 'jstanford@stanford.edu'))
         create(:page, item_id: 2346,
                       item_title: 'An American in Paris',
                       origin: 'SAL-NEWARK',

--- a/spec/features/authorization_spec.rb
+++ b/spec/features/authorization_spec.rb
@@ -15,12 +15,12 @@ describe 'User Authorization' do
 
   describe 'logout' do
     before do
-      stub_current_user(create(:webauth_user))
+      stub_current_user(create(:sso_user))
     end
 
     it 'is present in the home page' do
       visit root_path
-      expect(page).to have_link 'some-webauth-user: Logout'
+      expect(page).to have_link 'some-sso-user: Logout'
       # We don't test clicking on the link because Shibboleth provides the logout page
     end
   end

--- a/spec/features/create_aeon_page_request_spec.rb
+++ b/spec/features/create_aeon_page_request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Creating an Aeon request', js: true do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:api_json) { build(:special_collections_single_holding) }
 
   before do

--- a/spec/features/create_hold_recall_spec.rb
+++ b/spec/features/create_hold_recall_spec.rb
@@ -7,7 +7,7 @@ describe 'Creating a hold recall request' do
     stub_searchworks_api_json(build(:sal3_holdings))
   end
 
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   pending 'by an anonmyous user', js: true do
     it 'requires the library id field' do
@@ -48,7 +48,7 @@ describe 'Creating a hold recall request' do
     end
   end
 
-  describe 'by a webauth user' do
+  describe 'by a SSO user' do
     before { stub_current_user(user) }
 
     it 'is possible without filling in any user information' do

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Creating a mediated page request' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   before do
     allow_any_instance_of(PagingSchedule::Scheduler).to receive(:valid?).with(anything).and_return(true)
@@ -68,7 +68,7 @@ describe 'Creating a mediated page request' do
     end
   end
 
-  describe 'by a webauth user' do
+  describe 'by a SSO user' do
     before { stub_current_user(user) }
 
     it 'is possible without filling in any user information' do

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Creating a page request' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   describe 'item information' do
     it 'displays the items title' do
@@ -57,7 +57,7 @@ describe 'Creating a page request' do
     end
   end
 
-  describe 'by a webauth user' do
+  describe 'by a SSO user' do
     before { stub_current_user(user) }
 
     it 'is possible without filling in any user information' do
@@ -98,7 +98,7 @@ describe 'Creating a page request' do
       expect(current_url).to eq successful_page_url(Page.last)
       expect_to_be_on_success_page
       expect(page).to have_content(
-        'We\'ll send you an email at some-webauth-user@stanford.edu when processing is complete.'
+        'We\'ll send you an email at some-sso-user@stanford.edu when processing is complete.'
       )
     end
   end

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -13,7 +13,7 @@ describe 'Create Scan Request' do
   end
 
   it 'does not display a destination pickup' do
-    stub_current_user(create(:webauth_user))
+    stub_current_user(create(:sso_user))
 
     visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
 
@@ -22,14 +22,14 @@ describe 'Create Scan Request' do
   end
 
   it 'does not include the highlighted section around destination and needed date' do
-    stub_current_user(create(:webauth_user))
+    stub_current_user(create(:sso_user))
 
     visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
 
     expect(page).not_to have_css('.alert-warning.destination-note-callout')
   end
 
-  describe 'by an eligible webauth user' do
+  describe 'by an eligible SSO user' do
     before do
       stub_current_user(create(:scan_eligible_user))
     end
@@ -42,7 +42,7 @@ describe 'Create Scan Request' do
     end
   end
 
-  describe 'by non webauth user' do
+  describe 'by non SSO user' do
     it 'provides a link to page the item' do
       visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
 

--- a/spec/features/eligibility_validation_spec.rb
+++ b/spec/features/eligibility_validation_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Eligibility Validation' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   before do
     expect(Settings.features).to receive(:validate_eligibility).and_return(true)

--- a/spec/features/honey_pot_field_spec.rb
+++ b/spec/features/honey_pot_field_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Honey Pot Fields' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   before { stub_current_user(user) }
 

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Item Selector' do
   before do
-    stub_current_user(create(:webauth_user))
+    stub_current_user(create(:sso_user))
   end
 
   describe 'for single items' do

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -14,7 +14,7 @@ describe 'Mark As Complete', js: true do
     let!(:mediated_page) do
       create(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+        user: create(:non_sso_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
         barcodes: %w(34567890),
         ad_hoc_items: ['ABC 123'],
         created_at: Time.zone.now + 1.day
@@ -70,7 +70,7 @@ describe 'Mark As Complete', js: true do
     let!(:mediated_page) do
       create(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+        user: create(:non_sso_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
         barcodes: %w(34567890),
         approval_status: :marked_as_done,
         ad_hoc_items: ['ABC 123'],

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -15,20 +15,20 @@ describe 'Mediation table', js: true do
       # create some pending requests
       create(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user),
+        user: create(:non_sso_user),
         barcodes: %w(12345678 23456789),
         created_at: Time.zone.now - 1.day,
         needed_date: Time.zone.now + 3.days
       )
       create(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Joe Doe ', email: 'joedoe@example.com'),
+        user: create(:non_sso_user, name: 'Joe Doe ', email: 'joedoe@example.com'),
         barcodes: %w(34567890 45678901),
         needed_date: Time.zone.now + 2.days
       )
       create(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
+        user: create(:non_sso_user, name: 'Jim Doe ', email: 'jimdoe@example.com'),
         barcodes: %w(34567890),
         ad_hoc_items: ['ABC 123'],
         created_at: Time.zone.now + 1.day,
@@ -43,7 +43,7 @@ describe 'Mediation table', js: true do
       # create some completed requests (don't validate, since validation disallows needed dates which fall in the past)
       build(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Bob Doe', email: 'bobdoe@example.com'),
+        user: create(:non_sso_user, name: 'Bob Doe', email: 'bobdoe@example.com'),
         barcodes: %w(12345678 23456789),
         created_at: Time.zone.now - 7.days,
         needed_date: Time.zone.now - 2.days,
@@ -51,7 +51,7 @@ describe 'Mediation table', js: true do
       ).save(validate: false)
       build(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Alice Doe ', email: 'alicedoe@example.com'),
+        user: create(:non_sso_user, name: 'Alice Doe ', email: 'alicedoe@example.com'),
         barcodes: %w(12345678 23456789),
         created_at: Time.zone.now - 5.days,
         needed_date: Time.zone.now - 3.days,
@@ -59,7 +59,7 @@ describe 'Mediation table', js: true do
       ).save(validate: false)
       build(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Mal Doe ', email: 'maldoe@example.com'),
+        user: create(:non_sso_user, name: 'Mal Doe ', email: 'maldoe@example.com'),
         barcodes: %w(34567890 45678901),
         created_at: Time.zone.now - 3.days,
         needed_date: nil,
@@ -67,7 +67,7 @@ describe 'Mediation table', js: true do
       ).save(validate: false)
       build(
         :mediated_page_with_holdings,
-        user: create(:non_webauth_user, name: 'Eve Doe ', email: 'evedoe@example.com'),
+        user: create(:non_sso_user, name: 'Eve Doe ', email: 'evedoe@example.com'),
         barcodes: %w(34567890),
         ad_hoc_items: ['ABC 123'],
         created_at: Time.zone.now - 2.days,
@@ -301,17 +301,17 @@ describe 'Mediation table', js: true do
   end
 
   context 'contact email' do
-    context 'for webauth users that do not have their email address previously set by LDAP' do
+    context 'for SSO users that do not have their email address previously set by LDAP' do
       before do
         stub_current_user(create(:superadmin_user))
         create(
           :mediated_page_with_holdings,
-          user: create(:webauth_user, webauth: 'no-email-user', email: nil),
+          user: create(:sso_user, sunetid: 'no-email-user', email: nil),
           barcodes: %w(12345678 23456789)
         )
       end
 
-      it 'derives the email address from their webauth' do
+      it 'derives the email address from their sunetid' do
         visit admin_path('ART')
 
         within(first('[data-mediate-request]')) do
@@ -470,7 +470,7 @@ describe 'Mediation table', js: true do
     let!(:request) do
       build(
         :page_mp_mediated_page,
-        user: create(:non_webauth_user, name: 'Joe Doe ', email: 'joedoe@example.com'),
+        user: create(:non_sso_user, name: 'Joe Doe ', email: 'joedoe@example.com'),
         barcodes: %w(12345678 87654321)
       )
     end

--- a/spec/features/modal_layout_spec.rb
+++ b/spec/features/modal_layout_spec.rb
@@ -12,7 +12,7 @@ describe 'Modal Layout' do
   end
 
   it 'is used when the modal param is passed by the form and redirects' do
-    stub_current_user(create(:webauth_user))
+    stub_current_user(create(:sso_user))
     visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS', modal: true)
 
     expect(page).not_to have_css('#su-wrap')

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -34,7 +34,7 @@ describe 'Paging Schedule' do
 
   describe 'Estimated delivery', js: true do
     before do
-      stub_current_user(create(:webauth_user))
+      stub_current_user(create(:sso_user))
       stub_searchworks_api_json(build(:sal3_holdings))
     end
 

--- a/spec/features/remote_user_confirmation_spec.rb
+++ b/spec/features/remote_user_confirmation_spec.rb
@@ -3,16 +3,16 @@
 require 'rails_helper'
 
 describe 'Remote user confirmation' do
-  context 'for webauth users' do
+  context 'for SSO users' do
     it 'is not rendered' do
-      stub_current_user(create(:webauth_user))
+      stub_current_user(create(:sso_user))
       visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
 
       expect(page).not_to have_css('#remote-ip-check-overlay')
     end
   end
 
-  context 'for non-webauth users' do
+  context 'for non-SSO users' do
     before { stub_current_user(user) }
 
     context 'that are in the configured IP ranges' do

--- a/spec/features/requests_public_notes_spec.rb
+++ b/spec/features/requests_public_notes_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Public Notes', js: true do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   before do
     allow_any_instance_of(PagingSchedule::Scheduler).to receive(:valid?).with(anything).and_return(true)

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -6,7 +6,7 @@ describe 'Send Request Buttons' do
   before { stub_searchworks_api_json(build(:single_holding)) }
 
   describe 'as a Stanford user', js: true do
-    before { stub_current_user(create(:webauth_user)) }
+    before { stub_current_user(create(:sso_user)) }
 
     it 'allows submit' do
       visit new_page_path(item_id: '1234', origin: 'GREEN', origin_location: 'STACKS')
@@ -54,7 +54,7 @@ describe 'Send Request Buttons' do
   end
 
   describe 'for HOPKINS' do
-    it 'allows to send request via WebAuth login or a SUNet ID' do
+    it 'allows to send request via SSO login or a SUNet ID' do
       visit new_page_path(item_id: '1234', origin: 'HOPKINS', origin_location: 'STACKS')
       expect(page).to have_css('button', text: /Send request.*login with SUNet ID/)
       expect(page).to have_css('a', text: 'I don\'t have a SUNet ID')
@@ -67,7 +67,7 @@ describe 'Send Request Buttons' do
       visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
     end
 
-    it 'only allows to send request via WebAuth login' do
+    it 'only allows to send request via SSO login' do
       expect(page).to have_css('button', text: /Send request.*login with SUNet ID/)
       expect(page).not_to have_css('a', text: 'I don\'t have a SUNet ID')
     end

--- a/spec/features/status_page_spec.rb
+++ b/spec/features/status_page_spec.rb
@@ -10,7 +10,7 @@ describe 'Status Page' do
   end
 
   describe 'by webuath users' do
-    let(:user) { create(:webauth_user) }
+    let(:user) { create(:sso_user) }
 
     it 'is available' do
       visit status_mediated_page_path(request)
@@ -42,7 +42,7 @@ describe 'Status Page' do
   end
 
   describe 'status page title contains item title' do
-    let(:user) { create(:webauth_user) }
+    let(:user) { create(:sso_user) }
 
     it 'page' do
       my_req = create(:page, user: user)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -68,14 +68,14 @@ describe ApplicationHelper do
       allow(helper).to receive(:current_user).and_return(user)
     end
 
-    let(:user) { build(:webauth_user, name: 'Some Body') }
+    let(:user) { build(:sso_user, name: 'Some Body') }
 
     it 'includes the screen reader context' do
       expect(helper.render_user_information).to have_selector '.sr-only', text: 'You are logged in as'
     end
 
     it 'includes the email for the user' do
-      expect(helper.render_user_information).to have_content 'some-webauth-user@stanford.edu'
+      expect(helper.render_user_information).to have_content 'some-sso-user@stanford.edu'
     end
   end
 end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -13,8 +13,8 @@ describe RequestsHelper do
       )
     end
 
-    context 'for a webauth user' do
-      let(:user) { create(:webauth_user, ip_address: Settings.stanford_ips.singletons.first) }
+    context 'for a SSO user' do
+      let(:user) { create(:sso_user, ip_address: Settings.stanford_ips.singletons.first) }
 
       it 'is falsey regardless of location' do
         expect(helper).not_to be_render_remote_user_check
@@ -103,16 +103,16 @@ describe RequestsHelper do
   end
 
   describe 'requester info' do
-    let(:webauth_user) { User.create(webauth: 'jstanford', email: 'jstanford@stanford.edu') }
-    let(:non_webauth_user) { User.create(name: 'Joe', email: 'joe@xyz.com') }
+    let(:sso_user) { User.create(sunetid: 'jstanford', email: 'jstanford@stanford.edu') }
+    let(:non_sso_user) { User.create(name: 'Joe', email: 'joe@xyz.com') }
     let(:library_id_user) { User.create(library_id: '123456') }
 
-    it 'constructs requester info for webauth user' do
-      expect(requester_info(webauth_user)).to eq '<a href="mailto:jstanford@stanford.edu">jstanford@stanford.edu</a>'
+    it 'constructs requester info for SSO user' do
+      expect(requester_info(sso_user)).to eq '<a href="mailto:jstanford@stanford.edu">jstanford@stanford.edu</a>'
     end
 
-    it 'constructs requester info for non-webauth user' do
-      expect(requester_info(non_webauth_user)).to eq '<a href="mailto:joe@xyz.com">Joe (joe@xyz.com)</a>'
+    it 'constructs requester info for non-SSO user' do
+      expect(requester_info(non_sso_user)).to eq '<a href="mailto:joe@xyz.com">Joe (joe@xyz.com)</a>'
     end
 
     it 'constructs requester info for a library id user' do

--- a/spec/jobs/submit_borrow_direct_request_job_spec.rb
+++ b/spec/jobs/submit_borrow_direct_request_job_spec.rb
@@ -74,7 +74,7 @@ describe SubmitBorrowDirectRequestJob, type: :job do
     end
 
     context 'when the item is requestable and the request succeeds' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       before do
         expect(borrow_direct_item).to receive_messages(

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
       Sidekiq.logger.level = Logger::UNKNOWN
     end
 
-    let(:user) { build(:non_webauth_user) }
+    let(:user) { build(:non_sso_user) }
     let(:request) { create(:page_with_holdings, user: user) }
 
     describe '#perform' do
@@ -42,7 +42,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
   describe SubmitSymphonyRequestJob::SymWsCommand do
     subject { described_class.new(request, symphony_client: mock_client) }
 
-    let(:user) { build(:non_webauth_user) }
+    let(:user) { build(:non_sso_user) }
     let(:request) { scan }
     let(:scan) { create(:scan_with_holdings_barcodes, user: user) }
     let(:mock_client) { instance_double(SymphonyClient) }
@@ -75,7 +75,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
       end
 
       context 'for a patron with a library id' do
-        let(:user) { build(:webauth_user) }
+        let(:user) { build(:sso_user) }
         let(:request) { create(:page_with_holdings, user: user) }
         let(:patron) do
           Patron.new({
@@ -103,7 +103,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
       end
 
       context 'for a sunetid patron without a library id' do
-        let(:user) { build(:webauth_user) }
+        let(:user) { build(:sso_user) }
         let(:request) { create(:page_with_holdings, user: user) }
 
         before do
@@ -114,7 +114,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
           allow(user).to receive(:patron).and_return(nil)
           expect(mock_client).to receive(:place_hold) do |**params|
             expect(params).to include(
-              comment: ' some-webauth-user@stanford.edu',
+              comment: ' some-sso-user@stanford.edu',
               patron_barcode: 'HOLD@AR',
               recall_status: 'STANDARD'
             )

--- a/spec/mailers/mediation_mailer_spec.rb
+++ b/spec/mailers/mediation_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe MediationMailer do
   describe 'mediator_notification' do
-    let(:user) { build(:non_webauth_user) }
+    let(:user) { build(:non_sso_user) }
     let(:request) { create(:mediated_page, user: user) }
     let(:mediator_contact_info) { { request.origin => { email: 'someone@example.com' } } }
     before do

--- a/spec/mailers/picklist_mailer_spec.rb
+++ b/spec/mailers/picklist_mailer_spec.rb
@@ -48,11 +48,11 @@ describe PicklistMailer do
       allow(SymphonyClient).to receive(:new).and_return(mock_client)
       allow(SubmitSymphonyRequestJob).to receive(:perform_now)
 
-      create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
-      b = create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+      create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
+      b = create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
       b.item_statuses.to_a.first.approve!(user, Time.zone.now - 5.days)
       b.item_statuses.to_a.last.approve!(user, Time.zone.now - 1.day)
-      c = create(:mediated_page_with_holdings, user: create(:non_webauth_user), barcodes: %w(12345678 23456789))
+      c = create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
       c.item_statuses.first.approve!(user, Time.zone.now - 1.day)
     end
 

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe RequestStatusMailer do
   describe '#request_status' do
-    let(:user) { build(:non_webauth_user) }
+    let(:user) { build(:non_sso_user) }
     let(:request) { create(:page, user: user) }
     let(:mailer_method) { :request_status_for_page }
     let(:mail) { described_class.send(mailer_method, request) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -71,7 +71,7 @@ describe Ability do
     it { is_expected.not_to be_able_to(:create, admin_comment) }
 
     describe 'who fills out a name and email' do
-      let(:user) { build(:non_webauth_user) }
+      let(:user) { build(:non_sso_user) }
       let(:page) { create(:page, user: user) }
       let(:mediated_page) { create(:mediated_page, user: user) }
 
@@ -105,8 +105,8 @@ describe Ability do
     end
   end
 
-  describe 'a webauth user' do
-    let(:user) { create(:webauth_user) }
+  describe 'a SSO user' do
+    let(:user) { create(:sso_user) }
 
     it { is_expected.to be_able_to(:create, hold_recall) }
     it { is_expected.to be_able_to(:create, mediated_page) }
@@ -137,7 +137,7 @@ describe Ability do
     describe 'who did not create the requst' do
       before do
         request_objects.each do |object|
-          allow(object).to receive_messages(user_id: User.create(webauth: 'some-other-user').id)
+          allow(object).to receive_messages(user_id: User.create(sunetid: 'some-other-user').id)
         end
       end
 
@@ -200,7 +200,7 @@ describe Ability do
   end
 
   describe 'an origin library admin' do
-    let(:user) { create(:webauth_user) }
+    let(:user) { create(:sso_user) }
 
     before do
       allow(user).to receive_messages(ldap_groups: ['FAKE-ORIGIN-LIBRARY-TEST-LDAP-GROUP'])
@@ -228,7 +228,7 @@ describe Ability do
   end
 
   describe 'an origin location admin' do
-    let(:user) { create(:webauth_user) }
+    let(:user) { create(:sso_user) }
 
     before do
       allow(user).to receive_messages(ldap_groups: ['FAKE-ORIGIN-LOCATION-TEST-LDAP-GROUP'])

--- a/spec/models/illiad_request_spec.rb
+++ b/spec/models/illiad_request_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe IlliadRequest do
   subject { described_class.new(scan) }
 
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:scan) { create(:scan_with_holdings_barcodes, user: user) }
 
   describe 'illiad request json' do
     it 'includes the correct illiad routing info' do
-      expect(subject.illiad_transaction_request).to include('"Username":"some-webauth-user"')
+      expect(subject.illiad_transaction_request).to include('"Username":"some-sso-user"')
       expect(subject.illiad_transaction_request).to include('"ProcessType":"Borrowing"')
       expect(subject.illiad_transaction_request).to include('"RequestType":"Article"')
       expect(subject.illiad_transaction_request).to include('"SpecIns":"Scan and Deliver Request"')

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -349,10 +349,10 @@ describe Request do
     end
 
     describe 'users' do
-      it 'handles webauth users (w/o emails) correctly' do
-        User.create!(webauth: 'a-webauth-user')
-        webauth_user = User.new(webauth: 'current-webauth-user')
-        allow_any_instance_of(described_class).to receive_messages(user: webauth_user)
+      it 'handles SSO users (w/o emails) correctly' do
+        User.create!(sunetid: 'a-sso-user')
+        sso_user = User.new(sunetid: 'current-sso-user')
+        allow_any_instance_of(described_class).to receive_messages(user: sso_user)
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
@@ -539,7 +539,7 @@ describe Request do
     end
 
     context 'for a normal request' do
-      let(:user) { create(:non_webauth_user) }
+      let(:user) { create(:non_sso_user) }
 
       it 'goes to the user email address' do
         expect(subject.notification_email_address).to eq user.email_address
@@ -562,7 +562,7 @@ describe Request do
     end
 
     context 'for proxy requests without a notification email' do
-      let(:user) { create(:non_webauth_user) }
+      let(:user) { create(:non_sso_user) }
       let(:group) { instance_double(Group, email: '') }
 
       before do
@@ -599,7 +599,7 @@ describe Request do
     end
 
     describe 'for everybody else' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'sends an approval status email' do
         expect do

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -37,7 +37,7 @@ describe HoldRecall do
     end
 
     describe 'for everybody else' do
-      let(:subject) { create(:hold_recall, user: create(:webauth_user)) }
+      let(:subject) { create(:hold_recall, user: create(:sso_user)) }
 
       it 'sends an approval status email' do
         expect do

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe MediatedPage do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   before do
     allow_any_instance_of(PagingSchedule::Scheduler).to receive(:valid?).with(anything).and_return(true)
@@ -167,7 +167,7 @@ describe MediatedPage do
     end
 
     it 'adds the user email address to the token' do
-      subject.user = build(:non_webauth_user)
+      subject.user = build(:non_sso_user)
       expect(subject.to_token(version: 1)).to match(/jstanford@stanford.edu$/)
     end
   end

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -9,7 +9,7 @@ describe Page do
     end
 
     it 'adds the user email address to the token' do
-      subject.user = build(:non_webauth_user)
+      subject.user = build(:non_sso_user)
       expect(subject.to_token(version: 1)).to match(/jstanford@stanford.edu$/)
     end
   end
@@ -104,7 +104,7 @@ describe Page do
     end
 
     describe 'for everybody else' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       it 'sends an approval status email' do
         expect do

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -80,7 +80,7 @@ describe Scan do
     end
 
     describe 'for everybody else' do
-      let(:subject) { create(:scan, user: create(:webauth_user)) }
+      let(:subject) { create(:scan, user: create(:sso_user)) }
 
       it 'sends an approval status email' do
         expect do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 describe User do
   describe 'validations' do
-    it 'onlies allow unique webauth ids' do
-      described_class.create!(webauth: 'some-user')
+    it 'onlies allow unique sunetids' do
+      described_class.create!(sunetid: 'some-user')
       expect do
-        described_class.create!(webauth: 'some-user')
+        described_class.create!(sunetid: 'some-user')
       end.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
@@ -28,9 +28,9 @@ describe User do
   end
 
   describe '#email_address' do
-    describe 'for webauth users' do
+    describe 'for SSO users' do
       before do
-        subject.webauth = 'jstanford'
+        subject.sunetid = 'jstanford'
       end
 
       it 'returns the email address set by the email attribute' do
@@ -45,14 +45,14 @@ describe User do
 
         it 'Notifies the exception handling service' do
           expect(Honeybadger).to receive(:notify).with(
-            'Webauth user record being created without a valid email address. Using jstanford@stanford.edu instead.'
+            'SSO User being created without an email address. Using jstanford@stanford.edu instead.'
           )
           expect(subject.email_address).to eq 'jstanford@stanford.edu'
         end
       end
     end
 
-    describe 'for non-webauth users' do
+    describe 'for non-SSO users' do
       it 'returns the user email address' do
         subject.name = 'Jane Stanford'
         subject.email = 'jstanford@example.com'
@@ -69,16 +69,16 @@ describe User do
   end
 
   describe '#to_email_string' do
-    describe 'for webauth users' do
+    describe 'for SSO users' do
       it 'is their Stanford email address' do
         subject.name = 'Jane Stanford'
-        subject.webauth = 'jstanford'
+        subject.sunetid = 'jstanford'
         subject.email = 'jstanford@stanford.edu'
         expect(subject.to_email_string).to eq 'Jane Stanford (jstanford@stanford.edu)'
       end
     end
 
-    describe 'for non-webauth users' do
+    describe 'for non-SSO users' do
       it 'is their name plus their email in parenthesis' do
         subject.name = 'Jane Stanford'
         subject.email = 'jstanford@stanford.edu'
@@ -88,7 +88,7 @@ describe User do
 
     describe 'for users without a name' do
       it 'justs be their email address' do
-        subject.webauth = 'jstanford'
+        subject.sunetid = 'jstanford'
         subject.email = 'jstanford@stanford.edu'
         expect(subject.to_email_string).to eq 'jstanford@stanford.edu'
       end
@@ -102,14 +102,14 @@ describe User do
     end
   end
 
-  describe '#webauth_user?' do
-    it 'returns false when the user has no WebAuth attribute' do
-      expect(subject).not_to be_webauth_user
+  describe '#sso_user?' do
+    it 'returns false when the user has no sunetid attribute' do
+      expect(subject).not_to be_sso_user
     end
 
-    it 'returns true when the user has a WebAuth attribute' do
-      subject.webauth = 'WebAuth User'
-      expect(subject).to be_webauth_user
+    it 'returns true when the user has a sunetid attribute' do
+      subject.sunetid = 'SSO user'
+      expect(subject).to be_sso_user
     end
   end
 

--- a/spec/requests/admin_comments_requests_spec.rb
+++ b/spec/requests/admin_comments_requests_spec.rb
@@ -14,9 +14,9 @@ describe 'AdminComments' do
 
   describe '#create' do
     context 'when successful' do
-      it "merges the current user's webauth into the persisted comment as the commenter" do
+      it "merges the current user's sunetid into the persisted comment as the commenter" do
         post(url, params: { admin_comment: { comment: 'This is a comment' } }, headers: headers)
-        expect(AdminComment.last.commenter).to eq user.webauth
+        expect(AdminComment.last.commenter).to eq user.sunetid
       end
 
       context 'html response' do
@@ -65,7 +65,7 @@ describe 'AdminComments' do
   end
 
   context 'by a user who cannot add admin comments' do
-    let(:user) { create(:webauth_user) }
+    let(:user) { create(:sso_user) }
 
     it 'raises an access denied error' do
       expect { post(url, params: { admin_comment: { comment: 'A comment' } }) }.to raise_error(CanCan::AccessDenied)

--- a/spec/services/cdl_checkout_spec_spec.rb
+++ b/spec/services/cdl_checkout_spec_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CdlCheckout do
   subject { described_class.new('druid', user) }
 
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:catalog_info) do
     instance_double(CatalogInfo,
                     callkey: 'xyz',
@@ -123,7 +123,7 @@ RSpec.describe CdlCheckout do
       expect(symphony_client).to receive(:update_hold).and_return({})
 
       payload = subject.process_checkout('abc123')
-      expect(payload[:token]).to include sub: user.webauth
+      expect(payload[:token]).to include sub: user.sunetid
     end
   end
 end

--- a/spec/views/application/_item_selector.html.erb_spec.rb
+++ b/spec/views/application/_item_selector.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'application/_item_selector.html.erb' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
 
   before do
     without_partial_double_verification do

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'requests/status.html.erb' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:request) { create(:page, user: user) }
 
   before do

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'requests/success.html.erb' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:request) { create(:page, user: user) }
 
   before do
@@ -45,17 +45,17 @@ describe 'requests/success.html.erb' do
   end
 
   describe 'user information' do
-    describe 'for webauth users' do
-      let(:user) { create(:webauth_user) }
+    describe 'for SSO users' do
+      let(:user) { create(:sso_user) }
 
       it 'gives their stanford-email address' do
         render
-        expect(rendered).to have_content('some-webauth-user@stanford.edu')
+        expect(rendered).to have_content('some-sso-user@stanford.edu')
       end
     end
 
-    describe 'for non-webauth useres' do
-      let(:user) { create(:non_webauth_user) }
+    describe 'for non-SSO useres' do
+      let(:user) { create(:non_sso_user) }
 
       it 'gives their email' do
         render
@@ -66,7 +66,7 @@ describe 'requests/success.html.erb' do
 
   describe 'notification information' do
     context 'for a normal request made by a sponsor of a proxy group' do
-      let(:user) { create(:webauth_user) }
+      let(:user) { create(:sso_user) }
 
       before do
         allow(user).to receive(:sponsor?).and_return(true)
@@ -94,20 +94,20 @@ describe 'requests/success.html.erb' do
       end
     end
 
-    context 'for webauth users' do
-      let(:user) { create(:webauth_user) }
+    context 'for SSO users' do
+      let(:user) { create(:sso_user) }
 
       it 'indicates an email will be sent' do
         render
         expect(rendered).to include user.email_address
         expect(rendered).to include(
-          'We\'ll send you an email at <strong>some-webauth-user@stanford.edu</strong> when processing is complete.'
+          'We\'ll send you an email at <strong>some-sso-user@stanford.edu</strong> when processing is complete.'
         )
       end
     end
 
     context 'for name + email users' do
-      let(:user) { create(:non_webauth_user) }
+      let(:user) { create(:non_sso_user) }
 
       it 'indicates an email will be sent' do
         render

--- a/spec/views/scans/success.html.erb_spec.rb
+++ b/spec/views/scans/success.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'scans/success.html.erb' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:request) { create(:scan, user: user) }
 
   before do

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'shared/_request_status_information.html.erb' do
-  let(:user) { create(:webauth_user) }
+  let(:user) { create(:sso_user) }
   let(:request) { create(:scan, user: user) }
 
   before do

--- a/spec/views/shared/_top_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_top_navbar.html.erb_spec.rb
@@ -17,14 +17,14 @@ describe 'shared/_top_navbar.html.erb' do
   end
 
   describe 'logout link' do
-    let(:user) { create(:webauth_user) }
+    let(:user) { create(:sso_user) }
 
     it 'has a logout link if there is a user' do
-      expect(rendered).to have_css('a', text: 'some-webauth-user: Logout')
+      expect(rendered).to have_css('a', text: 'some-sso-user: Logout')
     end
 
     it 'redirects users back to the home page of the app' do
-      expect(rendered).to have_css('a[href="/webauth/logout?referrer=%2F"]')
+      expect(rendered).to have_css('a[href="/sso/logout?referrer=%2F"]')
     end
   end
 end


### PR DESCRIPTION
* Rename User attribute and create migration
* Rename login path in routes.rb
* Rename fixtures and update tests

Fixes #1325

The overall approach for this was:
- the property a `User` has isn't called WebAuth; it's more accurate to call it "SUNet ID" (e.g. `budak` for me).
- the thing we ask people to do isn't called WebAuth anymore; it uses Shibboleth now. Instead of naming it that, just rename it to SSO (for single-sign-on) so we don't care about the particular technology/protocol involved.