### PR TITLE
Revert Aeon configuration temporarily

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -385,53 +385,17 @@ locations:
       email: 'brannerlibrary@stanford.edu'
 
 pageable:
-  # Libraries using Aeon
-  - library: ARS
-    locations:
-      - RECORDINGS
-    aeon: true
-    aeon_site: ARS
-  - library: EAST-ASIA
-    locations:
-      - LOCKED-STK
-      - LOCK-STK-O
-      - LOCK-CHN
-    item_types:
-      - LCKSTK
-    aeon: true
-    aeon_site: EASTASIA
+  # Mediated pages
+  # NOTE: Aeon temporarily disabled; see dev or test settings to restore
   - library: RUMSEYMAP
     pickup_libraries:
       - RUMSEYMAP
-    aeon: true
-    aeon_site: RUMSEY
+    mediated: true
   - library: SPEC-COLL
     pickup_libraries:
       - SPEC-COLL
-    aeon: true
-    aeon_site: SPECUA
-  - library: SAL
-    locations:
-      - L-PAGE-EA
-    item_types:
-      - NH-INHOUSE
-    aeon: true
-    aeon_site: EASTASIA
-  - library: SAL3
-    locations:
-      - PAGE-AS
-    item_types:
-      - NH-INHOUSE
-    aeon: true
-    aeon_site: ARS
-  - library: SAL3
-    locations:
-      - PAGE-EA
-    item_types:
-      - LCKSTK
-    aeon: true
-    aeon_site: EASTASIA
-  # Mediated pages
+    mediated: true
+    item_commentable: true
   - library: ART
     locations:
       - ARTLCKL

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,3 +7,224 @@ mailer_host: 'localhost:3000'
 
 cdl:
   enabled: true
+
+# paging configuration; remove once Aeon is re-enabled
+pageable:
+  # Libraries using Aeon
+  - library: ARS
+    locations:
+      - RECORDINGS
+    aeon: true
+    aeon_site: ARS
+  - library: EAST-ASIA
+    locations:
+      - LOCKED-STK
+      - LOCK-STK-O
+      - LOCK-CHN
+    item_types:
+      - LCKSTK
+    aeon: true
+    aeon_site: EASTASIA
+  - library: RUMSEYMAP
+    pickup_libraries:
+      - RUMSEYMAP
+    aeon: true
+    aeon_site: RUMSEY
+  - library: SPEC-COLL
+    pickup_libraries:
+      - SPEC-COLL
+    aeon: true
+    aeon_site: SPECUA
+  - library: SAL
+    locations:
+      - L-PAGE-EA
+    item_types:
+      - NH-INHOUSE
+    aeon: true
+    aeon_site: EASTASIA
+  - library: SAL3
+    locations:
+      - PAGE-AS
+    item_types:
+      - NH-INHOUSE
+    aeon: true
+    aeon_site: ARS
+  - library: SAL3
+    locations:
+      - PAGE-EA
+    item_types:
+      - LCKSTK
+    aeon: true
+    aeon_site: EASTASIA
+  # Mediated pages
+  - library: ART
+    locations:
+      - ARTLCKL
+      - ARTLCKL-R
+      - ARTLCKM
+      - ARTLCKM-R
+      - ARTLCKO
+      - ARTLCKO-R
+      - ARTLCKS
+      - ARTLCKS-R
+    pickup_libraries:
+      - ART
+    mediated: true
+  - locations:
+      - PAGE-MP
+    pickup_libraries:
+      - EARTH-SCI
+    mediated: true
+  - library: EDUCATION
+    locations:
+      - LOCKED-STK
+    pickup_libraries:
+      - SPEC-COLL
+    mediated: true
+  # Location-specific pickup libraries
+  - locations:
+      - PAGE-AR
+    pickup_libraries: ['ART', 'SPEC-COLL']
+  - locations:
+      - PAGE-AS
+    pickup_libraries: ['ARS']
+  - locations:
+      - PAGE-BI
+    pickup_libraries: ['BIOLOGY']
+  - locations:
+      - PAGE-BU
+    pickup_libraries: ['BUSINESS']
+  - locations:
+      - PAGE-CH
+    pickup_libraries: ['CHEMCHMENG']
+  - locations:
+      - PAGE-EA
+      - HY-PAGE-EA
+      - L-PAGE-EA
+      - ND-PAGE-EA
+    pickup_libraries: ['EAST-ASIA']
+  - locations:
+      - PAGE-ED
+    pickup_libraries: ['EDUCATION']
+  - locations:
+      - PAGE-EN
+    pickup_libraries: ['ENG']
+  - locations:
+      - PAGE-ES
+    pickup_libraries: ['EARTH-SCI']
+  - locations:
+      - PAGE-GR
+    pickup_libraries: ['GREEN']
+  - locations:
+      - PAGE-HA
+    pickup_libraries: ['HV-ARCHIVE']
+  - locations:
+      - PAGE-HP
+    pickup_libraries: ['GREEN', 'HOPKINS']
+  - locations:
+      - PAGE-IRON
+    pickup_libraries: ['BUSINESS']
+  - locations:
+      - PAGE-LP
+    pickup_libraries: ['MUSIC', 'MEDIA-MTXT']
+  - locations:
+      - PAGE-LW
+    pickup_libraries: ['LAW']
+  - locations:
+      - PAGE-MA
+    pickup_libraries: ['MATH-CS']
+  - locations:
+      - PAGE-MD
+    pickup_libraries: ['MUSIC', 'MEDIA-MTXT']
+  - locations:
+      - PAGE-MM
+    pickup_libraries: ['MEDIA-MTXT']
+  - locations:
+      - PAGE-MP
+    pickup_libraries: ['EARTH-SCI']
+  - locations:
+      - PAGE-MU
+    pickup_libraries: ['MUSIC']
+  - locations:
+      - PAGE-RM
+    pickup_libraries: ['RUMSEYMAP']
+  - locations:
+      - PAGE-SI
+    pickup_libraries: ['SCIENCE']
+  - locations:
+      - PAGE-SP
+    pickup_libraries: ['SPEC-COLL']
+  # Library-specific pickup libraries
+  - library: HV-ARCHIVE
+    pickup_libraries:
+      - HV-ARCHIVE
+  - library: ARS
+    pickup_libraries:
+      - ARS
+  # Other request configuration
+  - library: LAW
+    default_pickup_library: LAW
+  - library: MEDIA-MTXT
+    additional_pickup_libraries: ['MEDIA-MTXT']
+  - locations_match:
+      - ^EAL-SETS$
+      - ^EAL-STKS-
+    default_pickup_library: EAST-ASIA
+  - library: SAL-NEWARK
+    item_commentable: true
+  - library: SAL3
+  - library: SAL
+  - library: EDUCATION
+  - library:
+      - ART
+      - BUSINESS
+      - EARTH-SCI
+      - EAST-ASIA
+      - EDUCATION
+      - ENG
+      - GREEN
+      - MEDIA-MTXT
+      - MUSIC
+      - SCIENCE
+    locations:
+      - INPROCESS
+      - ON-ORDER
+  - library: BUSINESS
+    locations:
+      - BUS-CMC
+      - BUS-PER
+      - BUS-TEMP
+      - MEDIA
+      - STACKS
+  - library: EDUCATION
+    locations:
+      - CURRICULUM
+      - CURRSTOR
+      - MICROTEXT
+      - PERM-RES
+      - STACKS
+      - STORAGE
+  - library: GREEN
+    locations:
+      - LOCKED-STK
+  - library: LAW
+    locations:
+      - BASEMENT
+      - FOLIO-BAS
+      - LAW-CAREER
+      - LOCKED-STK
+      - NEWBOOKS
+      - OUT-TRAVEL
+      - PERM-RES
+      - STACKS-1
+      - VROOMAN
+      - VROOMAN-OV
+      - WELLNESS
+  - library: MEDIA-MTXT
+    location:
+      - MM-CDCAB
+      - MM-OVERSIZ
+      - MM-STACKS
+  # For any other library... we just allow the request through and hope for the best.. for now.
+  - default_pickup_library: GREEN
+    send_honeybadger_notice_if_used: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -50,3 +50,224 @@ symws:
 
 cdl:
   enabled: true
+
+# paging configuration; remove once Aeon is re-enabled
+pageable:
+  # Libraries using Aeon
+  - library: ARS
+    locations:
+      - RECORDINGS
+    aeon: true
+    aeon_site: ARS
+  - library: EAST-ASIA
+    locations:
+      - LOCKED-STK
+      - LOCK-STK-O
+      - LOCK-CHN
+    item_types:
+      - LCKSTK
+    aeon: true
+    aeon_site: EASTASIA
+  - library: RUMSEYMAP
+    pickup_libraries:
+      - RUMSEYMAP
+    aeon: true
+    aeon_site: RUMSEY
+  - library: SPEC-COLL
+    pickup_libraries:
+      - SPEC-COLL
+    aeon: true
+    aeon_site: SPECUA
+  - library: SAL
+    locations:
+      - L-PAGE-EA
+    item_types:
+      - NH-INHOUSE
+    aeon: true
+    aeon_site: EASTASIA
+  - library: SAL3
+    locations:
+      - PAGE-AS
+    item_types:
+      - NH-INHOUSE
+    aeon: true
+    aeon_site: ARS
+  - library: SAL3
+    locations:
+      - PAGE-EA
+    item_types:
+      - LCKSTK
+    aeon: true
+    aeon_site: EASTASIA
+  # Mediated pages
+  - library: ART
+    locations:
+      - ARTLCKL
+      - ARTLCKL-R
+      - ARTLCKM
+      - ARTLCKM-R
+      - ARTLCKO
+      - ARTLCKO-R
+      - ARTLCKS
+      - ARTLCKS-R
+    pickup_libraries:
+      - ART
+    mediated: true
+  - locations:
+      - PAGE-MP
+    pickup_libraries:
+      - EARTH-SCI
+    mediated: true
+  - library: EDUCATION
+    locations:
+      - LOCKED-STK
+    pickup_libraries:
+      - SPEC-COLL
+    mediated: true
+  # Location-specific pickup libraries
+  - locations:
+      - PAGE-AR
+    pickup_libraries: ['ART', 'SPEC-COLL']
+  - locations:
+      - PAGE-AS
+    pickup_libraries: ['ARS']
+  - locations:
+      - PAGE-BI
+    pickup_libraries: ['BIOLOGY']
+  - locations:
+      - PAGE-BU
+    pickup_libraries: ['BUSINESS']
+  - locations:
+      - PAGE-CH
+    pickup_libraries: ['CHEMCHMENG']
+  - locations:
+      - PAGE-EA
+      - HY-PAGE-EA
+      - L-PAGE-EA
+      - ND-PAGE-EA
+    pickup_libraries: ['EAST-ASIA']
+  - locations:
+      - PAGE-ED
+    pickup_libraries: ['EDUCATION']
+  - locations:
+      - PAGE-EN
+    pickup_libraries: ['ENG']
+  - locations:
+      - PAGE-ES
+    pickup_libraries: ['EARTH-SCI']
+  - locations:
+      - PAGE-GR
+    pickup_libraries: ['GREEN']
+  - locations:
+      - PAGE-HA
+    pickup_libraries: ['HV-ARCHIVE']
+  - locations:
+      - PAGE-HP
+    pickup_libraries: ['GREEN', 'HOPKINS']
+  - locations:
+      - PAGE-IRON
+    pickup_libraries: ['BUSINESS']
+  - locations:
+      - PAGE-LP
+    pickup_libraries: ['MUSIC', 'MEDIA-MTXT']
+  - locations:
+      - PAGE-LW
+    pickup_libraries: ['LAW']
+  - locations:
+      - PAGE-MA
+    pickup_libraries: ['MATH-CS']
+  - locations:
+      - PAGE-MD
+    pickup_libraries: ['MUSIC', 'MEDIA-MTXT']
+  - locations:
+      - PAGE-MM
+    pickup_libraries: ['MEDIA-MTXT']
+  - locations:
+      - PAGE-MP
+    pickup_libraries: ['EARTH-SCI']
+  - locations:
+      - PAGE-MU
+    pickup_libraries: ['MUSIC']
+  - locations:
+      - PAGE-RM
+    pickup_libraries: ['RUMSEYMAP']
+  - locations:
+      - PAGE-SI
+    pickup_libraries: ['SCIENCE']
+  - locations:
+      - PAGE-SP
+    pickup_libraries: ['SPEC-COLL']
+  # Library-specific pickup libraries
+  - library: HV-ARCHIVE
+    pickup_libraries:
+      - HV-ARCHIVE
+  - library: ARS
+    pickup_libraries:
+      - ARS
+  # Other request configuration
+  - library: LAW
+    default_pickup_library: LAW
+  - library: MEDIA-MTXT
+    additional_pickup_libraries: ['MEDIA-MTXT']
+  - locations_match:
+      - ^EAL-SETS$
+      - ^EAL-STKS-
+    default_pickup_library: EAST-ASIA
+  - library: SAL-NEWARK
+    item_commentable: true
+  - library: SAL3
+  - library: SAL
+  - library: EDUCATION
+  - library:
+      - ART
+      - BUSINESS
+      - EARTH-SCI
+      - EAST-ASIA
+      - EDUCATION
+      - ENG
+      - GREEN
+      - MEDIA-MTXT
+      - MUSIC
+      - SCIENCE
+    locations:
+      - INPROCESS
+      - ON-ORDER
+  - library: BUSINESS
+    locations:
+      - BUS-CMC
+      - BUS-PER
+      - BUS-TEMP
+      - MEDIA
+      - STACKS
+  - library: EDUCATION
+    locations:
+      - CURRICULUM
+      - CURRSTOR
+      - MICROTEXT
+      - PERM-RES
+      - STACKS
+      - STORAGE
+  - library: GREEN
+    locations:
+      - LOCKED-STK
+  - library: LAW
+    locations:
+      - BASEMENT
+      - FOLIO-BAS
+      - LAW-CAREER
+      - LOCKED-STK
+      - NEWBOOKS
+      - OUT-TRAVEL
+      - PERM-RES
+      - STACKS-1
+      - VROOMAN
+      - VROOMAN-OV
+      - WELLNESS
+  - library: MEDIA-MTXT
+    location:
+      - MM-CDCAB
+      - MM-OVERSIZ
+      - MM-STACKS
+  # For any other library... we just allow the request through and hope for the best.. for now.
+  - default_pickup_library: GREEN
+    send_honeybadger_notice_if_used: true


### PR DESCRIPTION
This reverts paging configuration to pre-Aeon site until Aeon libraries
are ready to go live. It keeps the Aeon configuration active in dev
and test settings so that tests will pass.
