### PR TITLE
Rename scss-lint to scss_lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,8 +106,8 @@ group :development, :test do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
 
-  # scss-lint will test the scss files to enfoce styles
-  gem 'scss-lint', require: false
+  # scss_lint will test the scss files to enfoce styles
+  gem 'scss_lint', require: false
 
   gem 'rails-controller-testing'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,9 +382,9 @@ GEM
       tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
-    scss-lint (0.38.0)
+    scss_lint (0.43.2)
       rainbow (~> 2.0)
-      sass (~> 3.4.1)
+      sass (~> 3.4.15)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -508,7 +508,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails (~> 5.0)
-  scss-lint
+  scss_lint
   selenium-webdriver
   sidekiq
   sidekiq-statistic


### PR DESCRIPTION
The maintainers changed the gem name to follow rubygems conventions