### PR TITLE
Keeps Sidekiq on version 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 gem 'net-smtp', require: false
 
 # Sidekiq is our background processing framework, run via Active Job
-gem 'sidekiq'
+gem 'sidekiq', '< 7' # Remain on v6 until Redis is updated to v7 on VMs
 
 gem 'whenever'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,8 +334,6 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.1)
     redis (4.5.1)
-    redis-client (0.10.0)
-      connection_pool
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -403,11 +401,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.0.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.9.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -523,7 +520,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss_lint
   selenium-webdriver
-  sidekiq
+  sidekiq (< 7)
   simplecov
   sqlite3
   sul_styles (>= 0.5.0)

--- a/spec/requests/sidekiq_requests_spec.rb
+++ b/spec/requests/sidekiq_requests_spec.rb
@@ -8,7 +8,7 @@ describe 'Sidekiq requests' do
   context 'with superadmin privileges' do
     it 'is successful' do
       allow(CurrentUser).to receive(:for).and_return(double(super_admin?: true))
-      expect { get(url) }.to raise_error(RedisClient::CannotConnectError)
+      expect { get(url) }.to raise_error(Redis::CannotConnectError)
     end
   end
 


### PR DESCRIPTION
This will unblock dependency updates and deploys until Redis is updated and we can update Sidekiq to version 7. See: https://github.com/sul-dlss/operations-tasks/issues/3210#issuecomment-1302508219