### PR TITLE
Implement BorrowDirect Reshare requests for hold recalls

### DIFF
--- a/app/jobs/submit_iplc_listener_job.rb
+++ b/app/jobs/submit_iplc_listener_job.rb
@@ -34,6 +34,7 @@ class SubmitIplcListenerJob < ApplicationJob
 
     request.borrow_direct_response_data = iplc_response.as_json
     request.via_borrow_direct = true
+    # We don't care if this save was successful or not, because if it went through the back-end service, then requests is no longer the source of truth for this.
     request.save
 
     request.send_approval_status!

--- a/app/jobs/submit_iplc_listener_job.rb
+++ b/app/jobs/submit_iplc_listener_job.rb
@@ -34,7 +34,8 @@ class SubmitIplcListenerJob < ApplicationJob
 
     request.borrow_direct_response_data = iplc_response.as_json
     request.via_borrow_direct = true
-    # We don't care if this save was successful or not, because if it went through the back-end service, then requests is no longer the source of truth for this.
+    # We don't care if this save was successful or not, because if it went through the back-end service,
+    # then requests is no longer the source of truth for this.
     request.save
 
     request.send_approval_status!

--- a/app/jobs/submit_iplc_listener_job.rb
+++ b/app/jobs/submit_iplc_listener_job.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+##
+# Background job to send requests to IPLC.
+# If Reshare has the item and we succesfully request it, let the user know it is on the way.
+# If Reshare does not have it or we cannot succesfully request it, trigger the normal Symphony request workflow.
+class SubmitIplcListenerJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound do |job, _error|
+    Honeybadger.notify(
+      "Attempted to call Reshare for Request with ID #{job.request_id}, but no such Request was found."
+    )
+  end
+
+  def perform(request_id, instance_uuid)
+    request = Request.find(request_id)
+
+    Sidekiq.logger.info("Started SubmitIplcRequestJob for request #{request_id}")
+
+    begin
+      make_iplc_request(request, instance_uuid)
+    rescue StandardError => e
+      Honeybadger.notify("IPLC Request failed for #{request_id} with #{e}. Submitted to Symphony instead.")
+
+      request.send_to_symphony_now!
+    end
+
+    Sidekiq.logger.info("Completed SubmitIplcRequestJob for request #{request_id}")
+  end
+
+  def make_iplc_request(request, instance_uuid)
+    iplc_response = IplcWrapper.new(request, instance_uuid)
+
+    raise 'IPLC HTTP request failed' unless iplc_response.success?
+
+    request.borrow_direct_response_data = iplc_response.as_json
+    request.via_borrow_direct = true
+    request.save
+
+    request.send_approval_status!
+  end
+
+  # Basic client for working with the IPLC listener HTTP API.
+  class IplcWrapper
+    attr_reader :request, :instance_uuid
+
+    def initialize(request, instance_uuid)
+      @request = request
+      @instance_uuid = instance_uuid
+    end
+
+    def as_json(_options)
+      {
+        response: response,
+        params: iplc_params
+      }
+    end
+
+    def success?
+      iplc_request.status.success?
+    end
+
+    private
+
+    def iplc_request
+      @iplc_request ||= HTTP.get(Settings.borrow_direct.iplc_listener_url, params: iplc_params)
+    end
+
+    def response
+      @response ||= JSON.parse(iplc_request.body.to_s)
+    end
+
+    def iplc_params
+      {
+        svc_id: 'json',
+        req_id: iplc_patron_id,
+        rft_id: instance_uuid,
+        'res.org': 'ISIL:US-CST',
+        'svc.pickupLocation': iplc_pickup_location_code,
+        rfr_id: request.to_global_id.to_s
+      }
+    end
+
+    def iplc_patron_id
+      request.user.patron.university_id
+    end
+
+    def iplc_pickup_location_code
+      Settings.libraries[request.destination]&.iplc_pickup_location_code || "STA_#{request.destination.underscore}"
+    end
+  end
+end

--- a/app/jobs/submit_reshare_request_job.rb
+++ b/app/jobs/submit_reshare_request_job.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'debug'
+
+##
+# Background job to look up an item to request in Reshare.
+# If Reshare has the item and we start a request to Reshare .
+# If Reshare does not have it or we cannot succesfully request it, trigger the normal Symphony request.
+class SubmitReshareRequestJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound do |job, _error|
+    Honeybadger.notify(
+      "Attempted to call Reshare for Request with ID #{job.request_id}, but no such Request was found."
+    )
+  end
+
+  def perform(request_id)
+    request = Request.find(request_id)
+
+    Sidekiq.logger.info("Started SubmitReshareRequestJob for request #{request_id}")
+
+    begin
+      make_reshare_or_symphony_request(request)
+    rescue StandardError => e
+      Honeybadger.notify("Reshare Request failed for #{request_id} with #{e}. Submitted to Symphony instead.")
+
+      request.send_to_symphony_now!
+    end
+
+    Sidekiq.logger.info("Completed SubmitReshareRequestJob for request #{request_id}")
+  end
+
+  def make_reshare_or_symphony_request(request)
+    reshare_vufind_item = ReshareVufindWrapper.new(request)
+
+    if request.user.borrow_direct_eligible? && reshare_vufind_item.requestable?
+      request.reshare_vufind_response_data = reshare_vufind_item.as_json
+      request.via_borrow_direct = true
+      request.save
+
+      # Since we found the item to request, we can send a request to IPLC. We defer it to a background job
+      # to make error handling easier.
+      SubmitIplcListenerJob.perform_later(request.id, reshare_vufind_item.instance_uuid)
+    else
+      request.send_to_symphony_now!
+    end
+  end
+
+  # Basic client for wrapping Reshare's Vufind search API.
+  class ReshareVufindWrapper
+    attr_reader :request
+
+    delegate :searchworks_item, to: :request
+
+    # @param request [HoldRecall]
+    # @param isbn [String]
+    def initialize(request = nil, isbn: nil)
+      @request = request
+      @isbn = isbn
+    end
+
+    # @return [String] the reshare instance UUID for the instance we want to request
+    def instance_uuid
+      loanable_record['id']
+    end
+
+    # @return [Boolean] whether the item is requestable in Reshare
+    def requestable?
+      return false if requested_isbn.blank?
+
+      loanable_record.present?
+    end
+
+    def as_json(_options)
+      {
+        requestable: requestable?,
+        response: vufind_response,
+        instance_uuid: instance_uuid,
+        requested_isbn: requested_isbn
+      }
+    end
+
+    private
+
+    def vufind_response
+      @vufind_response ||= JSON.parse(vufind_request.body.to_s)
+    end
+
+    def requested_isbn
+      Array(@isbn || searchworks_item&.isbn).first
+    end
+
+    def loanable_record
+      vufind_response['records'].find { |record| record['lendingStatus'].include? 'LOANABLE' }
+    end
+
+    def vufind_request
+      params = vufind_request_params
+
+      raise ArgumentError, 'No ISBN provided' if params[:lookfor].blank?
+
+      HTTP.get("#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search", params: params)
+    end
+
+    # We try to match on the requested item's first ISBN; this is behavior inherited from
+    # the relais-based borrow direct implementation.
+    def vufind_request_params
+      {
+        lookfor: requested_isbn,
+        'field[]': ['id', 'title', 'lendingStatus'],
+        type: 'ISN',
+        page: 1,
+        sort: 'relevance',
+        limit: 20,
+        prettyPrint: false,
+        lng: 'en'
+      }
+    end
+  end
+end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -102,4 +102,8 @@ class Patron < SymphonyBase
   def group
     @group ||= Group.new(response)
   end
+
+  def university_id
+    fields['alternateID']
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -34,7 +34,8 @@ class Request < ActiveRecord::Base
   # Serialized data hash
   store :data, accessors: [
     :ad_hoc_items, :authors, :request_status_data, :item_comment, :public_notes, :page_range,
-    :proxy, :request_comment, :section_title, :symphony_response_data, :borrow_direct_response_data,
+    :proxy, :request_comment, :section_title, :symphony_response_data,
+    :reshare_vufind_response_data, :borrow_direct_response_data,
     :illiad_response_data
   ], coder: JSON
   serialize :barcodes, Array

--- a/app/models/requests/hold_recall.rb
+++ b/app/models/requests/hold_recall.rb
@@ -10,9 +10,13 @@ class HoldRecall < Request
   validates :needed_date, presence: true
 
   def submit!
-    return super unless request_via_borrow_direct?
-
-    SubmitBorrowDirectRequestJob.perform_later(id)
+    if Settings.features.hold_recall_via_reshare
+      SubmitReshareRequestJob.perform_later(id)
+    elsif Settings.features.hold_recall_via_relais
+      SubmitBorrowDirectRequestJob.perform_later(id)
+    else
+      super
+    end
   end
 
   def requires_needed_date?
@@ -21,9 +25,5 @@ class HoldRecall < Request
 
   def item_commentable?
     false
-  end
-
-  def request_via_borrow_direct?
-    Settings.features.hold_recall_via_borrow_direct
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,10 @@ class User < ActiveRecord::Base
     @patron ||= Patron.find_by(library_id: library_id) if library_id
   end
 
+  def borrow_direct_eligible?
+    patron.university_id.present?
+  end
+
   private
 
   def notify_honeybadger_of_missing_sso_email!

--- a/app/views/requests/status.html.erb
+++ b/app/views/requests/status.html.erb
@@ -23,6 +23,10 @@
   <% if can? :debug, current_request %>
     <hr />
     <% if current_request.via_borrow_direct? %>
+      <% if current_request.reshare_vufind_response_data %>
+        <h4>Vufind Response</h4>
+        <pre class="well"><%= JSON.pretty_generate(current_request.reshare_vufind_response_data || {}) %></pre>
+      <% end %>
       <h4>Borrow Direct Response</h4>
       <pre class="well"><%= JSON.pretty_generate(current_request.borrow_direct_response_data || {}) %></pre>
     <% else %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -77,10 +77,13 @@ stanford_ips:
   ranges: []
 borrow_direct:
   api_key: an-api-key
+  iplc_listener_url: https://iplc-listener.reshare.indexdata.com/iplc
+  reshare_vufind_url: https://borrowdirect.reshare.indexdata.com
 features:
   estimate_delivery: false
   hold_recall_service: true
-  hold_recall_via_borrow_direct: true
+  hold_recall_via_relais: true
+  hold_recall_via_reshare: false
   scan_service: true
 
 background_jobs:
@@ -187,6 +190,7 @@ libraries:
     hours: # Use SAL 1+2 hours while EDUCATION is closed
       library_slug: sal12
       location_slug: operations
+    iplc_pickup_location_code: STA_GREEN
   ENG:
     label: Engineering Library (Terman)
     hold_pseudopatron: HOLD@EN

--- a/spec/jobs/submit_iplc_listener_job_spec.rb
+++ b/spec/jobs/submit_iplc_listener_job_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SubmitIplcListenerJob, type: :job do
+  let(:user) { create(:library_id_user) }
+  let(:request) { create(:hold_recall_with_holdings, user: user) }
+  let(:sw_item) { double('SeachWorksItem', isbn: %w[12345 54321]) }
+
+  before do
+    Sidekiq.logger.level = Logger::UNKNOWN
+    allow(Patron).to receive(:find_by).with(library_id: user.library_id).at_least(:once).and_return(
+      double(exists?: true, email: 'patron@example.com')
+    )
+    allow(request).to receive(:searchworks_item).and_return(sw_item)
+  end
+
+  describe '#perform' do
+    let(:iplc_response_item) { double('IplcWrapper') }
+
+    before do
+      expect(SubmitIplcListenerJob::IplcWrapper).to receive(:new).with(request, 'iplc-uuid').and_return(
+        iplc_response_item
+      )
+    end
+
+    context 'when the item request in BorrowDirect throws an error' do
+      before do
+        expect(iplc_response_item).to receive(:success?).and_raise('The API Error')
+      end
+
+      it 'sends the request off to Symphony and notifies Honeybadger' do
+        expect(Honeybadger).to receive(:notify).with(
+          'IPLC Request failed for 1 with The API Error. Submitted to Symphony instead.'
+        )
+        expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, {})
+
+        subject.perform(request.id, 'iplc-uuid')
+      end
+    end
+
+    context 'when the item is requestable and the request succeeds' do
+      before do
+        expect(iplc_response_item).to receive_messages(
+          success?: true,
+          as_json: { 'mockResponse' => ['Successful Response'], 'RequestNumber' => '1' }
+        )
+
+        allow(described_class).to receive(:perform_later)
+      end
+
+      it 'persists the BorrowDirect response' do
+        subject.perform(request.id, 'iplc-uuid')
+
+        expect(request.reload.borrow_direct_response_data).to eq(
+          'mockResponse' => ['Successful Response'], 'RequestNumber' => '1'
+        )
+      end
+
+      it 'sets the via_borrow_direct? flag to true' do
+        subject.perform(request.id, 'iplc-uuid')
+
+        expect(request.reload).to be_via_borrow_direct
+      end
+
+      it 'sends the approval status email' do
+        expect(RequestStatusMailer).to receive(
+          :request_status_for_holdrecall
+        )
+
+        subject.perform(request.id, 'iplc-uuid')
+      end
+    end
+  end
+
+  describe SubmitReshareRequestJob::ReshareVufindWrapper do
+    subject(:reshare_vufind_item) { described_class.new(request) }
+
+    describe '#requestable?' do
+      context 'when the SearchWorksItem does not have an ISBN' do
+        before { expect(sw_item).to receive(:isbn).and_return(nil) }
+
+        it do
+          expect(subject).not_to be_requestable
+        end
+      end
+
+      context 'when the SearchWorksItem has an ISBN but the item is not findable in BorrowDirect' do
+        before do
+          stub_request(:get, %r{#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search})
+            .with(query: hash_including(lookfor: '12345'))
+            .to_return(body: '{"total":0,"records":[]}')
+        end
+
+        it do
+          expect(subject).not_to be_requestable
+        end
+      end
+
+      context 'when the SearchWorksItem has an ISBN but the item is not available in BorrowDirect' do
+        before do
+          stub_request(:get, %r{#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search})
+            .with(query: hash_including(lookfor: '12345'))
+            .to_return(body: '{"total":1,"records":[{"lendingStatus":["NONLENDABLE"]}]}')
+        end
+
+        it do
+          expect(subject).not_to be_requestable
+        end
+      end
+
+      context 'when the SearchWorksItem has an ISBN and the item is available in BorrowDirect' do
+        before do
+          stub_request(:get, %r{#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search})
+            .with(query: hash_including(lookfor: '12345'))
+            .to_return(body: '{"total":1,"records":[{"id":"12345", "lendingStatus":["LOANABLE"]}]}')
+        end
+
+        it do
+          expect(subject).to be_requestable.and have_attributes(instance_uuid: '12345')
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/submit_reshare_request_job_spec.rb
+++ b/spec/jobs/submit_reshare_request_job_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SubmitReshareRequestJob, type: :job do
+  let(:user) { create(:library_id_user) }
+  let(:patron) { instance_double('Patron', exists?: true, email: nil, university_id: '1234567') }
+  let(:request) { create(:hold_recall_with_holdings, user: user) }
+  let(:sw_item) { double('SeachWorksItem', isbn: %w[12345 54321]) }
+
+  before do
+    Sidekiq.logger.level = Logger::UNKNOWN
+    allow(Patron).to receive(:find_by).with(library_id: user.library_id).and_return(patron)
+    allow(request).to receive(:searchworks_item).and_return(sw_item)
+  end
+
+  describe '#perform' do
+    let(:reshare_vufind_item) { double('ReshareVufindWrapper') }
+
+    before do
+      expect(SubmitReshareRequestJob::ReshareVufindWrapper).to receive(:new).with(request).and_return(
+        reshare_vufind_item
+      )
+    end
+
+    context 'when the patron does not have a university ID' do
+      before do
+        allow(patron).to receive(:university_id).and_return(nil)
+      end
+
+      it 'sends the request to Symphony' do
+        expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, {})
+
+        subject.perform(request.id)
+      end
+    end
+
+    context 'when the item is not requestable in BorrowDirect' do
+      before { expect(reshare_vufind_item).to receive(:requestable?).and_return(false) }
+
+      it 'sends the request off to Symphony (without attempting to request it)' do
+        expect(reshare_vufind_item).not_to receive(:request_item)
+        expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, {})
+
+        subject.perform(request.id)
+      end
+    end
+
+    context 'when the item request in BorrowDirect throws an error' do
+      before do
+        expect(reshare_vufind_item).to receive(:requestable?).and_raise('The API Error')
+      end
+
+      it 'sends the request off to Symphony and notifies Honeybadger' do
+        expect(Honeybadger).to receive(:notify).with(
+          'Reshare Request failed for 1 with The API Error. Submitted to Symphony instead.'
+        )
+        expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, {})
+
+        subject.perform(request.id)
+      end
+    end
+
+    context 'when the item is requestable and the request succeeds' do
+      before do
+        expect(reshare_vufind_item).to receive_messages(
+          requestable?: true,
+          instance_uuid: '12345',
+          as_json: { 'mockResponse' => ['Successful Response'], 'RequestNumber' => '1' }
+        )
+
+        allow(SubmitIplcListenerJob).to receive(:perform_later)
+      end
+
+      it 'persists the BorrowDirect response' do
+        subject.perform(request.id)
+
+        expect(request.reload.reshare_vufind_response_data).to eq(
+          'mockResponse' => ['Successful Response'], 'RequestNumber' => '1'
+        )
+      end
+
+      it 'sets the via_borrow_direct? flag to true' do
+        subject.perform(request.id)
+
+        expect(request.reload).to be_via_borrow_direct
+      end
+
+      it 'enqueues the request to IPLC' do
+        subject.perform(request.id)
+
+        expect(SubmitIplcListenerJob).to have_received(:perform_later).with(request.id, '12345')
+      end
+    end
+  end
+
+  describe SubmitReshareRequestJob::ReshareVufindWrapper do
+    subject(:reshare_vufind_item) { described_class.new(request) }
+
+    describe '#requestable?' do
+      context 'when the SearchWorksItem does not have an ISBN' do
+        before { expect(sw_item).to receive(:isbn).and_return(nil) }
+
+        it do
+          expect(subject).not_to be_requestable
+        end
+      end
+
+      context 'when the SearchWorksItem has an ISBN but the item is not findable in BorrowDirect' do
+        before do
+          stub_request(:get, %r{#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search})
+            .with(query: hash_including(lookfor: '12345'))
+            .to_return(body: '{"total":0,"records":[]}')
+        end
+
+        it do
+          expect(subject).not_to be_requestable
+        end
+      end
+
+      context 'when the SearchWorksItem has an ISBN but the item is not available in BorrowDirect' do
+        before do
+          stub_request(:get, %r{#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search})
+            .with(query: hash_including(lookfor: '12345'))
+            .to_return(body: '{"total":1,"records":[{"lendingStatus":["NONLENDABLE"]}]}')
+        end
+
+        it do
+          expect(subject).not_to be_requestable
+        end
+      end
+
+      context 'when the SearchWorksItem has an ISBN and the item is available in BorrowDirect' do
+        before do
+          stub_request(:get, %r{#{Settings.borrow_direct.reshare_vufind_url}/api/v1/search})
+            .with(query: hash_including(lookfor: '12345'))
+            .to_return(body: '{"total":1,"records":[{"id":"12345", "lendingStatus":["LOANABLE"]}]}')
+        end
+
+        it do
+          expect(subject).to be_requestable.and have_attributes(instance_uuid: '12345')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
BorrowDirect is changing back-end providers. The new provider (reshare) requires our application do 2 things:

- look up an item in their VuFind to figure out what id to request
- send a request to the "IPLC listener" to request the item for our patron

Fixes https://github.com/sul-dlss/sul-requests/issues/1367
