### PR TITLE
Remove debug require

### DIFF
--- a/app/jobs/submit_reshare_request_job.rb
+++ b/app/jobs/submit_reshare_request_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'debug'
-
 ##
 # Background job to look up an item to request in Reshare.
 # If Reshare has the item and we start a request to Reshare .


### PR DESCRIPTION
Resolves:

```
bundler: failed to load command: bin/rails (bin/rails)
/usr/local/rvm/rubies/ruby-3.0.3/lib/ruby/3.0.0/debug.rb:6:in `<main>': undefined method `>' for nil:NilClass (NoMethodError)
        from /opt/app/requests/requests/shared/bundle/ruby/3.0.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /opt/app/requests/requests/shared/bundle/ruby/3.0.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /opt/app/requests/requests/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:38:in `require'
        from /opt/app/requests/requests/releases/20221213132352/app/jobs/submit_reshare_request_job.rb:3:in `<main>'
```