### PR TITLE
Enable reshare; Shut off relais.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,8 +82,8 @@ borrow_direct:
 features:
   estimate_delivery: false
   hold_recall_service: true
-  hold_recall_via_relais: true
-  hold_recall_via_reshare: false
+  hold_recall_via_relais: false
+  hold_recall_via_reshare: true
   scan_service: true
 
 background_jobs:


### PR DESCRIPTION
Can merge now. For deployment 12/13 at 11 AM Eastern when BorrowDirect switches from relais to reshare.