### PR TITLE
Ensure IPLC pickup location code is uppercase

### DIFF
--- a/app/jobs/submit_iplc_listener_job.rb
+++ b/app/jobs/submit_iplc_listener_job.rb
@@ -87,7 +87,7 @@ class SubmitIplcListenerJob < ApplicationJob
     end
 
     def iplc_pickup_location_code
-      Settings.libraries[request.destination]&.iplc_pickup_location_code || "STA_#{request.destination.underscore}"
+      Settings.libraries[request.destination]&.iplc_pickup_location_code || "STA_#{request.destination.underscore.upcase}"
     end
   end
 end


### PR DESCRIPTION
We're seeing an issue where pickup location codes are not populated in reshare and suspect it is because they're being sent as `STA_green` instead of `STA_GREEN`