### PR TITLE
Send the instance title with the IPLC request

### DIFF
--- a/app/jobs/submit_reshare_request_job.rb
+++ b/app/jobs/submit_reshare_request_job.rb
@@ -37,7 +37,9 @@ class SubmitReshareRequestJob < ApplicationJob
 
       # Since we found the item to request, we can send a request to IPLC. We defer it to a background job
       # to make error handling easier.
-      SubmitIplcListenerJob.perform_later(request.id, reshare_vufind_item.instance_uuid)
+      SubmitIplcListenerJob.perform_later(request.id,
+                                          reshare_vufind_item.instance_uuid,
+                                          reshare_vufind_item.instance_title)
     else
       request.send_to_symphony_now!
     end
@@ -61,6 +63,11 @@ class SubmitReshareRequestJob < ApplicationJob
       loanable_record['id']
     end
 
+    # @return [String] the reshare instance title for the instance we want to request
+    def instance_title
+      loanable_record['title']
+    end
+
     # @return [Boolean] whether the item is requestable in Reshare
     def requestable?
       return false if requested_isbn.blank?
@@ -73,6 +80,7 @@ class SubmitReshareRequestJob < ApplicationJob
         requestable: requestable?,
         response: vufind_response,
         instance_uuid: instance_uuid,
+        instance_title: instance_title,
         requested_isbn: requested_isbn
       }
     end

--- a/spec/jobs/submit_iplc_listener_job_spec.rb
+++ b/spec/jobs/submit_iplc_listener_job_spec.rb
@@ -19,7 +19,7 @@ describe SubmitIplcListenerJob, type: :job do
     let(:iplc_response_item) { double('IplcWrapper') }
 
     before do
-      expect(SubmitIplcListenerJob::IplcWrapper).to receive(:new).with(request, 'iplc-uuid').and_return(
+      expect(SubmitIplcListenerJob::IplcWrapper).to receive(:new).with(request, 'iplc-uuid', 'iplc-title').and_return(
         iplc_response_item
       )
     end
@@ -35,7 +35,7 @@ describe SubmitIplcListenerJob, type: :job do
         )
         expect(SubmitSymphonyRequestJob).to receive(:perform_now).with(request.id, {})
 
-        subject.perform(request.id, 'iplc-uuid')
+        subject.perform(request.id, 'iplc-uuid', 'iplc-title')
       end
     end
 
@@ -50,7 +50,7 @@ describe SubmitIplcListenerJob, type: :job do
       end
 
       it 'persists the BorrowDirect response' do
-        subject.perform(request.id, 'iplc-uuid')
+        subject.perform(request.id, 'iplc-uuid', 'iplc-title')
 
         expect(request.reload.borrow_direct_response_data).to eq(
           'mockResponse' => ['Successful Response'], 'RequestNumber' => '1'
@@ -58,7 +58,7 @@ describe SubmitIplcListenerJob, type: :job do
       end
 
       it 'sets the via_borrow_direct? flag to true' do
-        subject.perform(request.id, 'iplc-uuid')
+        subject.perform(request.id, 'iplc-uuid', 'iplc-title')
 
         expect(request.reload).to be_via_borrow_direct
       end
@@ -68,7 +68,7 @@ describe SubmitIplcListenerJob, type: :job do
           :request_status_for_holdrecall
         )
 
-        subject.perform(request.id, 'iplc-uuid')
+        subject.perform(request.id, 'iplc-uuid', 'iplc-title')
       end
     end
   end

--- a/spec/jobs/submit_reshare_request_job_spec.rb
+++ b/spec/jobs/submit_reshare_request_job_spec.rb
@@ -66,6 +66,7 @@ describe SubmitReshareRequestJob, type: :job do
         expect(reshare_vufind_item).to receive_messages(
           requestable?: true,
           instance_uuid: '12345',
+          instance_title: 'A title',
           as_json: { 'mockResponse' => ['Successful Response'], 'RequestNumber' => '1' }
         )
 
@@ -89,7 +90,7 @@ describe SubmitReshareRequestJob, type: :job do
       it 'enqueues the request to IPLC' do
         subject.perform(request.id)
 
-        expect(SubmitIplcListenerJob).to have_received(:perform_later).with(request.id, '12345')
+        expect(SubmitIplcListenerJob).to have_received(:perform_later).with(request.id, '12345', 'A title')
       end
     end
   end


### PR DESCRIPTION
If we don't send the instance title with the request to ReShare then: (1) no title appears in the ReShare Folio instance, and (2) no title is returned with the mod-rs request for the patron's request. This sends with the request the `instance_title` of the requested item along with the `instance_uuid` so both ILL staff and patrons can see the title information about requested items.