### PR TITLE
Use doubles for Config::Options rather than OpenStruct

### DIFF
--- a/spec/helpers/pickup_libraries_helper_spec.rb
+++ b/spec/helpers/pickup_libraries_helper_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe PickupLibrariesHelper do
     before do
       allow(Settings).to receive(:libraries).and_return(
         {
-          'ABC' => OpenStruct.new(label: 'Library 2'),
-          'XYZ' => OpenStruct.new(label: 'Library 1')
+          'ABC' => double(Config::Options, label: 'Library 2'),
+          'XYZ' => double(Config::Options, label: 'Library 1')
         }
       )
     end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe Request do
 
     it 'returns the item title from the fetched searchworks record for non persisted objects' do
       allow_any_instance_of(described_class).to receive(:bib_data)
-        .and_return(OpenStruct.new(title: 'A fetched title'))
+        .and_return(instance_double(described_class.bib_model_class, title: 'A fetched title'))
       expect(described_class.new.stored_or_fetched_item_title).to eq 'A fetched title'
     end
   end

--- a/spec/views/home/show.html.erb_spec.rb
+++ b/spec/views/home/show.html.erb_spec.rb
@@ -16,7 +16,7 @@ describe 'home/show' do
   describe 'superadmin' do
     before do
       allow(controller).to receive_messages(current_user: create(:superadmin_user))
-      allow(Request).to receive_messages(mediateable_origins: { 'SAL3' => OpenStruct.new })
+      allow(Request).to receive_messages(mediateable_origins: { 'SAL3' => double(Config::Options, library_override: nil) })
       render
     end
 


### PR DESCRIPTION
The double makes it clear that it's standing in place of another object