### PR TITLE
Fixup jest tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,11 @@ jobs:
         key: ${{ runner.os }}-gems-202103-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-202103
+    - name: Use Node.js 18.15
+      uses: actions/setup-node@v3
+      with:
+        # keep pinned to 18.15 until we upgrade past node 18 to avoid this error in CI: https://github.com/nodejs/node/issues/47563
+        node-version: '18.15'
     - name: Bundle install
       run: bundle config path vendor/bundle
     - name: Install dependencies

--- a/Rakefile
+++ b/Rakefile
@@ -19,5 +19,13 @@ task asset_paths: [:environment] do
 end
 
 task javascript_tests: [:environment] do
-  system 'yarn test'
+  cmd = 'yarn test'
+  success = system(cmd)
+
+  if success
+    puts 'JavaScript tests passed'
+  else
+    puts 'JavaScript tests failed'
+    exit(1)
+  end
 end

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "plugins": ["@babel/plugin-transform-runtime"],
   "presets": ["@babel/preset-env"]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "devDependencies": {
     "@babel/cli": "^7.12.16",
     "@babel/core": "^7.12.16",
-    "@babel/plugin-transform-runtime": "^7.12.15",
     "@babel/preset-env": "^7.12.16",
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.11.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,18 +775,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-runtime@^7.12.15":
-  version "7.22.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.4.tgz#f8353f313f18c3ce1315688631ec48657b97af42"
-  integrity sha512-Urkiz1m4zqiRo17klj+l3nXgiRTFQng91Bc1eiLF7BMQu1e7wE5Gcq9xSv062IF068NHjcutSbIMev60gXxAvA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.21.4"
-    "@babel/helper-plugin-utils" "^7.21.5"
-    babel-plugin-polyfill-corejs2 "^0.4.3"
-    babel-plugin-polyfill-corejs3 "^0.8.1"
-    babel-plugin-polyfill-regenerator "^0.5.0"
-    semver "^6.3.0"
-
 "@babel/plugin-transform-shorthand-properties@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz#6d6df7983d67b195289be24909e3f12a8f664dc9"


### PR DESCRIPTION
Fixes #1502

If I change a JS test to fail, the build/suite falis on `bundle exec rake`

```sh
sul-requests git:(jstest) ✗ bundle exec rake

... [ the ruby tests ] ...

Finished in 1 minute 16.61 seconds (files took 5.53 seconds to load)
1047 examples, 0 failures, 11 pending

Coverage report generated for RSpec to /Users/marloelilongley/Projects/sul-requests/coverage. 8694 / 8992 LOC (96.69%) covered.
yarn run v1.22.17
$ jest -c jest.config.js
Getting asset pipeline lookup path from Rails
Getting asset pipeline lookup path from Rails
 PASS  spec/javascripts/item_selector_limit_message_spec.js (19.911 s)
 FAIL  spec/javascripts/toggle_show_tabs_spec.js (20 s)
  ● Toggling show tabs › addToggleBehavior() › it allows the user to toggle back and forth between panes

    expect(received).toBeVisible()

    received value must be an HTMLElement or an SVGElement.
    Received has value: null

      12 |       toggleShowTabs.addToggleBehavior();
      13 |
    > 14 |       expect(document.querySelector('#thing-x')).toBeVisible();
         |                                                  ^
      15 |       expect(document.querySelector('#thing-b')).not.toBeVisible();
      16 |       
      17 |       $('#thing-a a').click();

      at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:342:30)
      at Object.toBeVisible (node_modules/expect/build/index.js:343:15)
      at Object.<anonymous> (spec/javascripts/toggle_show_tabs_spec.js:14:50)

 PASS  spec/javascripts/item_selector_filtering_spec.js (19.998 s)
 PASS  spec/javascripts/item_approval_spec.js (19.951 s)
 PASS  spec/javascripts/item_selector_spec.js (19.964 s)
 PASS  spec/javascripts/no_js_spec.js (20.029 s)
 PASS  spec/javascripts/item_selector_breadcrumbs_spec.js (20.065 s)
 PASS  spec/javascripts/additional_user_validation_fields_spec.js (20.038 s)
 PASS  spec/javascripts/item_selector_zero_message_spec.js (20.093 s)
 PASS  spec/javascripts/item_selector_ad_hoc_items_spec.js (20.107 s)
 PASS  spec/javascripts/date_selector_spec.js (20.046 s)
 PASS  spec/javascripts/item_selector_active_spec.js (20.052 s)
 PASS  spec/javascripts/paging_schedule_updater_spec.js (20.071 s)
 PASS  spec/javascripts/item_selector_limit_spec.js (20.114 s)
 PASS  spec/javascripts/mediation_table_spec.js (20.156 s)
 PASS  spec/javascripts/item_selector_incrementor_spec.js
 PASS  spec/javascripts/item_selector_checkedout_note_spec.js

Test Suites: 1 failed, 16 passed, 17 total
Tests:       1 failed, 69 passed, 70 total
Snapshots:   0 total
Time:        22.759 s, estimated 25 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
JavaScript tests failed





```
