### PR TITLE
Implement LocationRules engine for FOLIO

### DIFF
--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Folio
+  # Location information in FOLIO, analogous to LibraryLocation for Symphony
+  class Location
+    # Location details, used for configuration storage
+    Details = Struct.new(:page_aeon_site,
+                         :page_mediation_group_key,
+                         :page_service_points,
+                         :scan_service_point,
+                         :scan_pseudopatron_barcode,
+                         :scan_material_types,
+                         keyword_init: true) do
+      def self.from_dynamic(json)
+        new(page_aeon_site: json.fetch('scanAeonSite', nil),
+            page_mediation_group_key: json.fetch('scanMediationGroupKey', nil),
+            page_service_points: json.fetch('pageServicePoints', []),
+            scan_service_point: json.fetch('scanServicePoint', nil),
+            scan_pseudopatron_barcode: json.fetch('scanPseudopatronBarcode', nil),
+            scan_material_types: json.fetch('scanMaterialTypes', []))
+      end
+    end
+
+    attr_reader :id, :code, :name
+
+    def initialize(id:, code:, name:, details: {})
+      @id = id
+      @code = code
+      @name = name
+      @details = Details.new(**details.symbolize_keys)
+    end
+
+    def self.from_dynamic(json)
+      new(id: json.fetch('id'),
+          code: json.fetch('code'),
+          name: json.fetch('name'),
+          details: Details.from_dynamic(json['details'] || {}))
+    end
+
+    # Set of rules governing paging, scanning, etc.
+    def rules
+      [paging_rule, scanning_rule].compact
+    end
+
+    private
+
+    # Rule governing paging of material at this location, if enabled
+    def paging_rule
+      return unless @details.page_aeon_site.present? || @details.page_mediation_group_key.present? || @details.page_service_points.present?
+
+      Folio::LocationRules::PagingRule.new(
+        self,
+        aeon_site: @details.page_aeon_site,
+        mediation_group_key: @details.page_mediation_group_key,
+        service_points: @details.page_service_points
+      )
+    end
+
+    # Rule governing scanning of material at this location, if enabled
+    def scanning_rule
+      return if @details.scan_pseudopatron_barcode.blank?
+
+      Folio::LocationRules::ScanningRule.new(
+        self,
+        pseudopatron_barcode: @details.scan_pseudopatron_barcode,
+        material_types: @details.scan_material_types,
+        service_point: @details.scan_service_point
+      )
+    end
+  end
+end

--- a/app/models/folio/location_rules.rb
+++ b/app/models/folio/location_rules.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Folio
+  # Container for location rules defined on FOLIO locations
+  class LocationRules
+    include Enumerable
+
+    delegate :each, to: :rules
+
+    attr_reader :rules
+
+    # Rules organized by request type, used in RequestAbilities
+    def self.rules_by_request_type(rules = nil)
+      location_rules = new(rules)
+      {
+        pageable: location_rules.paging_rules,
+        scannable: location_rules.scanning_rules,
+        hold_recallable: [] # not handled at location level in FOLIO
+      }
+    end
+
+    # Fallback rules used when no other rules apply
+    def self.fallback_rules
+      [fallback_paging_rule, fallback_scanning_rule]
+    end
+
+    # A generic location that matches any request
+    def self.fallback_location
+      Folio::Location.new(id: nil, code: '*', name: 'fallback')
+    end
+
+    # A generic paging rule that matches any request
+    def self.fallback_paging_rule
+      PagingRule.new(
+        fallback_location,
+        service_points: [{ code: Settings.default_pickup_library }]
+      )
+    end
+
+    # A generic scanning rule that matches any request
+    def self.fallback_scanning_rule
+      ScanningRule.new(
+        fallback_location,
+        service_point: { code: Settings.default_scan_destination.key },
+        pseudopatron_barcode: Settings.default_scan_destination.patron_barcode
+      )
+    end
+
+    # Fetch all location rules from FOLIO, or provide a list of rules
+    def initialize(rules = nil, client: FolioClient.new)
+      @client = client
+      @rules = rules || default_rules
+    end
+
+    # Selects the rules that apply to a given request
+    def applies_to(request)
+      lazy.select { |rule| rule.applies_to?(request) }
+    end
+
+    # All rules that apply to paging requests
+    def paging_rules
+      lazy.select { |rule| rule.is_a? PagingRule }
+    end
+
+    # All rules that apply to scanning requests
+    def scanning_rules
+      lazy.select { |rule| rule.is_a? ScanningRule }
+    end
+
+    private
+
+    # List of service points that should be default options for pickup
+    def default_pickup_locations
+      @client.service_points.select(&:default_pickup_location)
+    end
+
+    # All rules configured in FOLIO, plus the fallback rules
+    def default_rules
+      @client.locations.flat_map(&:rules).compact + LocationRules.fallback_rules
+    end
+
+    # Generic rule for requests at a given location
+    class Rule
+      attr_reader :location
+
+      # Create a rule using extra data stored on a Location
+      # @param [Folio::Location] location
+      def initialize(location, send_honeybadger_notice_if_used: false)
+        @location = location
+        @send_honeybadger_notice_if_used = send_honeybadger_notice_if_used
+      end
+
+      # Test if the rule would apply to the given request
+      # @param [Request] request
+      def applies_to?(request)
+        return true if @location.code == '*'
+
+        @location.code.match? request.library_location.folio_location_code
+      end
+
+      # TODO: remove and rename after FOLIO migration is complete
+      # this name is confusing because .match? is supposed to be for regex
+      alias match? applies_to?
+    end
+
+    # Rule governing how page requests are handled at a given location
+    class PagingRule < Rule
+      attr_reader :mediation_group_key, :aeon_site
+
+      def initialize(location, aeon_site: nil, mediation_group_key: nil, service_points: [], **kwargs)
+        super(location, **kwargs)
+        @aeon_site = aeon_site
+        @mediation_group_key = mediation_group_key
+        @service_points = service_points
+      end
+
+      def aeon?
+        @aeon_site.present?
+      end
+
+      def mediated?
+        @mediation_group_key.present?
+      end
+
+      def pickup_libraries
+        service_points.map(&:code)
+      end
+
+      private
+
+      def service_points
+        @service_points.map { |sp| Folio::ServicePoint.new(sp) }
+      end
+
+      # TODO: find service points that are in the same library as the requested item, which should always be valid pickup locations
+      def local_service_points
+        []
+      end
+    end
+
+    # Rule governing how scan requests are handled at a given location
+    class ScanningRule < Rule
+      attr_reader :pseudopatron_barcode
+
+      MaterialType = Struct.new('MaterialType', :id, :name)
+
+      def initialize(location, pseudopatron_barcode: nil, material_types: [], service_point: nil, **kwargs)
+        super(location, **kwargs)
+        @pseudopatron_barcode = pseudopatron_barcode
+        @material_types = material_types
+        @service_point = service_point
+      end
+
+      def destination
+        service_point.code
+      end
+
+      def service_point
+        Folio::ServicePoint.new(@service_point)
+      end
+
+      def material_types
+        @material_types.map { |mt| MaterialType.new(mt) }
+      end
+    end
+  end
+end

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Folio
+  # A place where FOLIO items can be serviced (e.g. a pickup location)
+  class ServicePoint
+    attr_reader :id, :code, :name
+
+    def initialize(id:, code:, name:)
+      @id = id
+      @code = code
+      @name = name
+    end
+
+    def self.from_dynamic(json)
+      new(id: json.fetch('id'),
+          code: json.fetch('code'),
+          name: json.fetch('name'))
+    end
+  end
+end

--- a/app/models/location_rules.rb
+++ b/app/models/location_rules.rb
@@ -6,6 +6,14 @@ class LocationRules
 
   attr_reader :rules
 
+  # Rules organized by request type, used in RequestAbilities
+  def self.rules_by_request_type
+    {
+      pageable: new(Settings.pageable),
+      scannable: new(Settings.scannable)
+    }
+  end
+
   # @param [Config::Option] rules (see `Rule` class for rule data)
   def initialize(rules)
     @rules = rules

--- a/app/models/location_rules.rb
+++ b/app/models/location_rules.rb
@@ -42,8 +42,6 @@ class LocationRules
              :item_types, # multi-valued list of item type codes
              :only_scannable, # with covid-19 restrictions, some items were exclusively scannable
              :default_pickup_library,
-             :mediated,
-             :aeon,
              :aeon_site,
              :destination,
              :send_honeybadger_notice_if_used,
@@ -65,6 +63,14 @@ class LocationRules
 
     def pickup_libraries
       (rule.pickup_libraries || Settings.default_pickup_libraries) + (rule.additional_pickup_libraries || [])
+    end
+
+    def aeon?
+      aeon_site.present?
+    end
+
+    def mediated?
+      rule.mediated
     end
 
     private

--- a/app/models/request_abilities.rb
+++ b/app/models/request_abilities.rb
@@ -3,11 +3,10 @@
 # Describe request types available for a given generic request
 class RequestAbilities
   def self.rules
-    @rules ||= {
-      pageable: LocationRules.new(Settings.pageable),
-      scannable: LocationRules.new(Settings.scannable)
-    }
+    @rules ||= location_rules_class.rules_by_request_type
   end
+
+  class_attribute :location_rules_class, default: Settings.ils.location_rules&.constantize || LocationRules
 
   attr_reader :request
 

--- a/app/models/request_abilities.rb
+++ b/app/models/request_abilities.rb
@@ -18,24 +18,24 @@ class RequestAbilities
   def scannable?
     return false unless Settings.features.scan_service
 
-    scannable_location_rule.present?
+    scanning_rule.present?
   end
 
   # With covid-19 restrictions, some items were exclusively available for scanning
   def scannable_only?
-    scannable_location_rule&.only_scannable
+    scanning_rule&.only_scannable
   end
 
   def mediateable?
-    applicable_rules(:pageable).first&.mediated || aeon_pageable?
+    paging_rule&.mediated? || aeon_pageable?
   end
 
   def aeon_pageable?
-    applicable_rules(:pageable).first&.aeon
+    paging_rule&.aeon?
   end
 
   def aeon_site
-    applicable_rules(:pageable).first&.aeon_site if aeon_pageable?
+    paging_rule&.aeon_site if aeon_pageable?
   end
 
   # returns a true if any of the following is true
@@ -49,15 +49,15 @@ class RequestAbilities
   end
 
   def pageable?
-    !mediateable? && !hold_recallable? && location_rule.present?
+    !mediateable? && !hold_recallable? && paging_rule.present?
   end
 
-  def location_rule
-    @location_rule ||= applicable_rules(:pageable).first
+  def paging_rule
+    @paging_rule ||= applicable_rules(:pageable).first
   end
 
-  def scannable_location_rule
-    @scannable_location_rule ||= applicable_rules(:scannable).first
+  def scanning_rule
+    @scanning_rule ||= applicable_rules(:scannable).first
   end
 
   private

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -9,6 +9,8 @@ class FolioClient # rubocop:disable Metrics/ClassLength
 
   attr_reader :base_url
 
+  delegate :locations, to: :folio_graphql_client
+
   def initialize(url: Settings.folio.okapi_url, tenant: Settings.folio.tenant)
     uri = URI.parse(url)
 
@@ -118,6 +120,11 @@ class FolioClient # rubocop:disable Metrics/ClassLength
     search_response.dig('instances', 0, 'id')
   end
 
+  def get_location(code)
+    response = get_json('/locations', params: { query: CqlQuery.new(code:).to_query })
+    response.dig('locations', 0)
+  end
+
   def find_instance(instance_id:)
     get_json("/inventory/instances/#{instance_id}")
   end
@@ -189,5 +196,9 @@ class FolioClient # rubocop:disable Metrics/ClassLength
 
   def default_headers
     DEFAULT_HEADERS.merge({ 'X-Okapi-Tenant': @tenant, 'User-Agent': 'SulRequests' })
+  end
+
+  def folio_graphql_client
+    @folio_graphql_client ||= FolioGraphqlClient.new
   end
 end

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'http'
+
+# Calls the folio-graphql endpoint
+class FolioGraphqlClient
+  DEFAULT_HEADERS = {
+    accept: 'application/json, text/plain',
+    content_type: 'application/json'
+  }.freeze
+
+  attr_reader :base_url
+
+  def initialize(url: Settings.folio.graphql_url, tenant: Settings.folio.tenant)
+    uri = URI.parse(url)
+
+    @username = uri.user
+    @password = uri.password
+    @base_url = uri.dup.tap do |u|
+      u.user = nil
+      u.password = nil
+    end.to_s
+
+    @tenant = tenant
+  end
+
+  def get(path, **kwargs)
+    request(path, method: :get, **kwargs)
+  end
+
+  def post(path, **kwargs)
+    request(path, method: :post, **kwargs)
+  end
+
+  def get_json(path, **kwargs)
+    parse(get(path, **kwargs))
+  end
+
+  def post_json(path, **kwargs)
+    parse(post(path, **kwargs))
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def locations
+    data = post_json('/', json:
+    {
+      query:
+        <<~GQL
+          query LocationsWithRules {
+            locations {
+              id
+              code
+              name
+              details {
+                pageAeonSite
+                pageMediationGroupKey
+                pageServicePoints {
+                  id
+                  code
+                  name
+                }
+                scanServicePoint {
+                  id
+                  code
+                  name
+                }
+                scanPseudopatronBarcode
+                scanMaterialTypes {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        GQL
+    })
+    raise data['errors'].pluck('message').join("\n") if data.key?('errors')
+
+    data.dig('data', 'locations').map { |l| Folio::Location.from_dynamic(l) }
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def ping
+    # Every GraphQL server supports the trivial query that asks for the "type name" of the top-level query
+    # You can run a health check as a GET against an URL like this
+    # See https://www.apollographql.com/docs/apollo-server/monitoring/health-checks/
+    request('/graphql?query=%7B__typename%7D')
+  rescue HTTP::Error
+    false
+  end
+
+  private
+
+  def parse(response)
+    return nil if response.body.empty?
+
+    JSON.parse(response.body)
+  end
+
+  def request(path, headers: {}, method: :get, **other)
+    HTTP
+      .use(instrumentation: { instrumenter: ActiveSupport::Notifications.instrumenter, namespace: 'folio' })
+      .headers(default_headers.merge(headers))
+      .request(method, base_url + path, **other)
+  end
+
+  def default_headers
+    DEFAULT_HEADERS.merge({ 'User-Agent': 'FolioGraphqlClient', 'okapi_username' => @username,
+                            'okapi_password' => @password })
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,6 +56,7 @@ ils:
   bib_model: SearchworksItem # or Folio::BibData
   patron_model: Symphony::Patron
   request_job: SubmitSymphonyRequestJob
+  location_rules: LocationRules
 
 symphony:
   override: PASSWORD

--- a/spec/features/location_rules_spec.rb
+++ b/spec/features/location_rules_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Location rules configuration' do
+  let(:aeon_pageable_location) do
+    Folio::Location.new(id: nil, code: 'ARS-RECORDINGS', name: 'ARS Recordings', details:
+      {
+        page_aeon_site: 'ARS'
+      })
+  end
+
+  let(:mediated_pageable_location) do
+    Folio::Location.new(id: nil, code: 'SAL3-PAGE-MP', name: 'SAL3 PAGE-MP', details:
+      {
+        page_mediation_group_key: 'PAGE-MP',
+        page_service_points: ['EARTH-SCI']
+      })
+  end
+
+  let(:pageable_location) do
+    Folio::Location.new(id: nil, code: 'SAL3-PAGE-LP', name: 'SAL3 Page to LP', details:
+      {
+        page_service_points: ['MUSIC', 'MEDIA-CENTER']
+      })
+  end
+
+  let(:scannable_location) do
+    Folio::Location.new(id: nil, code: 'SAL-HY-PAGE-EA', name: 'SAL HY Page to East-Asia', details:
+      {
+        scan_material_types: ['book', 'periodical'],
+        scan_service_point: 'EAST-ASIA',
+        scan_pseudopatron_barcode: 'EAL-SCANREVIEW'
+      })
+  end
+
+  let(:locations) do
+    [
+      aeon_pageable_location,
+      mediated_pageable_location,
+      pageable_location,
+      scannable_location
+    ]
+  end
+
+  let(:rules) { Folio::LocationRules.rules_by_request_type(locations.map(&:rules).flatten) }
+
+  let(:request) { Request.new }
+
+  before do
+    allow(RequestAbilities).to receive(:rules).and_return(rules)
+    allow(Settings).to receive(:default_pickup_library).and_return('GREEN')
+  end
+
+  context 'when the requested item is in an aeon pageable location' do
+    before do
+      allow(request).to receive(:library_location).and_return(LibraryLocation.new('ARS', 'ARS-RECORDINGS'))
+    end
+
+    it 'is aeon pageable' do
+      expect(request).to be_aeon_pageable
+    end
+
+    it 'has the configured site for delivery from aeon' do
+      expect(request.aeon_site).to eq 'ARS'
+    end
+  end
+
+  context 'when the requested item is in a mediated pageable location' do
+    before do
+      allow(request).to receive(:location).and_return(mediated_pageable_location)
+    end
+
+    it 'is mediated pageable' do
+      expect(request).to be_mediateable
+    end
+
+    it 'only allows the configured service point for pickup' do
+      expect(request.pickup_libraries).to eq ['EARTH-SCI']
+    end
+  end
+
+  context 'when the requested item is in a pageable location' do
+    before do
+      allow(request).to receive(:location).and_return(pageable_location)
+    end
+
+    it 'is pageable' do
+      expect(request).to be_pageable
+    end
+
+    it 'only allows the configured service points for pickup' do
+      expect(request.pickup_libraries).to eq ['MUSIC', 'MEDIA-CENTER']
+    end
+  end
+
+  context 'when the requested item is in a scannable location' do
+    before do
+      allow(request).to receive(:location).and_return(scannable_location)
+    end
+
+    context 'when the requested item is of a scannable material type' do
+      before do
+        allow(request).to receive(:material_type).and_return('book')
+      end
+
+      it 'is scannable' do
+        expect(request).to be_scannable
+      end
+
+      it 'has the configured service point for scanning' do
+        expect(request.pickup_libraries).to eq ['EAST-ASIA']
+      end
+
+      it 'has the configured pseudopatron barcode for scanning'
+    end
+
+    context 'when the requested item is not of a scannable material type' do
+      before do
+        allow(request).to receive(:material_type).and_return('map')
+      end
+
+      it 'is not scannable' do
+        expect(request).not_to be_scannable
+      end
+    end
+  end
+
+  context 'when there are no rules matching the item' do
+    before do
+      allow(request).to receive(:location).and_return(Folio::Location.new(id: nil, code: 'GRE-STACKS', name: 'Green Stacks'))
+    end
+
+    it 'is pageable' do
+      expect(request).to be_pageable
+    end
+
+    it 'uses the fallback service point for paging' do
+      expect(request).pickup_libraries.to eq ['GREEN']
+    end
+
+    it 'is not scannable' do
+      expect(request).not_to be_scannable
+    end
+  end
+end


### PR DESCRIPTION
- Create a seam for changing the LocationRules implementation
- Rename methods in LocationRules and RequestAbilities to ease overrides
- Add folio graphQL client for location rule queries
- Create models for FOLIO locations and service points
- Implementation for LocationRules in FOLIO
