### PR TITLE
Don't send scans to the ILS if there is no configured destination

### DIFF
--- a/app/jobs/submit_scan_request_job.rb
+++ b/app/jobs/submit_scan_request_job.rb
@@ -13,6 +13,9 @@ class SubmitScanRequestJob < ApplicationJob
 
     scan.notify_ilb! if scan.illiad_error?
 
-    scan.send_to_ils_later!
+    # This ensures that only scan rules with a destination get sent to the ILS.
+    # We no longer want to send SAL3 requests to the ILS as this is handled by the ILLiad integration.
+    # SAL1/2 requests still go to the ILS at this time.
+    scan.send_to_ils_later! if scan.scan_destination.present?
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -171,6 +171,10 @@ class Request < ActiveRecord::Base
     location_rule&.pickup_libraries
   end
 
+  def scan_destination
+    {}
+  end
+
   class << self
     # The mediateable_origins will make multiple (efficient) database requests
     # in order to return the array of locations that are both configured as mediateable and have existing requests.

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -31,6 +31,11 @@ class Scan < Request
     RequestStatusMailer.request_status_for_scan(self).deliver_later if notification_email_address.present?
   end
 
+  # @return [Hash]
+  def scan_destination
+    scannable_location_rule&.destination || {}
+  end
+
   private
 
   def requested_item_is_not_scannable_only

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -623,10 +623,6 @@ hold_recallable:
       - INPROCESS
       - ON-ORDER
 
-default_scan_destination:
-  key: 'GREEN'
-  patron_barcode: 'GRE-SCANDELIVER'
-
 scannable:
   - library: SAL
     item_types:

--- a/spec/jobs/submit_scan_request_job_spec.rb
+++ b/spec/jobs/submit_scan_request_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SubmitScanRequestJob, type: :job do
       allow(Request.ils_job_class).to receive(:perform_later)
     end
 
-    let(:scan) { create(:scan, :without_validations) }
+    let(:scan) { create(:scan, :with_holdings) }
     let(:illiad_request) { instance_double(IlliadRequest, request!: double(body: { 'IlliadResponse' => 'Blah' }.to_json)) }
 
     it 'makes a request to illiad' do


### PR DESCRIPTION
Ref #1522 

This will allow us to complete #1522 by removing the `destination:` from the settings.yml.