### PR TITLE
Add ability for folio job to log its params and display them for debugging

### DIFF
--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -40,11 +40,13 @@ class SubmitSymphonyRequestJob < ApplicationJob
     delegate :user, to: :request
     delegate :patron, to: :user
 
-    def initialize(request, symphony_client: nil, barcode: nil)
+    # rubocop:disable Lint/UnusedMethodArgument
+    def initialize(request, logger: nil, symphony_client: nil, barcode: nil)
       @request = request
       @symphony_client = symphony_client || SymphonyClient.new
       @barcode = barcode
     end
+    # rubocop:enable Lint/UnusedMethodArgument
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def execute!

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# :nodoc:
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end

--- a/app/models/concerns/ils_request.rb
+++ b/app/models/concerns/ils_request.rb
@@ -18,7 +18,7 @@ module IlsRequest
 
   # This is used only in the debug view
   def ils_request_command
-    ils_job_class.command.new(self)
+    ils_job_class.command.new(self, logger:)
   end
 
   # NOTE: symphony_response_data + folio_response_data are stored in the JSON in the "data" column

--- a/app/models/folio_command_log.rb
+++ b/app/models/folio_command_log.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# This is a log of the requests made to the FOLIO API.
+# We keep this log so that we can see the request made on the debug page
+class FolioCommandLog < ApplicationRecord
+  belongs_to :request
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -40,6 +40,7 @@ class Request < ActiveRecord::Base
   serialize :barcodes, Array
 
   has_many :admin_comments
+  has_many :folio_command_logs
   belongs_to :user, autosave: true, optional: true
   accepts_nested_attributes_for :user
 

--- a/app/views/requests/status.html.erb
+++ b/app/views/requests/status.html.erb
@@ -33,6 +33,7 @@
       <h4>ILS Request</h4>
       <h5>Web Services Request</h5>
       <pre class="well"><%= JSON.pretty_generate(current_request.ils_request_command.request_params) %></pre>
+
       <h4>ILS Response</h4>
       <pre class="well"><%= JSON.pretty_generate(current_request.ils_response_data || {}) %></pre>
     <% end %>

--- a/db/migrate/20230703181415_create_folio_command_log.rb
+++ b/db/migrate/20230703181415_create_folio_command_log.rb
@@ -1,0 +1,15 @@
+class CreateFolioCommandLog < ActiveRecord::Migration[7.0]
+  def change
+    create_table :folio_command_logs do |t|
+      # Storing these UUIDs as strings because Sqlite doesn't have a UUID type.
+      t.string :pickup_location_id, null: false
+      t.string :user_id, null: false
+      t.string :barcode, null: false
+      t.string :item_id, null: false
+      t.string :patron_comments
+      t.date :expiration_date, null: false
+      t.references :request, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_24_160954) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_181415) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "commenter"
     t.string "comment"
     t.integer "request_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "folio_command_logs", force: :cascade do |t|
+    t.string "pickup_location_id", null: false
+    t.string "user_id", null: false
+    t.string "barcode", null: false
+    t.string "item_id", null: false
+    t.string "patron_comments"
+    t.date "expiration_date", null: false
+    t.integer "request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["request_id"], name: "index_folio_command_logs_on_request_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -63,4 +76,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_24_160954) do
     t.index ["sunetid"], name: "unique_users_by_sunetid", unique: true
   end
 
+  add_foreign_key "folio_command_logs", "requests"
 end

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SubmitFolioRequestJob do
       end
 
       it 'calls the create_item_hold API method' do
-        described_class.perform_now(request.id)
+        expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
         expect(client).to have_received(:create_item_hold).with('562a5cb0-e998-4ea2-80aa-34ac2b536238', 4, FolioClient::HoldRequest)
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe SubmitFolioRequestJob do
       end
 
       it 'calls the create_item_hold API method' do
-        described_class.perform_now(request.id)
+        expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
         expect(client).to have_received(:create_item_hold).with('2bd36e69-1f58-4f6b-9073-e8d932edeed2', 4, FolioClient::HoldRequest)
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe SubmitFolioRequestJob do
       end
 
       it 'calls the create_item_hold API method' do
-        described_class.perform_now(request.id)
+        expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(2)
         # once for each barcode
         expect(client).to have_received(:create_item_hold).with('0ba81714-52d4-4f37-8b4d-f9d929af048d', 4, FolioClient::HoldRequest).twice
       end


### PR DESCRIPTION
The SubmitFolioRequestJob::Command does not have a method called request_params. We can ignore this as it's on the debug page.

Fixes #1560