### PR TITLE
Delegate to requests to HoldRecall for FOLIO in-process items

### DIFF
--- a/app/models/folio/holdings.rb
+++ b/app/models/folio/holdings.rb
@@ -32,6 +32,10 @@ module Folio
       all.one? && all.first.checked_out?
     end
 
+    def single_in_process_item?
+      all.one? && all.first.processing?
+    end
+
     private
 
     def items_and_holdings

--- a/app/models/request_abilities.rb
+++ b/app/models/request_abilities.rb
@@ -43,13 +43,14 @@ class RequestAbilities
   # returns a true if any of the following is true
   #   - The incoming request includes a barcode (which means an item-level link, likely a checked out item)
   #   - The home location or current location is an allowed recallable location by Settings.hold_recallable
-  #   - There is only a single item to be requested and it is checked out
+  #   - There is only a single item to be requested and it is checked out or in process
   def hold_recallable?
     return false unless Settings.features.hold_recall_service
 
     request.barcode_present? ||
       hold_recallable_location? ||
-      single_checked_out_item?
+      single_checked_out_item? ||
+      single_in_process_item?
   end
 
   def pageable?
@@ -72,6 +73,10 @@ class RequestAbilities
 
   def single_checked_out_item?
     request.holdings_object.single_checked_out_item?
+  end
+
+  def single_in_process_item?
+    request.holdings_object.single_in_process_item?
   end
 
   def applicable_rules(request_type)

--- a/app/models/searchworks/holdings.rb
+++ b/app/models/searchworks/holdings.rb
@@ -35,6 +35,10 @@ module Searchworks
       all.one? && all.first.checked_out?
     end
 
+    def single_in_process_item?
+      all.one? && all.first.processing?
+    end
+
     private
 
     def library

--- a/spec/features/admin_comment_spec.rb
+++ b/spec/features/admin_comment_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Comments', js: true do
   let(:user) { create(:superadmin_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:request_status) do
     instance_double(ItemStatus, approved?: true, errored?: false, approver: 'bob', approval_time: '2023-05-31')
   end

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a mediated page request' do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) { [] }
 
   before do
@@ -135,7 +137,9 @@ RSpec.describe 'Creating a mediated page request' do
       ]
     end
 
-    let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items, single_checked_out_item?: false) }
+    let(:holdings_relationship) do
+      double(:relationship, where: selected_items, all: all_items, single_checked_out_item?: false, single_in_process_item?: false)
+    end
 
     let(:all_items) do
       [

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -7,7 +7,9 @@ require 'rails_helper'
 # Our controller tests are going to have to be sufficient where we test that we redirect
 # to the illiad URL passing the create scan URL via GET and that the create scan URL via GET works.
 RSpec.describe 'Create Scan Request' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe 'Home Page' do
   end
 
   describe 'mediation section' do
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) do
+      double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false)
+    end
 
     before do
       allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/features/honey_pot_field_spec.rb
+++ b/spec/features/honey_pot_field_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Honey Pot Fields' do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false) }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Item Selector' do
-  let(:holdings_relationship) { double(:relationship, where: requested_items, all: all_items, single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: requested_items, all: all_items, single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:all_items) { [] }
   let(:requested_items) { [] }
 

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Library Instructions' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: true) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: true, single_in_process_item?: false)
+  end
   let(:selected_items) { [double(:item, checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false)] }
 
   before do

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Mark As Complete', js: true do
   let(:user) { create(:superadmin_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:request_status) do
     instance_double(ItemStatus, approved?: true, errored?: false, approver: 'bob', approval_time: '2023-05-31')
   end

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -126,7 +126,9 @@ RSpec.describe 'Viewing all requests' do
 
   describe 'displays on a request page' do
     let(:message) { create(:message) }
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) do
+      double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false)
+    end
 
     before do
       allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/modal_layout_spec.rb
+++ b/spec/features/modal_layout_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Modal Layout' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Paging Schedule' do
-  let(:holdings_relationship) { double(:relationship, where: [], all: all_items, single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: [], all: all_items, single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:all_items) do
     [
       double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, barcode: '123123124',

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Pickup Libraries Dropdown' do
   let(:standard_pickup_lib_total) { Settings.default_pickup_libraries.count }
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false) }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Requests Delegation' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,

--- a/spec/features/requests_public_notes_spec.rb
+++ b/spec/features/requests_public_notes_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Public Notes', js: true do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items, single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: all_items, single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, barcode: '12345678', checked_out?: false, processing?: false, missing?: false, hold?: false,

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Send Request Buttons' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,

--- a/spec/features/status_page_spec.rb
+++ b/spec/features/status_page_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Status Page' do
   let(:request) { create(:mediated_page, user:) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) { [] }
 
   before do

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -7,7 +7,9 @@ describe RequestsHelper do
 
   describe '#select_for_pickup_libraries' do
     let(:form) { double('form') }
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) do
+      double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false)
+    end
 
     before do
       allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/jobs/submit_borrow_direct_request_job_spec.rb
+++ b/spec/jobs/submit_borrow_direct_request_job_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe SubmitBorrowDirectRequestJob, type: :job do
 
     context 'when the item is requestable and the request succeeds' do
       let(:user) { create(:sso_user) }
-      let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+      let(:holdings_relationship) do
+        double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+      end
       let(:selected_items) { [] }
 
       before do

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
     describe '#perform' do
       context 'when the request is found' do
         let(:mock_client) { instance_double(SymphonyClient) }
-        let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+        let(:holdings_relationship) do
+          double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+        end
         let(:selected_items) { [] }
 
         before do

--- a/spec/mailers/factories/request_status_mailer_factory_spec.rb
+++ b/spec/mailers/factories/request_status_mailer_factory_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe RequestStatusMailerFactory do
   subject(:mailer) { described_class.for(request) }
 
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) { [] }
 
   before do

--- a/spec/mailers/mediation_mailer_spec.rb
+++ b/spec/mailers/mediation_mailer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe MediationMailer do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) { [] }
 
   describe 'mediator_notification' do

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe RequestStatusMailer do
     let(:request) { build_stubbed(:page, user:) }
     let(:mailer_method) { :request_status_for_page }
     let(:mail) { described_class.send(mailer_method, request) }
-    let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) do
+      double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+    end
     let(:selected_items) { [] }
 
     before do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -79,7 +79,9 @@ describe Ability do
       it { is_expected.to be_able_to(:create, mediated_page) }
 
       describe 'and views a success page with a token' do
-        let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+        let(:holdings_relationship) do
+          double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false)
+        end
 
         before do
           allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/models/concerns/hold_recallable_spec.rb
+++ b/spec/models/concerns/hold_recallable_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'HoldRecallable' do
   subject(:request) { build(:request) }
 
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false) }
 
   before do
     allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
@@ -59,6 +59,18 @@ RSpec.describe 'HoldRecallable' do
       end
     end
 
+    context 'when a single item is in process' do
+      let(:holdings_object) do
+        instance_double(Searchworks::Holdings, single_in_process_item?: true, single_checked_out_item?: false, all: [], where: [])
+      end
+
+      before do
+        allow(request).to receive(:holdings_object).and_return(holdings_object)
+      end
+
+      it { is_expected.to be_hold_recallable }
+    end
+
     describe 'when ON-ORDER' do
       it 'is true when the origin_location is ON-ORDER' do
         request.origin_location = 'ON-ORDER'
@@ -86,7 +98,8 @@ RSpec.describe 'HoldRecallable' do
 
     context 'when CHECKEDOUT' do
       let(:holdings_object) do
-        instance_double(Searchworks::Holdings, single_checked_out_item?: single_checked_out, all: [], where: [])
+        instance_double(Searchworks::Holdings, single_checked_out_item?: single_checked_out, single_in_process_item?: false, all: [],
+                                               where: [])
       end
 
       before do

--- a/spec/models/concerns/pageable_spec.rb
+++ b/spec/models/concerns/pageable_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'Pageable' do
 
   describe '#pageable?' do
     context 'when the LibraryLocation is not mediatable or hold recallable' do
-      let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+      let(:holdings_relationship) do
+        double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false)
+      end
 
       before do
         request.origin = 'GREEN'

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/models/item_status_spec.rb
+++ b/spec/models/item_status_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ItemStatus do
   subject { described_class.new(request, barcode) }
 
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false) }
   let(:request) { create(:mediated_page_with_single_holding) }
   let(:barcode) { '3610512345' }
 

--- a/spec/models/request_approval_status_spec.rb
+++ b/spec/models/request_approval_status_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe RequestApprovalStatus do
 
       context 'for mediated pages' do
         let(:request) { create(:page_mp_mediated_page) }
-        let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+        let(:holdings_relationship) do
+          double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+        end
         let(:selected_items) { [] }
 
         before do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Request do
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false) }
   let(:bib_data) { double(:bib_data, title: 'Test title') }
 
   before do
@@ -82,7 +82,9 @@ RSpec.describe Request do
           origin_location: 'SAL-TEMP'
         )
       end
-      let(:holdings_relationship) { double(:relationship, where: [], all: all_holdings, single_checked_out_item?: false) }
+      let(:holdings_relationship) do
+        double(:relationship, where: [], all: all_holdings, single_checked_out_item?: false, single_in_process_item?: false)
+      end
 
       let(:all_holdings) do
         # This is just used for Searchworks integration

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe HoldRecall do
   end
 
   describe 'send_approval_status!' do
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) do
+      double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false)
+    end
 
     before do
       allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/requests/admin_comments_requests_spec.rb
+++ b/spec/requests/admin_comments_requests_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'AdminComments' do
   let(:mediated_page) { create(:mediated_page) }
   let(:headers) { { 'HTTP_REFERER' => 'http://example.com' } }
   let(:url) { "/mediated_pages/#{mediated_page.id}/admin_comments" }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) { [] }
 
   before do

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe 'requests/status.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { build_stubbed(:page, user:) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) { [] }
 
   before do

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe 'requests/success.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { create(:page, user:, item_title: 'Test title') }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) do
+    double(:relationship, where: selected_items, all: [], single_checked_out_item?: false, single_in_process_item?: false)
+  end
   let(:selected_items) do
     [
       double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'shared/_request_status_information.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { create(:scan, :without_validations, :with_item_title, user:) }
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false, single_in_process_item?: false) }
 
   before do
     allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)


### PR DESCRIPTION
If there is a single item and it's being processed, don't offer
the user the option to page or scan and instead treat it as a
hold recall.
