### PR TITLE
Re add picklists for Symphony -> FOLIO migration interim time

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,7 +10,7 @@ class AdminController < ApplicationController
     )
   end
 
-  before_action :load_and_authorize_library_location, only: [:show]
+  before_action :load_and_authorize_library_location, only: [:show, :picklist]
 
   def index
     authorize! :manage, Request.new
@@ -21,6 +21,15 @@ class AdminController < ApplicationController
   def show
     @dates = next_three_days_with_requests
     @mediated_pages = mediated_pages
+  end
+
+  def picklist
+    @range = range_param
+    @items = origin_filtered_mediated_pages.where(updated_at: @range).flat_map do |request|
+      request_has_items_approved_within_range?(request, @range)
+    end
+
+    render layout: false
   end
 
   def holdings

--- a/app/mailers/picklist_mailer.rb
+++ b/app/mailers/picklist_mailer.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+###
+#  Mailer class to send emails to mediators after requests have been submitted
+###
+class PicklistMailer < ApplicationMailer
+  # Send a picklist email that includes all items approved since the last time the
+  # picklist was generated.
+  def self.deliver_picklist(
+    location,
+    last_run_file: nil,
+    default: (1.day.ago)...Time.zone.now
+  )
+    last_run_file ||= Rails.root + "tmp/state/picklist_last_send_#{location}_#{Rails.env}"
+
+    with_last_run_bookkeeping(last_run_file) do |stored_last_run|
+      range = stored_last_run.present? ? Time.zone.parse(stored_last_run)...Time.zone.now : default
+
+      picklist_notification(location, range:).deliver_now
+
+      range.last
+    end
+  end
+
+  def self.with_last_run_bookkeeping(file)
+    File.open(file, File::RDWR | File::CREAT) do |f|
+      f.flock(File::LOCK_EX)
+      current_value = f.read
+
+      new_value = yield(current_value)
+
+      f.rewind
+      f.write(new_value.to_s)
+      f.flush
+      f.truncate(f.pos)
+    end
+  end
+
+  def picklist_notification(location, range:)
+    @items = approved_items_from(location, range)
+
+    return if @items.empty?
+
+    attachments["picklist-#{range.first.iso8601}.html"] = ApplicationController.render(
+      template: 'admin/picklist',
+      layout: false,
+      assigns: { items: @items, range: }
+    )
+
+    mail(
+      to: picklist_notification_email_address(location),
+      subject: "#{location} picklist"
+    )
+  end
+
+  private
+
+  def picklist_notification_email_address(location)
+    Rails.application.config.picklist_contact_info.fetch(
+      location
+    )[:email]
+  end
+
+  def approved_items_from(location, range)
+    MediatedPage.for_origin(location).where(updated_at: range).flat_map do |request|
+      request.item_statuses.select do |item_status|
+        item_status.approved? &&
+          item_status.approval_time &&
+          Time.zone.parse(item_status.approval_time).between?(range.begin, range.end)
+      end
+    end
+  end
+end

--- a/app/views/admin/_picklist_item.html.erb
+++ b/app/views/admin/_picklist_item.html.erb
@@ -1,0 +1,28 @@
+<%- request = item_status.request %>
+<div class="request">
+  <small class="req-id">
+    Request ID #<%= request.id %>
+    <% if request.item_statuses.count > 1 %>
+     (item <%= request.item_statuses.map(&:id).index(item_status.id) + 1 %> of <%= request.item_statuses.count %>)
+   <% end %>
+  </small>
+  <table>
+    <tr><th scope="row">Call Number:</th><td><%= item_status.catalog_info.display_call_number %></td></tr>
+    <tr><th scope="row">Home Location:</th><td><%= request.origin_location %></td></tr>
+    <tr><th scope="row">Current Location:</th><td><%= item_status.catalog_info.current_location %></td></tr>
+    <tr><th scope="row">Title:</th><td><span class="text"><%= request.item_title %></span></td></tr>
+    <tr><th scope="row">Author:</th><td><span class="text"><%= request.bib_info.author %></span></td></tr>
+    <tr><th scope="row">Pubyear:</th><td><%= request.bib_info.pub_year %></td></tr>
+    <tr><th scope="row">Cat key:</th><td><%= request.item_id %></td></tr>
+    <tr><th scope="row">Item ID:</th><td><%= item_status.id %></td></tr>
+    <tr><th scope="row">Copy Note:</th><td><span class="text"><%= (request.public_notes || {})[item_status.id] %></span></td></tr>
+    <tr><th scope="row">User ID:</th><td><%= request.user.library_id %></td></tr>
+    <tr><th scope="row">User Name:</th><td><span class="text"><%= request.user.name %></span></td></tr>
+    <tr><th scope="row">User Email:</th><td><span class="text"><%= request.user.email_address %></span></td></tr>
+    <tr><th scope="row">User Profile:</th><td><%= request.user.patron&.profile_key %></td></tr>
+    <tr><th scope="row">User Item Note:</th><td><span class="text"><%= request.item_comment %></span></td></tr>
+    <tr><th scope="row">User Request Comment:</th><td><span class="text"><%= request.request_comment %></span></td></tr>
+    <tr><th scope="row">Planned Date of Use:</th><td><%= l(request.needed_date.to_date, format: :short) if request.needed_date %></td></tr>
+    <tr><th scope="row">Request Date:</th><td><%= l(request.created_at.to_date, format: :short) %></td></tr>
+  </table>
+</div>

--- a/app/views/admin/picklist.html.erb
+++ b/app/views/admin/picklist.html.erb
@@ -1,0 +1,79 @@
+<html>
+<head>
+  <style>
+    @media print {
+      .page {
+        page-break-after: always;
+      }
+      .page:last-of-type {
+        page-break-after: inherit;
+      }
+    }
+
+    @media screen {
+      body {
+        background-color: #f8f8f8;
+      }
+      .page {
+        background-color: #fff;
+        margin-bottom: 50px;
+        border: 1px solid #ccc;
+        box-shadow: 3px 3px 3px #ddd;
+      }
+    }
+
+    .page {
+      position: relative;
+      height: 11in;
+      width: 8.5in;
+      box-sizing: border-box;
+      padding-top: 0.5in;
+      padding-bottom: 0.5in;
+      padding-left: 0.5in;
+      padding-right: 0.5in;
+      overflow: hidden;
+    }
+
+    .request {
+      position: relative;
+      margin-bottom: 0.5in;
+    }
+
+    hr + .request {
+      margin-top: 0.5in;
+    }
+
+    .req-id { position: absolute; right: 0; bottom: 0; }
+
+    th { text-align: right; padding-right: 1em; width: 22ch; }
+    hr {
+      margin-left: -0.5in;
+      margin-right: -0.5in;
+    }
+
+    tbody {
+      vertical-align: top;
+    }
+
+    .text {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+<% @items.each do |item_status| %>
+  <div class="page">
+    <% item_markup = capture do %>
+      <%= render 'admin/picklist_item', item_status: item_status %>
+    <% end %>
+
+    <%= item_markup %>
+    <hr />
+    <%= item_markup %>
+  </div>
+  <% end %>
+</body>
+</html>

--- a/app/views/picklist_mailer/picklist_notification.html.erb
+++ b/app/views/picklist_mailer/picklist_notification.html.erb
@@ -1,0 +1,3 @@
+Requests for SPEC-COLL can be printed from the attached file.
+
+Number of requests: <%= @items.count %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,6 @@ module SULRequests
     }
 
     config.picklist_contact_info = {
-      'SPEC-COLL' => { email: 'specialcollections@stanford.edu' }
     }
 
     config.illiad_nvtgc_map = {

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,10 @@ module SULRequests
       'RUMSEYMAP'  => { email: 'sul-requests-rumsey@lists.stanford.edu' }
     }
 
+    config.picklist_contact_info = {
+      'SPEC-COLL' => { email: 'specialcollections@stanford.edu' }
+    }
+
     config.illiad_nvtgc_map = {
       default: 'st2',
       'organization:law' => 'rcj',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
 
   resources :admin, only: [:index, :show] do
     member do
+      get :picklist
       get :holdings, as: :holdings
       get :approve_item, as: :approve_item
     end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,11 +1,3 @@
-every '30 11 * * 1-5', roles: :production_cron do
-  runner 'PicklistMailer.deliver_picklist "SPEC-COLL"'
-end
-
-every '30 15 * * 1-5', roles: :production_cron do
-  runner 'PicklistMailer.deliver_picklist "SPEC-COLL"'
-end
-
 every '* * * * *' do
   runner 'ExpireCdlCheckoutsJob.perform_now'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,11 @@
+every '30 11 * * 1-5', roles: :production_cron do
+  runner 'PicklistMailer.deliver_picklist "SPEC-COLL"'
+end
+
+every '30 15 * * 1-5', roles: :production_cron do
+  runner 'PicklistMailer.deliver_picklist "SPEC-COLL"'
+end
+
 every '* * * * *' do
   runner 'ExpireCdlCheckoutsJob.perform_now'
 end

--- a/spec/mailers/picklist_mailer_spec.rb
+++ b/spec/mailers/picklist_mailer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PicklistMailer do
+  describe '.deliver_picklist' do
+    let(:state_file) do
+      Tempfile.new('foo').tap do |t|
+        t.write(last_run_time)
+        t.rewind
+        t.close
+      end
+    end
+    let(:last_run_time) { Time.zone.parse('2020-08-01T00:00:00Z') }
+    let(:now) { Time.zone.parse('2020-08-15T00:00:00Z') }
+
+    before do
+      allow(Time.zone).to receive(:now).and_return(now)
+      allow(described_class).to receive(:picklist_notification).and_return(double(deliver_now: true))
+    end
+
+    it 'sends a picklist since the last time it was run' do
+      described_class.deliver_picklist('ART', last_run_file: state_file.path)
+
+      expect(described_class).to have_received(:picklist_notification).with('ART', range: last_run_time...now)
+    end
+
+    it 'defaults to the last day' do
+      described_class.deliver_picklist('ART', last_run_file: Tempfile.new('whatever').path)
+
+      expect(described_class).to have_received(:picklist_notification).with('ART', range: (now - 1.day)...now)
+    end
+
+    it 'records its last run time' do
+      described_class.deliver_picklist('ART', last_run_file: state_file.path)
+
+      expect(File.read(state_file.path)).to eq now.to_s
+    end
+  end
+
+  describe '#picklist_notification' do
+    let(:user) { create(:superadmin_user) }
+    let(:mock_client) do
+      instance_double(SymphonyClient, login_by_library_id: nil, bib_info: {}, catalog_info: {}, patron_info: {})
+    end
+
+    before do
+      allow(SymphonyClient).to receive(:new).and_return(mock_client)
+      allow(SubmitSymphonyRequestJob).to receive(:perform_now)
+
+      create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
+      b = create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
+      b.item_statuses.to_a.first.approve!(user, 5.days.ago)
+      b.item_statuses.to_a.last.approve!(user, 1.day.ago)
+      c = create(:mediated_page_with_holdings, user: create(:non_sso_user), barcodes: %w(12345678 23456789))
+      c.item_statuses.first.approve!(user, 1.day.ago)
+    end
+
+    it 'attaches a picklist' do
+      skip 'SPEC-COLL is using Aeon now'
+      mail = described_class.picklist_notification('SPEC-COLL', range: (2.days.ago)...Time.zone.now)
+
+      expect(mail.to).to include 'specialcollections@stanford.edu'
+      expect(mail.attachments.length).to eq 1
+
+      body = Capybara.HTML(mail.attachments.first.decode_body)
+
+      expect(body).to have_css '.page', count: 2
+      expect(body).to have_content '23456789'
+      expect(body).to have_content '12345678'
+    end
+  end
+end

--- a/spec/routing/admin_routing_spec.rb
+++ b/spec/routing/admin_routing_spec.rb
@@ -15,5 +15,9 @@ describe AdminController, type: :routing do
     it 'routes to #holdings' do
       expect(get: '/admin/1/holdings').to route_to('admin#holdings', id: '1')
     end
+
+    it 'routes to #picklists' do
+      expect(get: '/admin/SPEC-COLL/picklist').to route_to('admin#picklist', id: 'SPEC-COLL')
+    end
   end
 end


### PR DESCRIPTION
Part of #1578 

TODO:
- [ ] remove spec-coll-isms
- [ ] streamline picklists for paging (remove excess bib. info, patron details, etc)
- [ ] reformat picklist into a table (e.g. no need to provide picklist info in duplicate, 1 request per page)