### PR TITLE
Delegate hold-recallability to ILS-specific implementations

### DIFF
--- a/app/components/request_and_pickup_button_component.rb
+++ b/app/components/request_and_pickup_button_component.rb
@@ -23,7 +23,7 @@ class RequestAndPickupButtonComponent < ViewComponent::Base
   end
 
   def single_checked_out_item?
-    @current_request.holdings_object.all.one? && @current_request.holdings_object.all.first.checked_out?
+    @current_request.holdings_object.one? && @current_request.holdings_object.all?(&:checked_out?)
   end
 
   def single_library_value

--- a/app/components/request_and_pickup_button_component.rb
+++ b/app/components/request_and_pickup_button_component.rb
@@ -23,7 +23,7 @@ class RequestAndPickupButtonComponent < ViewComponent::Base
   end
 
   def single_checked_out_item?
-    @current_request.holdings_object.single_checked_out_item?
+    @current_request.holdings_object.all.one? && @current_request.holdings_object.all.first.checked_out?
   end
 
   def single_library_value

--- a/app/components/scan_to_pdf_button_component.rb
+++ b/app/components/scan_to_pdf_button_component.rb
@@ -15,7 +15,7 @@ class ScanToPdfButtonComponent < ViewComponent::Base
   end
 
   def single_checked_out_item?
-    @current_request.holdings_object.single_checked_out_item?
+    @current_request.holdings_object.all.one? && @current_request.holdings_object.all.first.checked_out?
   end
 
   def single_library_value

--- a/app/components/scan_to_pdf_button_component.rb
+++ b/app/components/scan_to_pdf_button_component.rb
@@ -15,7 +15,7 @@ class ScanToPdfButtonComponent < ViewComponent::Base
   end
 
   def single_checked_out_item?
-    @current_request.holdings_object.all.one? && @current_request.holdings_object.all.first.checked_out?
+    @current_request.holdings_object.one? && @current_request.holdings_object.all?(&:checked_out?)
   end
 
   def single_library_value

--- a/app/models/concerns/holdings.rb
+++ b/app/models/concerns/holdings.rb
@@ -18,11 +18,13 @@ module Holdings
 
   # @return [Array<OpenStruct>] a list of every holding in the requested library/location
   def all_holdings
-    holdings_object.all
+    holdings_object
   end
 
   # @return [Array<OpenStruct>] a list of every holding in the requested library/location with the requested barcodes
   def requested_holdings
-    holdings_object.where(barcodes: Array(requested_barcode || barcodes))
+    requested_item_barcodes = Set.new(Array(requested_barcode || barcodes))
+
+    holdings_object.select { |item| requested_item_barcodes.include? item.barcode }
   end
 end

--- a/app/models/folio/holdings.rb
+++ b/app/models/folio/holdings.rb
@@ -28,6 +28,8 @@ module Folio
       end
     end
 
+    # TODO: extend Enumerable so .all?, .any?, etc. are simpler
+
     private
 
     def items_and_holdings

--- a/app/models/folio/holdings.rb
+++ b/app/models/folio/holdings.rb
@@ -28,10 +28,6 @@ module Folio
       end
     end
 
-    def single_checked_out_item?
-      all.one? && all.first.checked_out?
-    end
-
     private
 
     def items_and_holdings

--- a/app/models/folio/item_with_status.rb
+++ b/app/models/folio/item_with_status.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Folio
-  # Other status that we aren't using include "Unavailable", "In process", "Intellectual item", "In transit"
+  # Other statuses that we aren't using include "Unavailable" and "Intellectual item"
   STATUS_CHECKED_OUT = 'Checked out'
   STATUS_ON_ORDER = 'On order'
   STATUS_AVAILABLE = 'Available'
@@ -9,6 +9,13 @@ module Folio
   STATUS_MISSING = 'Missing'
   STATUS_IN_PROCESS_NR = 'In process (non-requestable)'
   STATUS_IN_PROCESS = 'In process'
+  STATUS_AWAITING_PICKUP = 'Awaiting pickup'
+  STATUS_AWAITING_DELIVERY = 'Awaiting delivery'
+  STATUS_IN_TRANSIT = 'In transit'
+  STATUS_MISSING = 'Missing'
+  STATUS_PAGED = 'Paged'
+  STATUS_RESTRICTED = 'Restricted'
+  STATUS_NONE = ''
 
   PAGE_LOCATIONS = %w(HILA-SAL3-STACKS
                       HILA-SAL3-STACKS
@@ -19,6 +26,21 @@ module Folio
                       SPEC-SAL3-RBC
                       SPEC-SAL3-U-ARCHIVES
                       SPEC-SAL3-U-ARCHIVES).freeze
+
+  # Statuses that FOLIO treats as valid for intiating a hold/recall
+  # See: https://github.com/folio-org/mod-circulation/blob/master/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java#L71-L94
+  HOLD_RECALL_STATUSES = [
+    STATUS_CHECKED_OUT,
+    STATUS_AWAITING_PICKUP,
+    STATUS_AWAITING_DELIVERY,
+    STATUS_IN_TRANSIT,
+    STATUS_MISSING,
+    STATUS_PAGED,
+    STATUS_ON_ORDER,
+    STATUS_IN_PROCESS,
+    STATUS_RESTRICTED,
+    STATUS_NONE
+  ].freeze
 
   ItemWithStatus = Data.define(:barcode, :status, :request_status, :type, :public_note, :permanent_location, :temporary_location,
                                :callnumber) do
@@ -58,6 +80,10 @@ module Folio
 
     def paged?
       PAGE_LOCATIONS.include?(permanent_location)
+    end
+
+    def hold_recallable?
+      HOLD_RECALL_STATUSES.include?(status)
     end
   end
 end

--- a/app/models/request_abilities.rb
+++ b/app/models/request_abilities.rb
@@ -42,14 +42,14 @@ class RequestAbilities
 
   # returns a true if any of the following is true
   #   - The incoming request includes a barcode (which means an item-level link, likely a checked out item)
-  #   - The home location or current location is an allowed recallable location by Settings.hold_recallable
-  #   - There is only a single item to be requested and it is checked out
+  #   - The origin location is an allowed recallable location by Settings.hold_recallable
+  #   - All items in the holdings are hold/recallable, e.g. checked out, on order, in transit, etc.
   def hold_recallable?
     return false unless Settings.features.hold_recall_service
 
     request.barcode_present? ||
       hold_recallable_location? ||
-      single_checked_out_item?
+      all_items_hold_recallable?
   end
 
   def pageable?
@@ -66,12 +66,12 @@ class RequestAbilities
 
   private
 
-  def hold_recallable_location?
-    applicable_rules(:hold_recallable).any?
+  def all_items_hold_recallable?
+    request.holdings_object.all.any? && request.holdings_object.all.all?(&:hold_recallable?)
   end
 
-  def single_checked_out_item?
-    request.holdings_object.single_checked_out_item?
+  def hold_recallable_location?
+    applicable_rules(:hold_recallable).any?
   end
 
   def applicable_rules(request_type)

--- a/app/models/request_abilities.rb
+++ b/app/models/request_abilities.rb
@@ -67,7 +67,7 @@ class RequestAbilities
   private
 
   def all_items_hold_recallable?
-    request.holdings_object.all.any? && request.holdings_object.all.all?(&:hold_recallable?)
+    request.holdings_object.any? && request.holdings_object.all?(&:hold_recallable?)
   end
 
   def hold_recallable_location?

--- a/app/models/searchworks/holding_item.rb
+++ b/app/models/searchworks/holding_item.rb
@@ -49,7 +49,11 @@ module Searchworks
     end
 
     def missing?
-      MISSING_LOCATIONS.include?(current_location_code) # TODO: itemStatus == 'Missing' in Folio
+      MISSING_LOCATIONS.include?(current_location_code)
+    end
+
+    def hold_recallable?
+      checked_out? || missing? || processing? || on_order?
     end
   end
 end

--- a/app/models/searchworks/holdings.rb
+++ b/app/models/searchworks/holdings.rb
@@ -31,10 +31,6 @@ module Searchworks
       end
     end
 
-    def single_checked_out_item?
-      all.one? && all.first.checked_out?
-    end
-
     private
 
     def library

--- a/app/models/searchworks/holdings.rb
+++ b/app/models/searchworks/holdings.rb
@@ -31,6 +31,8 @@ module Searchworks
       end
     end
 
+    # TODO: extend Enumerable so .all?, .any?, etc. are simpler
+
     private
 
     def library

--- a/app/models/searchworks/holdings.rb
+++ b/app/models/searchworks/holdings.rb
@@ -5,6 +5,8 @@ module Searchworks
   #  Winnows down the entire holdings to just what was requested by the user
   ###
   class Holdings
+    include Enumerable
+
     # @param [Request] request the users request
     # @param [Array<Searchworks::Holding>] holdings all of the holdings for the requested item
     def initialize(request, holdings)
@@ -12,26 +14,14 @@ module Searchworks
       @holdings = holdings
     end
 
-    # @return [Array<OpenStruct>] a list of every holding in the requested library/location with the given barcodes
-    def where(barcodes: [])
-      return [] if barcodes.empty?
+    def each(&block)
+      return to_enum(:each) unless block
 
-      all.select do |item|
-        barcodes.include?(item.barcode)
-      end
-    end
-
-    # @return [Array<OpenStruct>] a list of every holding in the requested library/location
-    def all
-      return [] if location.blank?
-
-      location.items.map do |item|
+      location&.items&.each do |item|
         item.request_status = @request.item_status(item.barcode)
-        item
+        yield item
       end
     end
-
-    # TODO: extend Enumerable so .all?, .any?, etc. are simpler
 
     private
 

--- a/app/views/application/_item_selector.html.erb
+++ b/app/views/application/_item_selector.html.erb
@@ -18,7 +18,7 @@
       <%= barcode.hidden_field single_item.barcode.present? ? single_item.barcode : 'NO_BARCODE', value: 1 %>
     <% elsif f.object.all_holdings.many? %>
       <div id='selected-items-filter' data-behavior='item-selector' data-limit-reached-message="<%= t('sul_requests.limit_reached_message', limit: f.object.item_limit) %>">
-        <% if f.object.all_holdings.length >= 10 %>
+        <% if f.object.all_holdings.count >= 10 %>
           <div class='form-group'>
             <label class='control-label <%= label_column_class %>' for='item-selector-search'>Search item list</label>
             <div class='<%= content_column_class %>'>

--- a/app/views/scans/_form_additional.html.erb
+++ b/app/views/scans/_form_additional.html.erb
@@ -13,7 +13,7 @@
     Earliest delivery
   </div>
   <% if Settings.features.estimate_delivery %>
-    <div class='<%= content_column_class %> input-like-text' data-single-library-value='<%= 'SCAN' unless current_request.holdings_object.single_checked_out_item? %>'>
+    <div class='<%= content_column_class %> input-like-text' data-single-library-value='<%= 'SCAN' unless current_request.holdings_object.all.one? %>'>
       <span data-scheduler-text='true' aria-live='polite'></span>
       <%= f.hidden_field :estimated_delivery, data: { 'scheduler-field' => true } %>
     </div>

--- a/app/views/scans/_form_additional.html.erb
+++ b/app/views/scans/_form_additional.html.erb
@@ -13,7 +13,7 @@
     Earliest delivery
   </div>
   <% if Settings.features.estimate_delivery %>
-    <div class='<%= content_column_class %> input-like-text' data-single-library-value='<%= 'SCAN' unless current_request.holdings_object.all.one? %>'>
+    <div class='<%= content_column_class %> input-like-text' data-single-library-value='<%= 'SCAN' unless current_request.holdings_object.one? %>'>
       <span data-scheduler-text='true' aria-live='polite'></span>
       <%= f.hidden_field :estimated_delivery, data: { 'scheduler-field' => true } %>
     </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -637,13 +637,9 @@ default_pickup_libraries:
 
 hold_recallable:
   - locations:
-      - MISSING
-      - INPROCESS
-      - ON-ORDER
-  - current_locations:
-      - MISSING
-      - INPROCESS
-      - ON-ORDER
+    - MISSING
+    - INPROCESS
+    - ON-ORDER
 
 scannable:
   - library: SAL

--- a/spec/factories/scans.rb
+++ b/spec/factories/scans.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     trait :with_holdings_barcodes do
       with_holdings
       after(:build) do |scan|
-        scan.barcodes = [scan.holdings.first.barcode, scan.holdings.last.barcode]
+        scan.barcodes = [scan.holdings.first.barcode, scan.holdings.to_a.last.barcode]
       end
     end
   end

--- a/spec/features/admin_comment_spec.rb
+++ b/spec/features/admin_comment_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Comments', js: true do
   let(:user) { create(:superadmin_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:request_status) do
     instance_double(ItemStatus, approved?: true, errored?: false, approver: 'bob', approval_time: '2023-05-31')
   end
@@ -21,7 +20,7 @@ RSpec.describe 'Admin Comments', js: true do
   end
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
 
     stub_searchworks_api_json(build(:searchable_holdings))
     stub_current_user(user)
@@ -39,6 +38,8 @@ RSpec.describe 'Admin Comments', js: true do
       within(first('[data-mediate-request]')) do
         page.find('a.mediate-toggle').click
       end
+
+      expect(page).to have_css('.admin-comments')
 
       within('.admin-comments') do
         expect(page).to have_css('form#new_admin_comment', visible: :hidden)

--- a/spec/features/admin_comment_spec.rb
+++ b/spec/features/admin_comment_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Comments', js: true do
   let(:user) { create(:superadmin_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:request_status) do
     instance_double(ItemStatus, approved?: true, errored?: false, approver: 'bob', approval_time: '2023-05-31')
   end

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a mediated page request' do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   before do
@@ -135,7 +135,7 @@ RSpec.describe 'Creating a mediated page request' do
       ]
     end
 
-    let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items, single_checked_out_item?: false) }
+    let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items) }
 
     let(:all_items) do
       [

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -4,11 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a mediated page request' do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-  let(:selected_items) { [] }
+  let(:all_items) { [] }
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(all_items)
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
 
     allow_any_instance_of(PagingSchedule::Scheduler).to receive(:valid?).with(anything).and_return(true)
@@ -126,17 +125,6 @@ RSpec.describe 'Creating a mediated page request' do
   end
 
   describe 'selecting barcodes' do
-    let(:selected_items) do
-      [
-        double(:item, barcode: '12345678', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,
-                      callnumber: 'ABC 123'),
-        double(:item, barcode: '34567555', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,
-                      callnumber: 'ABC 321')
-      ]
-    end
-
-    let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items) }
-
     let(:all_items) do
       [
         double(:item, barcode: '12345678', checked_out?: false, processing?: false, missing?: false,

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -7,16 +7,16 @@ require 'rails_helper'
 # Our controller tests are going to have to be sufficient where we test that we redirect
 # to the illiad URL passing the create scan URL via GET and that the create scan URL via GET works.
 RSpec.describe 'Create Scan Request' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
-      double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123')
+      double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123', checked_out?: false, hold?: false, missing?: false,
+                    processing?: false, hold_recallable?: false)
     ]
   end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     allow(SubmitScanRequestJob).to receive(:perform_later)
     stub_searchworks_api_json(build(:sal3_holdings))
   end

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -7,7 +7,7 @@ require 'rails_helper'
 # Our controller tests are going to have to be sufficient where we test that we redirect
 # to the illiad URL passing the create scan URL via GET and that the create scan URL via GET works.
 RSpec.describe 'Create Scan Request' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Home Page' do
   end
 
   describe 'mediation section' do
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
     before do
       allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -45,10 +45,8 @@ RSpec.describe 'Home Page' do
   end
 
   describe 'mediation section' do
-    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
-
     before do
-      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+      allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
       create(:mediated_page)
       create(:page_mp_mediated_page)
       stub_current_user(create(:superadmin_user))

--- a/spec/features/honey_pot_field_spec.rb
+++ b/spec/features/honey_pot_field_spec.rb
@@ -4,11 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Honey Pot Fields' do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
     stub_current_user(user)
   end
 

--- a/spec/features/honey_pot_field_spec.rb
+++ b/spec/features/honey_pot_field_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Honey Pot Fields' do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -3,15 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Item Selector' do
-  let(:holdings_relationship) { double(:relationship, where: requested_items, all: all_items) }
-  let(:all_items) { [] }
-  let(:requested_items) { [] }
-
   let(:bib_data) { double(:bib_data, title: 'Test title') }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(bib_data)
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(all_items)
     stub_current_user(create(:sso_user))
   end
 
@@ -178,16 +174,16 @@ RSpec.describe 'Item Selector' do
                           hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890124', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 234', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890125', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 567', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890126', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 890', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890127', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?')
 
           ]
@@ -264,40 +260,21 @@ RSpec.describe 'Item Selector' do
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890124', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 234', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890125', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 567', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890126', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 890', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890127', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?')
 
-        ]
-      end
-      let(:requested_items) do
-        [
-          double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
-                        status_text: 'Available', public_note: 'huh?'),
-
-          double(:item, callnumber: 'ABC 456', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
-                        status_text: 'Available', public_note: 'huh?'),
-
-          double(:item, callnumber: 'ABC 789', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '34567890', status_class: 'available',
-                        status_text: 'Available', public_note: 'huh?'),
-
-          double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
-                        status_text: 'Available', public_note: 'huh?')
         ]
       end
 
@@ -354,8 +331,6 @@ RSpec.describe 'Item Selector' do
       end
 
       it 'persists items that are not currently visible due to filtering' do
-        skip('The CDN we load the date slider from seems to block Travis') if ENV['ci']
-
         fill_in_required_date
 
         within('#item-selector') do
@@ -454,19 +429,19 @@ RSpec.describe 'Item Selector' do
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890124', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 234', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890125', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 567', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890126', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 890', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890127', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?')
       ]
     end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Item Selector' do
-  let(:holdings_relationship) { double(:relationship, where: requested_items, all: all_items, single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: requested_items, all: all_items) }
   let(:all_items) { [] }
   let(:requested_items) { [] }
 
@@ -21,7 +21,7 @@ RSpec.describe 'Item Selector' do
     let(:all_items) do
       [
         double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,
-                      barcode: '9999')
+                      hold_recallable?: false, barcode: '9999')
       ]
     end
 
@@ -46,10 +46,10 @@ RSpec.describe 'Item Selector' do
       let(:all_items) do
         [
           double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '9999', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '9999', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
           double(:item, callnumber: 'ABC 321', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '8888', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '8888', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?')
 
         ]
@@ -86,10 +86,10 @@ RSpec.describe 'Item Selector' do
         let(:all_items) do
           [
             double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '12345678', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?', type: 'STKS'),
             double(:item, callnumber: 'ABC 321', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '23456789', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?', type: 'STKS')
 
           ]
@@ -113,22 +113,22 @@ RSpec.describe 'Item Selector' do
         let(:all_items) do
           [
             double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '12345678', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 456', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '23456789', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 789', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '34567890', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '34567890', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 012', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '45678901', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '45678901', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 345', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '56789012', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '56789012', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 678', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?')
 
           ]
@@ -160,34 +160,34 @@ RSpec.describe 'Item Selector' do
         let(:all_items) do
           [
             double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '12345678', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 456', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '23456789', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 789', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '34567890', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '34567890', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 012', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '45678901', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '45678901', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 345', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '56789012', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '56789012', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 678', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 234', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 567', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?'),
             double(:item, callnumber: 'ABC 890', checked_out?: false, processing?: false, missing?: false,
-                          hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                          hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                           status_text: 'Available', public_note: 'huh?')
 
           ]
@@ -240,43 +240,43 @@ RSpec.describe 'Item Selector' do
       let(:all_items) do
         [
           double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '12345678', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 456', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '23456789', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 789', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '34567890', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '34567890', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 012', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '45678901', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '45678901', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 345', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '56789012', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '56789012', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 678', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 234', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 567', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 890', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?')
 
         ]
@@ -284,19 +284,19 @@ RSpec.describe 'Item Selector' do
       let(:requested_items) do
         [
           double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '12345678', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 456', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '23456789', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 789', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '34567890', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '34567890', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?'),
 
           double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                        hold?: false, on_order?: false, barcode: '67890123', status_class: 'available',
+                        hold?: false, on_order?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                         status_text: 'Available', public_note: 'huh?')
         ]
       end
@@ -430,43 +430,43 @@ RSpec.describe 'Item Selector' do
     let(:all_items) do
       [
         double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '12345678', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 456', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '23456789', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 789', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '34567890', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '34567890', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 012', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '45678901', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '45678901', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 345', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '56789012', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '56789012', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 678', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 901', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 234', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 567', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 890', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '67890123', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '67890123', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?')
       ]
     end
@@ -510,11 +510,11 @@ RSpec.describe 'Item Selector' do
     let(:all_items) do
       [
         double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, barcode: '12345678', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '12345678', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?'),
 
         double(:item, callnumber: 'ABC 321', checked_out?: true, processing?: false, missing?: false,
-                      hold?: false, barcode: '87654321', status_class: 'available',
+                      hold?: false, hold_recallable?: false, barcode: '87654321', status_class: 'available',
                       status_text: 'Available', public_note: 'huh?', due_date: '01/01/2015')
 
       ]
@@ -540,11 +540,11 @@ RSpec.describe 'Item Selector' do
     let(:all_items) do
       [
         double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, on_order?: false, barcode: '45678901', status_class: 'available',
+                      hold?: false, on_order?: false, hold_recallable?: false, barcode: '45678901', status_class: 'available',
                       status_text: 'Available', public_note: 'note for 45678901'),
 
         double(:item, callnumber: 'ABC 321', checked_out?: false, processing?: false, missing?: false,
-                      hold?: false, on_order?: false, barcode: '23456789', status_class: 'available',
+                      hold?: false, on_order?: false, hold_recallable?: false, barcode: '23456789', status_class: 'available',
                       status_text: 'Available', public_note: 'note for 23456789')
 
       ]

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Library Instructions' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: true) }
-  let(:selected_items) { [double(:item, checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false)] }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: selected_items) }
+  let(:selected_items) do
+    [double(:item, callnumber: 'ABC 123', barcode: '12345678', checked_out?: true, processing?: false, missing?: false, hold?: false,
+                   on_order?: false, hold_recallable?: true)]
+  end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Library Instructions' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: selected_items) }
   let(:selected_items) do
     [double(:item, callnumber: 'ABC 123', barcode: '12345678', checked_out?: true, processing?: false, missing?: false, hold?: false,
                    on_order?: false, hold_recallable?: true)]
@@ -11,7 +10,7 @@ RSpec.describe 'Library Instructions' do
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     stub_searchworks_api_json(build(:library_instructions_holdings))
   end
 

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Mark As Complete', js: true do
   let(:user) { create(:superadmin_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:request_status) do
     instance_double(ItemStatus, approved?: true, errored?: false, approver: 'bob', approval_time: '2023-05-31')
   end
@@ -22,7 +21,7 @@ RSpec.describe 'Mark As Complete', js: true do
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     stub_searchworks_api_json(build(:searchable_holdings))
     stub_current_user(user)
   end

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Mark As Complete', js: true do
   let(:user) { create(:superadmin_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:request_status) do
     instance_double(ItemStatus, approved?: true, errored?: false, approver: 'bob', approval_time: '2023-05-31')
   end

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Viewing all requests' do
 
   describe 'displays on a request page' do
     let(:message) { create(:message) }
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
     before do
       allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -126,11 +126,10 @@ RSpec.describe 'Viewing all requests' do
 
   describe 'displays on a request page' do
     let(:message) { create(:message) }
-    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
     before do
       allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+      allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
     end
 
     it 'displays the broadcast message' do

--- a/spec/features/modal_layout_spec.rb
+++ b/spec/features/modal_layout_spec.rb
@@ -3,16 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Modal Layout' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
-      double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123')
+      double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
+                    hold?: false, hold_recallable?: false)
     ]
   end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     stub_searchworks_api_json(build(:sal3_holdings))
   end
 

--- a/spec/features/modal_layout_spec.rb
+++ b/spec/features/modal_layout_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Modal Layout' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Paging Schedule' do
-  let(:holdings_relationship) { double(:relationship, where: [], all: all_items, single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: all_items) }
   let(:all_items) do
     [
-      double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, barcode: '123123124',
-                     checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?', type: 'STKS'),
-      double('item', callnumber: 'ABC 321', processing?: false, missing?: false, hold?: false, on_order?: false, barcode: '9928812',
-                     checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?', type: 'STKS')
+      double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
+                     barcode: '123123124', checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?',
+                     type: 'STKS'),
+      double('item', callnumber: 'ABC 321', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
+                     barcode: '9928812', checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?',
+                     type: 'STKS')
     ]
   end
 

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Paging Schedule' do
-  let(:holdings_relationship) { double(:relationship, where: [], all: all_items) }
   let(:all_items) do
     [
       double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
@@ -17,7 +16,7 @@ RSpec.describe 'Paging Schedule' do
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(all_items)
     stub_current_user(create(:superadmin_user))
   end
 

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -4,11 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Pickup Libraries Dropdown' do
   let(:standard_pickup_lib_total) { Settings.default_pickup_libraries.count }
-  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
   end
 
   describe 'for multiple libraries' do

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Pickup Libraries Dropdown' do
   let(:standard_pickup_lib_total) { Settings.default_pickup_libraries.count }
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Requests Delegation' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -3,17 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Requests Delegation' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false,
-                    hold?: false, on_order?: false)
+                    hold?: false, on_order?: false, hold_recallable?: false)
     ]
   end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
   end
 
   describe 'non-scannable materials' do
@@ -54,7 +53,8 @@ RSpec.describe 'Requests Delegation' do
 
     let(:selected_items) do
       [
-        double(:item, barcode: '34567890', type: 'NONCIRC', callnumber: 'ABC 123')
+        double(:item, barcode: '34567890', type: 'NONCIRC', callnumber: 'ABC 123', hold_recallable?: false, checked_out?: false,
+                      processing?: false, missing?: false)
       ]
     end
 

--- a/spec/features/requests_public_notes_spec.rb
+++ b/spec/features/requests_public_notes_spec.rb
@@ -4,19 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Public Notes', js: true do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items) }
-  let(:selected_items) do
-    [
-      double(:item, barcode: '12345678', checked_out?: false, processing?: false, missing?: false, hold?: false,
-                    on_order?: false, callnumber: 'ABC 123', status_class: 'available', status_text: 'Available'),
-      double(:item, barcode: '23456789', checked_out?: false, processing?: false, missing?: false, hold?: false,
-                    on_order?: false, callnumber: 'ABC 456', status_class: 'available', status_text: 'Available'),
-      double(:item, barcode: '34567890', checked_out?: false, processing?: false, missing?: false, hold?: false,
-                    on_order?: false, callnumber: 'ABC 012', status_class: 'available', status_text: 'Available'),
-      double(:item, barcode: '45678901', checked_out?: false, processing?: false, missing?: false, hold?: false,
-                    on_order?: false, callnumber: 'ABC 345', status_class: 'available', status_text: 'Available')
-    ]
-  end
   let(:all_items) do
     [
       double(:item, barcode: '12345678', checked_out?: false, processing?: false, missing?: false, hold?: false,
@@ -37,7 +24,7 @@ RSpec.describe 'Public Notes', js: true do
   before do
     allow_any_instance_of(PagingSchedule::Scheduler).to receive(:valid?).with(anything).and_return(true)
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(all_items)
   end
 
   describe 'public_notes' do

--- a/spec/features/requests_public_notes_spec.rb
+++ b/spec/features/requests_public_notes_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Public Notes', js: true do
   let(:user) { create(:sso_user) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items, single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: all_items) }
   let(:selected_items) do
     [
       double(:item, barcode: '12345678', checked_out?: false, processing?: false, missing?: false, hold?: false,

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -3,11 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Send Request Buttons' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,
-                    barcode: '12345678', type: 'STKS')
+                    hold_recallable?: false, barcode: '12345678', type: 'STKS')
     ]
   end
 
@@ -15,7 +14,7 @@ RSpec.describe 'Send Request Buttons' do
     stub_searchworks_api_json(build(:single_holding))
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
 
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
   end
 
   describe 'as a Stanford user', js: true do

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Send Request Buttons' do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,

--- a/spec/features/status_page_spec.rb
+++ b/spec/features/status_page_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Status Page' do
   let(:request) { create(:mediated_page, user:) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   before do

--- a/spec/features/status_page_spec.rb
+++ b/spec/features/status_page_spec.rb
@@ -4,12 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Status Page' do
   let(:request) { create(:mediated_page, user:) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-  let(:selected_items) { [] }
 
   before do
     stub_current_user(user)
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
   end
 
   describe 'by webuath users' do

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -7,10 +7,9 @@ describe RequestsHelper do
 
   describe '#select_for_pickup_libraries' do
     let(:form) { double('form') }
-    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
     before do
-      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+      allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
       allow(form).to receive_messages(object: request)
     end
 

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -7,7 +7,7 @@ describe RequestsHelper do
 
   describe '#select_for_pickup_libraries' do
     let(:form) { double('form') }
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
     before do
       allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -18,14 +18,12 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
     describe '#perform' do
       context 'when the request is found' do
         let(:mock_client) { instance_double(SymphonyClient) }
-        let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-        let(:selected_items) { [] }
 
         before do
           allow(mock_client).to receive(:place_hold).and_return({})
           allow(mock_client).to receive(:bib_info).and_return({})
           allow_any_instance_of(SubmitSymphonyRequestJob::Command).to receive(:symphony_client).and_return(mock_client)
-          allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+          allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
         end
 
         it 'calls send_approval_status! on the request object' do

--- a/spec/jobs/submit_symphony_request_job_spec.rb
+++ b/spec/jobs/submit_symphony_request_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SubmitSymphonyRequestJob, type: :job do
     describe '#perform' do
       context 'when the request is found' do
         let(:mock_client) { instance_double(SymphonyClient) }
-        let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+        let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
         let(:selected_items) { [] }
 
         before do

--- a/spec/mailers/factories/request_status_mailer_factory_spec.rb
+++ b/spec/mailers/factories/request_status_mailer_factory_spec.rb
@@ -5,11 +5,8 @@ require 'rails_helper'
 RSpec.describe RequestStatusMailerFactory do
   subject(:mailer) { described_class.for(request) }
 
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-  let(:selected_items) { [] }
-
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
     request.user = create(:anon_user)
   end
 

--- a/spec/mailers/factories/request_status_mailer_factory_spec.rb
+++ b/spec/mailers/factories/request_status_mailer_factory_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe RequestStatusMailerFactory do
   subject(:mailer) { described_class.for(request) }
 
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   before do

--- a/spec/mailers/mediation_mailer_spec.rb
+++ b/spec/mailers/mediation_mailer_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe MediationMailer do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   describe 'mediator_notification' do
@@ -11,7 +10,7 @@ RSpec.describe MediationMailer do
     let(:request) { create(:mediated_page, user:) }
     let(:mediator_contact_info) { { request.origin => { email: 'someone@example.com' } } }
     before do
-      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
       allow(Rails.application.config).to receive(:mediator_contact_info).and_return(mediator_contact_info)
     end
 

--- a/spec/mailers/mediation_mailer_spec.rb
+++ b/spec/mailers/mediation_mailer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MediationMailer do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   describe 'mediator_notification' do

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RequestStatusMailer do
     let(:request) { build_stubbed(:page, user:) }
     let(:mailer_method) { :request_status_for_page }
     let(:mail) { described_class.send(mailer_method, request) }
-    let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
     let(:selected_items) { [] }
 
     before do

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe RequestStatusMailer do
     let(:request) { build_stubbed(:page, user:) }
     let(:mailer_method) { :request_status_for_page }
     let(:mail) { described_class.send(mailer_method, request) }
-    let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
     let(:selected_items) { [] }
 
     before do
-      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     end
 
     describe '#request_status_for_u003' do
@@ -131,7 +130,7 @@ RSpec.describe RequestStatusMailer do
 
         context 'for a page with holdings' do
           let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user:) }
-          let(:selected_items) { [double(:item, barcode: '3610512345678', callnumber: 'ABC 123')] }
+          let(:selected_items) { [double(:item, barcode: '3610512345678', callnumber: 'ABC 123', hold_recallable?: false)] }
 
           it 'has the data' do
             expect(body).to include("Title: #{request.item_title}")
@@ -225,7 +224,8 @@ RSpec.describe RequestStatusMailer do
       describe 'user blocked' do
         let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user:) }
         let(:selected_items) do
-          [double(:item, barcode: '3610512345678', callnumber: 'ABC 123', request_status: double('status', text: 'foo'))]
+          [double(:item, barcode: '3610512345678', callnumber: 'ABC 123', request_status: double('status', text: 'foo'),
+                         hold_recallable?: false)]
         end
 
         before do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -79,7 +79,7 @@ describe Ability do
       it { is_expected.to be_able_to(:create, mediated_page) }
 
       describe 'and views a success page with a token' do
-        let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+        let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
         before do
           allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -79,11 +79,9 @@ describe Ability do
       it { is_expected.to be_able_to(:create, mediated_page) }
 
       describe 'and views a success page with a token' do
-        let(:holdings_relationship) { double(:relationship, where: [], all: []) }
-
         before do
           allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-          allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+          allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
         end
 
         describe 'for a page' do

--- a/spec/models/concerns/hold_recallable_spec.rb
+++ b/spec/models/concerns/hold_recallable_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe 'HoldRecallable' do
   subject(:request) { build(:request) }
 
   let(:all) { [] }
-  let(:holdings) { double(:holdings, where: [], all:) }
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(all)
   end
 
   describe '#hold_recallable?' do

--- a/spec/models/concerns/hold_recallable_spec.rb
+++ b/spec/models/concerns/hold_recallable_spec.rb
@@ -5,18 +5,15 @@ require 'rails_helper'
 RSpec.describe 'HoldRecallable' do
   subject(:request) { build(:request) }
 
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:all) { [] }
+  let(:holdings) { double(:holdings, where: [], all:) }
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings)
   end
 
   describe '#hold_recallable?' do
-    it 'is false by default' do
-      expect(request).not_to be_hold_recallable
-    end
-
-    describe 'when a barcode is provided' do
+    context 'when a barcode is provided' do
       it 'is true' do
         request.requested_barcode = '3610512345'
         expect(request).to be_hold_recallable
@@ -29,80 +26,43 @@ RSpec.describe 'HoldRecallable' do
       end
     end
 
-    describe 'when INPROCESS' do
-      it 'is true when the origin_location is INPROCESS' do
-        request.origin_location = 'INPROCESS'
+    context 'when the origin location is a hold recallable location' do
+      it 'is true' do
+        request.origin_location = 'MISSING'
         expect(request).to be_hold_recallable
       end
+    end
 
-      it 'is true when all the current locations are INPROCESS' do
-        expect(request).to receive_messages(
-          holdings: [
-            double('holding', current_location: double('location', code: 'INPROCESS')),
-            double('holding', current_location: double('location', code: 'INPROCESS')),
-            double('holding', current_location: double('location', code: 'INPROCESS'))
-          ]
-        )
-
-        expect(request).to be_hold_recallable
-      end
-
-      it 'is false when only some of the current locations are INPROCESS' do
-        expect(request).to receive_messages(
-          holdings: [
-            double('holding', current_location: double('location', code: 'INPROCESS')),
-            double('holding', current_location: double('location', code: 'ANOTHER-LOCATION'))
-          ]
-        )
-
+    context 'when the origin location is not a hold recallable location' do
+      it 'is false' do
+        request.origin_location = 'STACKS'
         expect(request).not_to be_hold_recallable
       end
     end
 
-    describe 'when ON-ORDER' do
-      it 'is true when the origin_location is ON-ORDER' do
-        request.origin_location = 'ON-ORDER'
-        expect(request).to be_hold_recallable
+    context 'when all items are hold/recallable' do
+      let(:all) do
+        [
+          double(:item, hold_recallable?: true),
+          double(:item, hold_recallable?: true)
+        ]
       end
 
-      it 'is true when the current location is ON-ORDER' do
-        allow(request).to receive_messages(holdings: [
-                                             double('holding', current_location: double('location', code: 'ON-ORDER'))
-                                           ])
-
-        expect(request).to be_hold_recallable
-      end
-    end
-
-    context 'when MISSING' do
-      it 'is true when the current_location is MISSING' do
-        allow(request).to receive_messages(holdings: [
-                                             double('holding', current_location: double('location', code: 'MISSING'))
-                                           ])
-
+      it 'is true' do
         expect(request).to be_hold_recallable
       end
     end
 
-    context 'when CHECKEDOUT' do
-      let(:holdings_object) do
-        instance_double(Searchworks::Holdings, single_checked_out_item?: single_checked_out, all: [], where: [])
+    context 'when some items are not hold/recallable' do
+      let(:all) do
+        [
+          double(:item, hold_recallable?: true),
+          double(:item, hold_recallable?: false)
+        ]
       end
 
-      before do
-        allow(request).to receive(:holdings_object).and_return(holdings_object)
-      end
-
-      context 'when there is a single checked out item' do
-        let(:single_checked_out) { true }
-
-        it { is_expected.to be_hold_recallable }
-      end
-
-      context 'when there is are multiple items' do
-        let(:single_checked_out) { false }
-
-        it { is_expected.not_to be_hold_recallable }
+      it 'is false' do
+        expect(request).not_to be_hold_recallable
       end
     end
   end

--- a/spec/models/concerns/pageable_spec.rb
+++ b/spec/models/concerns/pageable_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Pageable' do
 
   describe '#pageable?' do
     context 'when the LibraryLocation is not mediatable or hold recallable' do
-      let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+      let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
       before do
         request.origin = 'GREEN'

--- a/spec/models/concerns/pageable_spec.rb
+++ b/spec/models/concerns/pageable_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe 'Pageable' do
 
   describe '#pageable?' do
     context 'when the LibraryLocation is not mediatable or hold recallable' do
-      let(:holdings_relationship) { double(:relationship, where: [], all: []) }
-
       before do
         request.origin = 'GREEN'
         request.origin_location = 'STACKS'
-        allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+        allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
       end
 
       it { is_expected.to be_pageable }

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -3,15 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
-      double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123')
+      double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123', hold_recallable?: false)
     ]
   end
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     create(:mediated_page)
     create(:page)
     create(:page)

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard do
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, barcode: '34567890', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/models/item_status_spec.rb
+++ b/spec/models/item_status_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ItemStatus do
   subject { described_class.new(request, barcode) }
 
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
   let(:request) { create(:mediated_page_with_single_holding) }
   let(:barcode) { '3610512345' }
 

--- a/spec/models/item_status_spec.rb
+++ b/spec/models/item_status_spec.rb
@@ -5,14 +5,13 @@ require 'rails_helper'
 RSpec.describe ItemStatus do
   subject { described_class.new(request, barcode) }
 
-  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
   let(:request) { create(:mediated_page_with_single_holding) }
   let(:barcode) { '3610512345' }
 
   before do
     allow(Request.ils_job_class).to receive(:perform_now)
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(double(:bib_data, title: 'Test title'))
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
   end
 
   describe '#status_object' do

--- a/spec/models/request_approval_status_spec.rb
+++ b/spec/models/request_approval_status_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RequestApprovalStatus do
 
       context 'for mediated pages' do
         let(:request) { create(:page_mp_mediated_page) }
-        let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+        let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
         let(:selected_items) { [] }
 
         before do

--- a/spec/models/request_approval_status_spec.rb
+++ b/spec/models/request_approval_status_spec.rb
@@ -27,11 +27,9 @@ RSpec.describe RequestApprovalStatus do
 
       context 'for mediated pages' do
         let(:request) { create(:page_mp_mediated_page) }
-        let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-        let(:selected_items) { [] }
 
         before do
-          allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+          allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
         end
 
         it 'is the mediated page text' do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Request do
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
   let(:bib_data) { double(:bib_data, title: 'Test title') }
 
   before do
@@ -82,7 +82,7 @@ RSpec.describe Request do
           origin_location: 'SAL-TEMP'
         )
       end
-      let(:holdings_relationship) { double(:relationship, where: [], all: all_holdings, single_checked_out_item?: false) }
+      let(:holdings_relationship) { double(:relationship, where: [], all: all_holdings) }
 
       let(:all_holdings) do
         # This is just used for Searchworks integration

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Request do
-  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
+  let(:items) { [] }
   let(:bib_data) { double(:bib_data, title: 'Test title') }
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:new).and_return(bib_data)
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(items)
   end
 
   describe 'validations' do
@@ -26,7 +26,7 @@ RSpec.describe Request do
         stub_searchworks_api_json(build(:multiple_holdings))
       end
 
-      let(:holdings_relationship) { double(:relationship, where: [double('item', barcode: '3610512345678')]) }
+      let(:items) { [double('item', barcode: '3610512345678')] }
 
       let(:create_request) do
         described_class.create!(
@@ -82,9 +82,7 @@ RSpec.describe Request do
           origin_location: 'SAL-TEMP'
         )
       end
-      let(:holdings_relationship) { double(:relationship, where: [], all: all_holdings) }
-
-      let(:all_holdings) do
+      let(:items) do
         # This is just used for Searchworks integration
         [double(:item, type: 'NONCIRC', code: 'SAL-TEMP', barcode: '12345678')]
       end
@@ -192,7 +190,7 @@ RSpec.describe Request do
   describe '#holdings' do
     describe 'when persisted' do
       let(:subject) { create(:request_with_multiple_holdings, barcodes: ['3610512345678']) }
-      let(:holdings_relationship) { double(:relationship, where: [double('item', barcode: '3610512345678')]) }
+      let(:items) { [double('item', barcode: '3610512345678')] }
 
       it 'gets the holdings from the requested location by the persisted barcodes' do
         holdings = subject.holdings
@@ -227,10 +225,9 @@ RSpec.describe Request do
 
       it 'gets all the holdings for the requested location' do
         holdings = request.holdings
-        expect(holdings).to be_a Array
-        expect(holdings.length).to eq 3
+        expect(holdings.count).to eq 3
         expect(holdings.first.barcode).to eq '3610512345678'
-        expect(holdings.last.barcode).to eq '12345679'
+        expect(holdings.to_a.last.barcode).to eq '12345679'
       end
     end
   end
@@ -239,15 +236,14 @@ RSpec.describe Request do
     subject(:all_holdings) { request.all_holdings }
 
     let(:request) { build(:request_with_multiple_holdings, barcodes: ['3610512345678']) }
-    let(:holdings_relationship) do
-      double(:relationship, all: [double('item', barcode: '3610512345678'), double('item'), double('item', barcode: '12345679')])
+    let(:items) do
+      [double('item', barcode: '3610512345678'), double('item'), double('item', barcode: '12345679')]
     end
 
     it 'gets all the holdings for the requested location' do
-      expect(all_holdings).to be_a Array
-      expect(all_holdings.length).to eq 3
+      expect(all_holdings.count).to eq 3
       expect(all_holdings.first.barcode).to eq '3610512345678'
-      expect(all_holdings.last.barcode).to eq '12345679'
+      expect(all_holdings.to_a.last.barcode).to eq '12345679'
     end
   end
 
@@ -255,7 +251,7 @@ RSpec.describe Request do
     subject(:holdings) { request.requested_holdings }
 
     let(:request) { create(:request_with_multiple_holdings, barcodes: ['3610512345678']) }
-    let(:holdings_relationship) { double(:relationship, where: [double('item', barcode: '3610512345678')]) }
+    let(:items) { [double('item', barcode: '3610512345678')] }
 
     it 'gets the holdings from the requested location by the persisted barcodes' do
       expect(holdings).to be_a Array

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HoldRecall do
   end
 
   describe 'send_approval_status!' do
-    let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
     before do
       allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -13,10 +13,8 @@ RSpec.describe HoldRecall do
   end
 
   describe 'send_approval_status!' do
-    let(:holdings_relationship) { double(:relationship, where: [], all: []) }
-
     before do
-      allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+      allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
     end
 
     describe 'for library id users' do

--- a/spec/models/searchworks/holdings_spec.rb
+++ b/spec/models/searchworks/holdings_spec.rb
@@ -9,63 +9,29 @@ RSpec.describe Searchworks::Holdings do
     allow(Request).to receive(:bib_model_class).and_return(SearchworksItem)
   end
 
-  describe '#all' do
-    describe 'items that exist' do
-      let(:item) { build(:green_stacks_searchworks_item) }
+  describe 'items that exist' do
+    let(:item) { build(:green_stacks_searchworks_item) }
 
-      it 'are present for the requested location' do
-        expect(subject.all).to be_a Array
-        expect(subject.all.length).to eq 1
-        expect(subject.all.first.barcode).to eq '12345678'
-        expect(subject.all.first.callnumber).to eq 'ABC 123'
-      end
-
-      it 'adds the request_status object to the items' do
-        expect(subject.all.first.request_status).to be_a ItemStatus
-      end
+    it 'are present for the requested location' do
+      expect(subject.count).to eq 1
+      expect(subject.first.barcode).to eq '12345678'
+      expect(subject.first.callnumber).to eq 'ABC 123'
     end
 
-    describe 'items that do not exist' do
-      let(:item) { build(:green_stacks_searchworks_item) }
-
-      before do
-        allow(item).to receive_messages(request: build(:request, origin: 'SAL3', origin_location: 'STACKS'))
-      end
-
-      it 'are not present for the requested location' do
-        expect(subject.all).to eq([])
-      end
+    it 'adds the request_status object to the items' do
+      expect(subject.first.request_status).to be_a ItemStatus
     end
   end
 
-  describe '#where' do
-    let(:item) { build(:green_stacks_multi_holdings_searchworks_item) }
+  describe 'items that do not exist' do
+    let(:item) { build(:green_stacks_searchworks_item) }
 
-    context 'when given an array of barcodes' do
-      subject(:by_barcodes) { requested_holdings.where(barcodes: %w(3610512345678 3610587654321)) }
-
-      it 'returns the items' do
-        expect(by_barcodes).to be_a Array
-        expect(by_barcodes.length).to eq 2
-        expect(by_barcodes.first.barcode).to eq '3610512345678'
-        expect(by_barcodes.last.barcode).to eq '3610587654321'
-      end
+    before do
+      allow(item).to receive_messages(request: build(:request, origin: 'SAL3', origin_location: 'STACKS'))
     end
 
-    context 'when given a single barcode' do
-      subject(:by_barcodes) { requested_holdings.where(barcodes: ['12345679']) }
-
-      it 'returns the items' do
-        expect(by_barcodes).to be_a Array
-        expect(by_barcodes.length).to eq 1
-        expect(by_barcodes.first.barcode).to eq '12345679'
-      end
-    end
-
-    context 'when the given barcode does not exist' do
-      subject(:by_barcodes) { requested_holdings.where(barcodes: ['not-a-barcode']) }
-
-      it { is_expected.to be_empty }
+    it 'are not present for the requested location' do
+      expect(subject.count).to eq 0
     end
   end
 end

--- a/spec/models/searchworks/holdings_spec.rb
+++ b/spec/models/searchworks/holdings_spec.rb
@@ -38,56 +38,6 @@ RSpec.describe Searchworks::Holdings do
     end
   end
 
-  describe '#single_checked_out_item?' do
-    subject(:requested_holdings) do
-      described_class.new(request, holdings)
-    end
-
-    let(:request) { build(:request) }
-
-    context 'when the holdings include a single checked out item' do
-      let(:holdings) do
-        [
-          Searchworks::Holding.new('code' => 'BIOLOGY',
-                                   'locations' =>
-           [{ 'code' => 'STACKS',
-              'items' =>
-              [{ 'barcode' => '87654321',
-                 'callnumber' => 'ABC 321',
-                 'current_location' => { 'code' => 'CHECKEDOUT' },
-                 'due_date' => '01/01/2015',
-                 'type' => 'STKS',
-                 'status' => { 'availability_class' => 'page', 'status_text' => 'Available' } }] }])
-        ]
-      end
-
-      it { is_expected.to be_single_checked_out_item }
-    end
-
-    context 'when the holdings includes multiple items' do
-      let(:holdings) do
-        [
-          Searchworks::Holding.new('code' => 'BIOLOGY',
-                                   'locations' =>
-             [{ 'code' => 'STACKS',
-                'items' =>
-                [{ 'barcode' => '12345678',
-                   'callnumber' => 'ABC 123',
-                   'type' => 'STKS',
-                   'status' => { 'availability_class' => 'available', 'status_text' => 'Available' } },
-                 { 'barcode' => '87654321',
-                   'callnumber' => 'ABC 321',
-                   'current_location' => { 'code' => 'CHECKEDOUT' },
-                   'due_date' => '01/01/2015',
-                   'type' => 'STKS',
-                   'status' => { 'availability_class' => 'page', 'status_text' => 'Available' } }] }])
-        ]
-      end
-
-      it { is_expected.not_to be_single_checked_out_item }
-    end
-  end
-
   describe '#where' do
     let(:item) { build(:green_stacks_multi_holdings_searchworks_item) }
 

--- a/spec/requests/admin_comments_requests_spec.rb
+++ b/spec/requests/admin_comments_requests_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'AdminComments' do
   let(:mediated_page) { create(:mediated_page) }
   let(:headers) { { 'HTTP_REFERER' => 'http://example.com' } }
   let(:url) { "/mediated_pages/#{mediated_page.id}/admin_comments" }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   before do

--- a/spec/requests/admin_comments_requests_spec.rb
+++ b/spec/requests/admin_comments_requests_spec.rb
@@ -7,11 +7,9 @@ RSpec.describe 'AdminComments' do
   let(:mediated_page) { create(:mediated_page) }
   let(:headers) { { 'HTTP_REFERER' => 'http://example.com' } }
   let(:url) { "/mediated_pages/#{mediated_page.id}/admin_comments" }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-  let(:selected_items) { [] }
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
     stub_current_user(user)
   end
 

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -5,14 +5,12 @@ require 'rails_helper'
 RSpec.describe 'requests/status.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { build_stubbed(:page, user:) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
-  let(:selected_items) { [] }
 
   before do
     allow(view).to receive_messages(current_request: request)
     allow(view).to receive_messages(current_user: user)
     allow(controller).to receive_messages(current_user: user)
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
   end
 
   it 'has an icon and h1 heading' do

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'requests/status.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { build_stubbed(:page, user:) }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) { [] }
 
   before do

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -5,15 +5,14 @@ require 'rails_helper'
 RSpec.describe 'requests/success.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { create(:page, user:, item_title: 'Test title') }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
-      double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123')
+      double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123', hold_recallable?: false)
     ]
   end
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(selected_items)
     allow(view).to receive_messages(current_request: request)
     allow(view).to receive_messages(current_user: user)
   end

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'requests/success.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { create(:page, user:, item_title: 'Test title') }
-  let(:holdings_relationship) { double(:relationship, where: selected_items, all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: selected_items, all: []) }
   let(:selected_items) do
     [
       double(:item, barcode: '12345678', type: 'STKS', callnumber: 'ABC 123')

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'shared/_request_status_information.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { create(:scan, :without_validations, :with_item_title, user:) }
-  let(:holdings_relationship) { double(:relationship, where: [], all: [], single_checked_out_item?: false) }
+  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
   before do
     allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -5,10 +5,9 @@ require 'rails_helper'
 RSpec.describe 'shared/_request_status_information.html.erb' do
   let(:user) { create(:sso_user) }
   let(:request) { create(:scan, :without_validations, :with_item_title, user:) }
-  let(:holdings_relationship) { double(:relationship, where: [], all: []) }
 
   before do
-    allow(HoldingsRelationshipBuilder).to receive(:build).and_return(holdings_relationship)
+    allow(HoldingsRelationshipBuilder).to receive(:build).and_return([])
     allow(view).to receive_messages(current_request: request)
   end
 


### PR DESCRIPTION
Currently, a request becomes a hold/recall when any of three conditions are met:
1. a barcode is provided (meaning a single item is requested)
2. the holding is in a special hold/recallable origin location (in symphony this covers things like `CHECKEDOUT`)
3. there is only one item in the holding, and that item is checked out

This PR expands the third condition to cover all the possibilities we aren't handling — namely, if _every_ item in the holding is allowed to be hold/recalled (checked out, in process, etc). It does this by delegating `hold_recallable?` down to the item level for each ILS's implementation. In Symphony, `CHECKEDOUT`, `INPROCESS`, etc. are item locations. In FOLIO, they are item statuses.

Fixes #1557
