### PR TITLE
Fix mysql database migration error

### DIFF
--- a/db/migrate/20230703181415_create_folio_command_log.rb
+++ b/db/migrate/20230703181415_create_folio_command_log.rb
@@ -8,7 +8,7 @@ class CreateFolioCommandLog < ActiveRecord::Migration[7.0]
       t.string :item_id, null: false
       t.string :patron_comments
       t.date :expiration_date, null: false
-      t.references :request, null: false, foreign_key: true
+      t.references :request, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,5 +76,4 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_181415) do
     t.index ["sunetid"], name: "unique_users_by_sunetid", unique: true
   end
 
-  add_foreign_key "folio_command_logs", "requests"
 end


### PR DESCRIPTION
> Column `request_id` on table `folio_command_logs` does not match column `id` on `requests`, which has type `int(11)`. To resolve this issue, change the type of the `request_id` column on `folio_command_logs` to be :integer. (For example `t.integer :request_id`).
