### PR TITLE
Make RequestAbilities#location_rule private

### DIFF
--- a/app/helpers/pickup_libraries_helper.rb
+++ b/app/helpers/pickup_libraries_helper.rb
@@ -28,15 +28,11 @@ module PickupLibrariesHelper
       pickup_libraries_array(pickup_libraries),
       {
         label: label_for_pickup_libraries_dropdown(pickup_libraries),
-        selected: form.object.destination || default_pickup_library(form.object)
+        selected: form.object.destination || form.object.default_pickup_library
       },
       aria: { controls: 'scheduler-text' },
       data: { 'paging-schedule-updater' => 'true', 'text-selector' => "[data-text-object='#{form.object.object_id}']" }
     )
-  end
-
-  def default_pickup_library(request)
-    request.location_rule&.default_pickup_library || Settings.default_pickup_library
   end
 
   def single_library_markup(form, library)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -27,7 +27,7 @@ class Request < ActiveRecord::Base
   }
 
   delegate :hold_recallable?, :mediateable?, :pageable?, :aeon_pageable?, :scannable?, :scannable_only?,
-           :location_rule, :scannable_location_rule, :aeon_site, to: :request_abilities
+           :default_pickup_library, :pickup_libraries, :scan_destination, :aeon_site, to: :request_abilities
 
   delegate :finding_aid, :finding_aid?, to: :bib_data, allow_nil: true
 
@@ -167,14 +167,6 @@ class Request < ActiveRecord::Base
 
   def library_id_error?
     errors[:library_id].present?
-  end
-
-  def pickup_libraries
-    location_rule&.pickup_libraries
-  end
-
-  def scan_destination
-    {}
   end
 
   class << self

--- a/app/models/request_abilities.rb
+++ b/app/models/request_abilities.rb
@@ -11,6 +11,8 @@ class RequestAbilities
 
   attr_reader :request
 
+  delegate :send_honeybadger_notice_if_used, to: :location_rule, allow_nil: true
+
   # @param [Request] request
   def initialize(request)
     @request = request
@@ -53,6 +55,20 @@ class RequestAbilities
     !mediateable? && !hold_recallable? && location_rule.present?
   end
 
+  def scan_destination
+    scannable_location_rule&.destination || {}
+  end
+
+  def pickup_libraries
+    location_rule&.pickup_libraries || Settings.default_pickup_libraries
+  end
+
+  def default_pickup_library
+    location_rule&.default_pickup_library || Settings.default_pickup_library
+  end
+
+  private
+
   def location_rule
     @location_rule ||= applicable_rules(:pageable).first
   end
@@ -60,8 +76,6 @@ class RequestAbilities
   def scannable_location_rule
     @scannable_location_rule ||= applicable_rules(:scannable).first
   end
-
-  private
 
   def all_items_hold_recallable?
     request.holdings_object.any? && request.holdings_object.all?(&:hold_recallable?)

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -16,7 +16,7 @@ class Page < Request
 
   # Ideally, we'll be able to drop the wildcard rule because no requests will make it here
   after_create do
-    next unless location_rule&.send_honeybadger_notice_if_used
+    next unless request_abilities&.send_honeybadger_notice_if_used
 
     Honeybadger.notify("WARNING: Using default location rule for page #{id} (origin: #{origin}, origin_location: #{origin_location})")
   end

--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -31,11 +31,6 @@ class Scan < Request
     RequestStatusMailer.request_status_for_scan(self).deliver_later if notification_email_address.present?
   end
 
-  # @return [Hash]
-  def scan_destination
-    scannable_location_rule&.destination || {}
-  end
-
   private
 
   def requested_item_is_not_scannable_only

--- a/spec/helpers/pickup_libraries_helper_spec.rb
+++ b/spec/helpers/pickup_libraries_helper_spec.rb
@@ -23,24 +23,4 @@ RSpec.describe PickupLibrariesHelper do
       expect(pickup_libraries).to eq([['Library 1', 'XYZ'], ['Library 2', 'ABC']])
     end
   end
-
-  describe '#default_pickup_library' do
-    it 'sets an origin specific default' do
-      default = helper.send(:default_pickup_library, Request.new(origin: 'LAW', origin_location: 'STACKS'))
-
-      expect(default).to eq 'LAW'
-    end
-
-    it 'sets an origin location specific default' do
-      default = helper.send(:default_pickup_library, Request.new(origin: 'SAL3', origin_location: 'EAL-SETS'))
-
-      expect(default).to eq 'EAST-ASIA'
-    end
-
-    it 'falls back to a default location' do
-      default = helper.send(:default_pickup_library, Request.new(origin: 'ART', origin_location: 'STACKS'))
-
-      expect(default).to eq 'GREEN'
-    end
-  end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -661,4 +661,24 @@ RSpec.describe Request do
       expect(item_status['36105212920537']['msgcode']).to eq 'S001'
     end
   end
+
+  describe '#default_pickup_library' do
+    it 'sets an origin specific default' do
+      request = described_class.new(origin: 'LAW', origin_location: 'STACKS')
+
+      expect(request.default_pickup_library).to eq 'LAW'
+    end
+
+    it 'sets an origin location specific default' do
+      request = described_class.new(origin: 'SAL3', origin_location: 'EAL-SETS')
+
+      expect(request.default_pickup_library).to eq 'EAST-ASIA'
+    end
+
+    it 'falls back to a default location' do
+      request = described_class.new(origin: 'ART', origin_location: 'STACKS')
+
+      expect(request.default_pickup_library).to eq 'GREEN'
+    end
+  end
 end


### PR DESCRIPTION
This creates a more convenient seam for a FOLIO implementation, which may not have the same kinds of location rules