### PR TITLE
Allow the log level to be customized with an environment variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
This will allow us to have different log levels in stage than we use in production.  This follows the upstream template https://github.com/rails/rails/blob/d4a5f1cca64c22b4ac37243423fe66e2d31daabb/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt\#L73