### PR TITLE
Fix undefined variable

### DIFF
--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -48,15 +48,15 @@ class FolioClient
   end
 
   def proxy_group_info(user_id)
-    get_json('/proxiesfor', params: { query: CqlQuery.new(userId: user_id).to_query })
+    response = get_json('/proxiesfor', params: { query: CqlQuery.new(userId: user_id).to_query })
 
-    repsonse.dig('proxiesFor', 0)
+    response.dig('proxiesFor', 0)
   end
 
   def proxy_info(user_id)
-    get_json('/proxiesfor', params: { query: CqlQuery.new(proxyUserId: user_id).to_query })
+    response = get_json('/proxiesfor', params: { query: CqlQuery.new(proxyUserId: user_id).to_query })
 
-    repsonse.dig('proxiesFor', 0)
+    response.dig('proxiesFor', 0)
   end
 
   def patron_blocks(user_id)


### PR DESCRIPTION
Fixes #1605

This adds back the variable that was likely removed by rubocop autocorrecting an unused variable.