### PR TITLE
Don't include scan destination parameters for non-scans

### DIFF
--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -142,6 +142,8 @@ class SubmitSymphonyRequestJob < ApplicationJob
     end
 
     def scan_destination
+      return {} unless request.is_a? Scan
+
       request.scan_destination.to_h.slice(:key, :patron_barcode)
     end
 


### PR DESCRIPTION
It looks like #1533, #1537, and #1593 caused us to use the scan information for all types of requests. 

Fixes VUF-9243