### PR TITLE
Updating FOLIO finding aid check for parity with Symphony

### DIFF
--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -65,7 +65,7 @@ module Folio
 
     def finding_aid
       @electronic_access.find do |access|
-        access.fetch('materialsSpecification') == 'Finding aid available online'
+        access.fetch('materialsSpecification')&.match?(/Finding aid/i)
       end&.fetch('uri')
     end
 


### PR DESCRIPTION
#1476 is overly precise about how to identify a finding aid. Current Symphony logic just looks for the words "finding aid" in the note:

https://github.com/sul-dlss/searchworks_traject_indexer/blob/262550878c417d69c6fbe8078f293f551e87163f/lib/marc_links.rb#L152-L154