### PR TITLE
Remove HOOVER and HV-ARCHIVE config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,8 +36,6 @@ module SULRequests
     config.mediator_contact_info = {
       'ART'        => { email: 'sul-requests-art@lists.stanford.edu' },
       'EDUCATION'  => { email: 'sul-requests-education@lists.stanford.edu'},
-      'HV-ARCHIVE' => { email: 'sul-requests-hoover-archive@lists.stanford.edu' },
-      'HOOVER'     => { email: 'sul-requests-hoover-library@lists.stanford.edu' },
       'HOPKINS'    => { email: 'sul-requests-hopkins@lists.stanford.edu' },
       'PAGE-MP'    => { email: 'sul-requests-branner@lists.stanford.edu' },
       'SPEC-COLL'  => { email: 'sul-requests-spec@lists.stanford.edu' },

--- a/config/initializers/paging_schedule.rb
+++ b/config/initializers/paging_schedule.rb
@@ -117,26 +117,6 @@ Rails.application.config.after_initialize do
       business_days_later 3
     end
 
-    # Hoover Archive
-    when_paging from: 'HV-ARCHIVE', to: 'HV-ARCHIVE', before: '10:00am' do
-      will_arrive after: '11:00am'
-      business_days_later 1
-    end
-    when_paging from: 'HV-ARCHIVE', to: 'HV-ARCHIVE', after: '10:00am' do
-      will_arrive after: '11:00am'
-      business_days_later 2
-    end
-
-    # Hoover
-    when_paging from: 'HOOVER', to: 'HOOVER', before: '10:00am' do
-      will_arrive after: '11:00am'
-      business_days_later 1
-    end
-    when_paging from: 'HOOVER', to: 'HOOVER', after: '10:00am' do
-      will_arrive after: '11:00am'
-      business_days_later 2
-    end
-
     # Special Collections
     when_paging from: 'SPEC-COLL', to: 'SPEC-COLL', before: '10:00am' do
       will_arrive after: '9:00am'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,7 +29,6 @@ origin_admin_groups:
   ART: []
   EDUCATION: []
   HOPKINS: []
-  HV-ARCHIVE: []
   RUMSEYMAP: []
   SPEC-COLL: []
 
@@ -40,7 +39,6 @@ mediateable_origins:
   ART: {}
   EDUCATION: {}
   HOPKINS: {}
-  HV-ARCHIVE: {}
   PAGE-MP:
     library_override: EARTH-SCI
   RUMSEYMAP: {}
@@ -234,17 +232,6 @@ libraries:
     hours:
       library_slug: green
       location_slug: library-circulation
-  HOOVER:
-    label: Hoover Library
-    instructions: Items must be requested in advance and viewed on-site.
-    contact_info:
-      phone: "(650) 723-3563"
-      email: hooverarchives@stanford.edu
-    hold_pseudopatron: HOLD@HL
-    folio_hold_pseudopatron: 560fbbf8-35b6-4440-b218-6c4aa6625258
-    hours:
-      library_slug: hoover
-      location_slug: library-circulation
   HOPKINS:
     label: Marine Biology Library (Miller)
     contact_info:
@@ -256,18 +243,6 @@ libraries:
     hours:
       library_slug: hopkins
       location_slug: library-circulation
-  HV-ARCHIVE:
-    label: Hoover Archives
-    instructions: Items must be requested in advance and viewed on-site.
-    contact_info:
-      phone: "(650) 723-3563"
-      email: hooverarchives@stanford.edu
-    folio_pickup_service_point_code: HILA
-    hold_pseudopatron: HOLD@HA
-    folio_hold_pseudopatron: d36cbac2-7ae7-49b3-b786-a389e67a3344
-    hours:
-      library_slug: hila
-      location_slug: reference
   LANE-MED:
     label: Medical Library (Lane)
     hours:
@@ -509,9 +484,6 @@ pageable:
       - PAGE-GR
     pickup_libraries: ['GREEN']
   - locations:
-      - PAGE-HA
-    pickup_libraries: ['HV-ARCHIVE']
-  - locations:
       - PAGE-HP
     pickup_libraries: ['GREEN', 'HOPKINS']
   - locations:
@@ -548,9 +520,6 @@ pageable:
       - PAGE-SP
     pickup_libraries: ['SPEC-COLL']
   # Library-specific pickup libraries
-  - library: HV-ARCHIVE
-    pickup_libraries:
-      - HV-ARCHIVE
   - library: ARS
     pickup_libraries:
       - ARS

--- a/spec/views/home/_mediation.html.erb_spec.rb
+++ b/spec/views/home/_mediation.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'home/_mediation.html.erb' do
   before do
     allow(view).to receive_messages(
-      locations: ['SPEC-COLL', 'HOOVER', 'HV-ARCHIVE']
+      locations: ['SPEC-COLL']
     )
     render
   end
@@ -13,7 +13,5 @@ RSpec.describe 'home/_mediation.html.erb' do
   it 'has title and description' do
     expect(rendered).to have_css('h2', text: 'Mediation')
     expect(rendered).to have_css('a', text: 'Special Collections')
-    expect(rendered).to have_css('a', text: 'Hoover Library')
-    expect(rendered).to have_css('a', text: 'Hoover Archives')
   end
 end


### PR DESCRIPTION
Hoover no longer uses requests. This restores consistency between mediateable_origins and mediator_contact_info