### PR TITLE
[HOLD behind a feature flag until 8/18 at noon] Add a migration alert to hold-recall and page emails

### DIFF
--- a/app/views/request_status_mailer/_migration_message.html.erb
+++ b/app/views/request_status_mailer/_migration_message.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (borrow_direct:) -%>
+
+<strong>Stanford Libraries will be undergoing a major system upgrade Saturday, August 19 through Sunday, August 27.
+<% if borrow_direct %>
+  Requests fulfilled by our BorrowDirect partners may be available for pickup during the upgrade.
+  You will be notified by staff. Most requests will be processed and available after August 31. 
+<% else %>
+ Requests will be processed on August 28, and items will be available for pickup on or after August 31. 
+<% end %>
+<a href="https://library.stanford.edu/news/major-system-upgrade-august-19-27">More information about the upgrade.</a></strong>

--- a/app/views/request_status_mailer/request_status_for_holdrecall.html.erb
+++ b/app/views/request_status_mailer/request_status_for_holdrecall.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <body>
+    <%= render 'migration_message', borrow_direct: true if Settings.features.migration %>
     <%= render 'pickup_confirmation' %>
 
     <p>

--- a/app/views/request_status_mailer/request_status_for_page.html.erb
+++ b/app/views/request_status_mailer/request_status_for_page.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <body>
+    <%= render 'migration_message', borrow_direct: false if Settings.features.migration %>
+
     <%= render 'pickup_confirmation' %>
 
     <p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,6 +95,7 @@ features:
   hold_recall_via_reshare: true
   scan_service: true
   mediator_email: true
+  migration: false
 
 background_jobs:
   enabled: false


### PR DESCRIPTION
Fixes #1576 