### PR TITLE
Increase Capybara wait time when running on Github Actions

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,10 @@ Capybara.register_driver :headless_chrome do |app|
   end
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
-Capybara.default_max_wait_time = 5
+
+# Set a little higher for github actions, to avoid flappy tests
+Capybara.default_max_wait_time = ENV['CI'] ? 5 : 10
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
This helps to avoid flappiness in feature specs.
Fixes #1653