### PR TITLE
Support the Folio cutover by mediating all page requests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,3 +46,8 @@ jobs:
       run: bundle exec rake
       env:
         SETTINGS__ILS__BIB_MODEL: SearchworksItem
+    - name: Run tests for Cutover
+      run: bundle exec rake
+      env:
+        SETTINGS__FEATURES__MIGRATION: true
+        SETTINGS__ILS__BIB_MODEL: SearchworksItem

--- a/app/controllers/mediated_pages_controller.rb
+++ b/app/controllers/mediated_pages_controller.rb
@@ -19,11 +19,13 @@ class MediatedPagesController < RequestsController
   protected
 
   def update_params
-    params.require(:mediated_page).permit(:approval_status, :needed_date)
+    params.require(:request).permit(:approval_status, :needed_date)
   end
 
   def validate_request_type
-    raise UnmediateableItemError unless current_request.mediateable? || (current_request.pageable? && params[:action] == 'update')
+    return if current_request.mediateable? || (Settings.features.migration && current_request.pageable? && params[:action] == 'update')
+
+    raise UnmediateableItemError
   end
 
   class UnmediateableItemError < StandardError

--- a/app/controllers/mediated_pages_controller.rb
+++ b/app/controllers/mediated_pages_controller.rb
@@ -23,7 +23,7 @@ class MediatedPagesController < RequestsController
   end
 
   def validate_request_type
-    raise UnmediateableItemError unless current_request.mediateable?
+    raise UnmediateableItemError unless current_request.mediateable? || (current_request.pageable? && params[:action] == 'update')
   end
 
   class UnmediateableItemError < StandardError

--- a/app/jobs/submit_folio_request_job.rb
+++ b/app/jobs/submit_folio_request_job.rb
@@ -124,7 +124,7 @@ class SubmitFolioRequestJob < ApplicationJob
     end
 
     def expiration_date
-      @expiration_date ||= (request.needed_date || (Time.zone.today + 3.years)).to_time.utc.iso8601
+      @expiration_date ||= ((request.needed_date unless request.is_a?(Page)) || (Time.zone.today + 3.years)).to_time.utc.iso8601
     end
 
     def request_comments

--- a/app/jobs/submit_symphony_request_job.rb
+++ b/app/jobs/submit_symphony_request_job.rb
@@ -203,7 +203,7 @@ class SubmitSymphonyRequestJob < ApplicationJob
 
     def generic_request
       {
-        fill_by_date: request.needed_date,
+        fill_by_date:,
         key: request.destination == 'SPEC-COLL' ? 'SPEC-DESK' : request.destination,
         recall_status: patron&.fee_borrower? ? 'NO' : 'STANDARD',
         patron_barcode:,
@@ -211,6 +211,12 @@ class SubmitSymphonyRequestJob < ApplicationJob
         for_group: (request.proxy? || request.user.proxy?),
         force: true
       }
+    end
+
+    def fill_by_date
+      return if request.is_a? Page
+
+      request.needed_date
     end
 
     def place_hold_params

--- a/app/models/concerns/request_validations.rb
+++ b/app/models/concerns/request_validations.rb
@@ -46,7 +46,7 @@ module RequestValidations
     errors.add(:needed_date, 'Date cannot be earlier than today') if needed_date < Time.zone.today
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
   def library_id_exists
     return unless user
 
@@ -57,7 +57,10 @@ module RequestValidations
     # required when necessary, so if it's blank here, it's not required
     return if user.library_id.blank?
 
+    # If we're in migration-mode, the ILS isn't available to validate the library ID
+    return if Settings.features.migration
+
     errors.add(:library_id, 'This ID was not found in our records') unless user.patron&.exists?
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
 end

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -81,6 +81,10 @@ class MediatedPage < Request
     for_origin(origin).where('needed_date > ?', date).distinct.pluck(:needed_date).sort
   end
 
+  def default_needed_date
+    nil
+  end
+
   private
 
   def send_confirmation!

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -34,6 +34,8 @@ class MediatedPage < Request
     # creating a mediated page should not submit the request to ILS (it needs to wait for approvals)
     send_confirmation!
     notify_mediator!
+
+    true
   end
 
   def all_approved?

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -21,6 +21,16 @@ class Page < Request
     Honeybadger.notify("WARNING: Using default location rule for page #{id} (origin: #{origin}, origin_location: #{origin_location})")
   end
 
+  def default_needed_date
+    [Time.zone.parse('2023-08-31'), Time.zone.now].max
+  end
+
+  def needed_date
+    return super unless Settings.features.migration
+
+    super || default_needed_date
+  end
+
   private
 
   def page_validator

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -3,7 +3,7 @@
 ###
 #  Request class for making simple page requests
 ###
-class Page < Request
+class Page < (Settings.features.migration ? MediatedPage : Request)
   validate :page_validator
   validates :destination, presence: true
   validate :destination_is_a_pickup_library
@@ -25,6 +25,10 @@ class Page < Request
     [Time.zone.parse('2023-08-31'), Time.zone.now].max
   end
 
+  def requires_needed_date?
+    Settings.features.migration ? true : false
+  end
+
   def needed_date
     return super unless Settings.features.migration
 
@@ -33,7 +37,15 @@ class Page < Request
 
   private
 
+  def mediated_page_validator
+    page_validator
+  end
+
   def page_validator
     errors.add(:base, 'This item is not pageable') unless pageable?
+  end
+
+  def needed_date_is_valid
+    true
   end
 end

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -37,6 +37,12 @@ class Page < (Settings.features.migration ? MediatedPage : Request)
 
   private
 
+  def send_confirmation!
+    return unless Settings.features.migration
+
+    RequestStatusMailer.request_status_for_page(self).deliver_later if notification_email_address.present?
+  end
+
   def mediated_page_validator
     page_validator
   end

--- a/app/views/admin/_library_table.html.erb
+++ b/app/views/admin/_library_table.html.erb
@@ -30,7 +30,7 @@
               <%=
                 editable_opts =
                   {
-                    name: 'mediated_page[needed_date]',
+                    name: 'request[needed_date]',
                     type: 'date',
                     value: request.needed_date.to_s,
                     url: mediated_page_path(request),

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -1,6 +1,6 @@
 <div class='admin-comments'>
   <div class='button-group'>
-    <%= bootstrap_form_for(@request, remote: true, html: { class: 'mark-as-complete-form', 'data-type': 'json' }) do |f| %>
+    <%= bootstrap_form_for(@request.becomes(MediatedPage), as: :request, remote: true, html: { class: 'mark-as-complete-form', 'data-type': 'json' }) do |f| %>
       <%= f.hidden_field :approval_status, value: 'marked_as_done' %>
       <button class='btn btn-default btn-xs' <%= 'disabled' unless @request.unapproved? %> data-behavior='mark-as-complete'>Mark as done</button>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         needed_date: 'I plan to visit on'
       page:
         <<: *request_anchor
+        needed_date: 'Process by'
       scan:
         <<: *request_anchor
         authors: 'Author(s)'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
 
   resources :requests, only: :new
   resources :aeon_pages, only: :new
-  resources :pages, concerns: [:creatable_via_get_redirect, :successable, :statusable]
+  resources :pages, concerns: [:admin_commentable, :creatable_via_get_redirect, :successable, :statusable]
   resources :scans, concerns: [:creatable_via_get_redirect, :successable, :statusable]
   resources :mediated_pages, concerns: [:admin_commentable, :creatable_via_get_redirect, :successable, :statusable]
   resources :hold_recalls, concerns: [:creatable_via_get_redirect, :successable, :statusable]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,20 @@ origin_admin_groups:
   HOPKINS: []
   RUMSEYMAP: []
   SPEC-COLL: []
+  # temporary mediated locations for FOLIO migration
+  ARS: []
+  BUSINESS: []
+  EARTH-SCI: []
+  EAST-ASIA: []
+  ENG: []
+  GREEN: []
+  LAW: []
+  MEDIA-MTXT: []
+  MUSIC: []
+  SAL: []
+  SAL3: []
+  SAL-NEWARK: []
+  SCIENCE: []
 
 origin_location_admin_groups:
   PAGE-MP: []
@@ -43,6 +57,20 @@ mediateable_origins:
     library_override: EARTH-SCI
   RUMSEYMAP: {}
   SPEC-COLL: {}
+  # temporary mediated locations for FOLIO migration
+  ARS: {}
+  BUSINESS: {}
+  EARTH-SCI: {}
+  EAST-ASIA: {}
+  ENG: {}
+  GREEN: {}
+  LAW: {}
+  MEDIA-MTXT: {}
+  MUSIC: {}
+  SAL: {}
+  SAL3: {}
+  SAL-NEWARK: {}
+  SCIENCE: {}
 
 contact_email: 'site-admin-sul-requests@lists.stanford.edu'
 

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe MediatedPagesController do
     context 'when successful' do
       it 'returns the json representation of the updated request' do
         expect(mediated_page).not_to be_marked_as_done
-        patch :update, params: { id: mediated_page.id, mediated_page: { approval_status: 'marked_as_done' } }, format: :json
+        patch :update, params: { id: mediated_page.id, request: { approval_status: 'marked_as_done' } }, format: :json
 
         expect(mediated_page.reload).to be_marked_as_done
         expect(response.parsed_body['id']).to eq mediated_page.id
@@ -192,14 +192,14 @@ RSpec.describe MediatedPagesController do
       end
 
       it 'returns an error status code' do
-        patch :update, params: { id: mediated_page.id, mediated_page: { marked_as_complete: 'true' } }, format: :json
+        patch :update, params: { id: mediated_page.id, request: { marked_as_complete: 'true' } }, format: :json
 
         expect(response).not_to be_successful
         expect(response).to have_http_status :bad_request
       end
 
       it 'returns a small json error message' do
-        patch :update, params: { id: mediated_page.id, mediated_page: { marked_as_complete: 'true' } }, format: :json
+        patch :update, params: { id: mediated_page.id, request: { marked_as_complete: 'true' } }, format: :json
 
         expect(response.parsed_body).to eq('status' => 'error')
       end
@@ -210,7 +210,7 @@ RSpec.describe MediatedPagesController do
       let!(:mediated_page) { create(:mediated_page, user:) }
 
       it 'renders forbidden' do
-        patch :update, params: { id: mediated_page.id, mediated_page: { marked_as_complete: 'true' } }, format: :js
+        patch :update, params: { id: mediated_page.id, request: { marked_as_complete: 'true' } }, format: :js
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe 'Item Selector' do
   end
 
   describe 'for multiple items', js: true do
-    before do
-      allow_any_instance_of(MediatedPage).to receive(:item_limit).and_return(5)
-    end
-
     describe 'where there are not enough to be searchable' do
       let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS') }
 
@@ -150,12 +146,13 @@ RSpec.describe 'Item Selector' do
     end
 
     describe 'when there are enough to be searchable' do
-      let(:request_path) { new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL') }
-
       before do
+        allow_any_instance_of(MediatedPage).to receive(:item_limit).and_return(5)
         stub_bib_data_json(build(:searchable_holdings))
         visit request_path
       end
+
+      let(:request_path) { new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL') }
 
       it 'limits items using the search box' do
         within('#item-selector') do

--- a/spec/mailers/factories/request_status_mailer_factory_spec.rb
+++ b/spec/mailers/factories/request_status_mailer_factory_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RequestStatusMailerFactory do
   end
 
   describe 'user errors' do
+    before do
+      pending('During the FOLIO migration we do not have this information') if Settings.features.migration
+    end
+
     describe 'Error U003' do
       let(:request) { create(:page_with_holdings, symphony_response_data: { usererr_code: 'U003' }) }
 

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -205,6 +205,8 @@ RSpec.describe RequestStatusMailer do
 
       describe 'failure' do
         before do
+          pending('During the FOLIO migration we are not sending these messages') if Settings.features.migration
+
           allow(request.ils_response).to receive(:all_successful?).and_return false
         end
 
@@ -217,6 +219,8 @@ RSpec.describe RequestStatusMailer do
         let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user:) }
 
         before do
+          pending('During the FOLIO migration we are not sending these messages') if Settings.features.migration
+
           stub_symphony_response(build(:symphony_page_with_blocked_user))
         end
 

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Dashboard do
   end
 
   describe 'request type methods' do
+    before do
+      pending('During the migration, we count pages and mediated pages') if Settings.features.migration
+    end
+
     it 'returns the count of the different types of requests' do
       expect(subject.hold_recalls).to eq 0
       expect(subject.mediated_pages).to eq 1

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -564,6 +564,10 @@ RSpec.describe Request do
     describe 'for everybody else' do
       let(:user) { create(:sso_user) }
 
+      before do
+        pending('Page requests are not being approved during the FOLIO migration') if Settings.features.migration
+      end
+
       it 'sends an approval status email' do
         expect do
           subject.send_approval_status!
@@ -589,7 +593,8 @@ RSpec.describe Request do
     end
 
     it 'returns the subset of origin codes that are configured and mediated pages that exist in the database' do
-      expect(described_class.mediateable_origins.to_h.keys).to eq %w(ART PAGE-MP)
+      # SAL3 is temporarily included during the FOLIO migration period
+      expect(described_class.mediateable_origins.to_h.keys).to eq %w(ART PAGE-MP SAL3)
     end
   end
 

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe MediatedPage do
       it 'sends a mediator email, but does not send a confirmation email' do
         subject.user = create(:library_id_user)
         expect do
-          subject.submit!
+          expect(subject.submit!).to be true
         end.to have_enqueued_mail
       end
     end
@@ -203,7 +203,7 @@ RSpec.describe MediatedPage do
 
       it 'sends a confirmation email and a mediator email' do
         expect do
-          subject.submit!
+          expect(subject.submit!).to be true
         end.to have_enqueued_mail.twice
       end
     end

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Page do
     end
 
     before do
-      expect(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).at_least(:once).and_return(
+      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).at_least(:once).and_return(
         double(exists?: user_exists)
       )
     end
@@ -82,6 +82,10 @@ RSpec.describe Page do
 
     context 'when the library ID does not exist' do
       let(:user_exists) { false }
+
+      before do
+        pending('ILS is not available to look up users during the FOLIO migration') if Settings.features.migration
+      end
 
       it { expect(subject).not_to be_valid }
     end
@@ -110,6 +114,10 @@ RSpec.describe Page do
 
     describe 'for everybody else' do
       let(:user) { create(:sso_user) }
+
+      before do
+        pending('Page requests are not being approved during the FOLIO migration') if Settings.features.migration
+      end
 
       it 'sends an approval status email' do
         expect do

--- a/spec/views/application/_item_selector.html.erb_spec.rb
+++ b/spec/views/application/_item_selector.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'application/_item_selector.html.erb' do
   let(:user) { create(:sso_user) }
 
   before do
-    view.bootstrap_form_for(request, url: '/') do |f|
+    view.bootstrap_form_for(request, url: '/', as: :request) do |f|
       @f = f
     end
 
@@ -38,9 +38,9 @@ RSpec.describe 'application/_item_selector.html.erb' do
     it 'shows an item selector' do
       expect(rendered).to have_selector '[data-behavior="item-selector"]'
 
-      expect(rendered).to have_selector 'input[name="mediated_page[barcodes][45678901]"]'
-      expect(rendered).to have_selector 'input[name="mediated_page[barcodes][12345678]"]'
-      expect(rendered).to have_selector 'input[name="mediated_page[barcodes][89012345]"]'
+      expect(rendered).to have_selector 'input[name="request[barcodes][45678901]"]'
+      expect(rendered).to have_selector 'input[name="request[barcodes][12345678]"]'
+      expect(rendered).to have_selector 'input[name="request[barcodes][89012345]"]'
     end
   end
 end

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'requests/status.html.erb' do
   it 'has the needed date' do
     request.needed_date = Time.zone.today
     render
-    expect(rendered).to have_css('dt', text: 'Needed on')
+    expect(rendered).to have_css('dt', text: 'Process by')
     expect(rendered).to have_css('dd', text: l(Time.zone.today, format: :long))
   end
 

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'requests/success.html.erb' do
   it 'has the needed date' do
     request.needed_date = Time.zone.today
     render
-    expect(rendered).to have_css('dt', text: 'Needed on')
+    expect(rendered).to have_css('dt', text: 'Process by')
     expect(rendered).to have_css('dd', text: l(Time.zone.today, format: :long))
   end
 


### PR DESCRIPTION
To support the FOLIO migration, we need to make sure requests don't hit the ILS as part of the normal workflow, but we also want to support patrons placing requests for manual fulfillment during the migration or automated fulfillment after FOLIO is available.

This PR changes our normal `Page` requests (which immediately hit the ILS) to act like `MediatedPage` requests (which need staff intervention first). It also enables the `needed_by` field for Page requests, so the patron can indicate some urgency (but we default to a post-migration to encourage patience).

Additional validation that we normally perform, including patron status or valid library id status, will be suspended. Staff will verify eligibility out-of-band. 

During the migration, staff who fulfill pending requests will use the standard mediation workflows to mark requests "done". After FOLIO is available, we can exclude those requests from further processing.

Most of this work is transparent to current usage in -prod or behind a feature flag. The one exception is site + super admins will see a SAL3 mediation link (because of existing PAGE-MP material). This view is limited to a small number of staff, so 🤷‍♂️ 

Fixes #1577

---

TODone:
- [x] spin up the app and see if it works
- [x] write some tests for using `Settings.feature_flags.migration` to make sure things work (somehow.. maybe a separate test suite run?)
- [x] do some UAT
- [x] add request destinations to the mediation table
