### PR TITLE
Fall back on LDAP-provided univ id data when available

### DIFF
--- a/app/jobs/submit_iplc_listener_job.rb
+++ b/app/jobs/submit_iplc_listener_job.rb
@@ -85,7 +85,7 @@ class SubmitIplcListenerJob < ApplicationJob
     end
 
     def iplc_patron_id
-      request.user.patron.university_id
+      request.user.university_id
     end
 
     # Symphony location codes can be converted to ReShare location codes by:

--- a/app/jobs/submit_iplc_listener_job.rb
+++ b/app/jobs/submit_iplc_listener_job.rb
@@ -85,7 +85,7 @@ class SubmitIplcListenerJob < ApplicationJob
     end
 
     def iplc_patron_id
-      request.user.university_id
+      request.user.university_id || request.user.barcode
     end
 
     # Symphony location codes can be converted to ReShare location codes by:

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -33,16 +33,19 @@ class CurrentUser
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def update_ldap_attributes(user)
     user.name = ldap_name
     user.ldap_group_string = ldap_group_string
     user.sucard_number = ldap_sucard_number
+    user.univ_id = ldap_univ_id
     user.affiliation = ldap_affiliation
     user.email = ldap_email
     user.student_type = ldap_student_type
 
     user.save if user.changed?
   end
+  # rubocop:enable Metrics/AbcSize
 
   def ldap_name
     ldap_attributes['displayName']
@@ -50,6 +53,10 @@ class CurrentUser
 
   def ldap_group_string
     ldap_attributes['eduPersonEntitlement']
+  end
+
+  def ldap_univ_id
+    ldap_attributes['suUnivID']
   end
 
   def ldap_sucard_number

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,12 @@ class User < ActiveRecord::Base
     patron&.barcode || library_id
   end
 
+  # Prefer the patron information from the ILS, but fall back to the univ ID
+  # so that the system can function when the ILS is offline
+  def university_id
+    patron&.university_id || univ_id
+  end
+
   def library_id=(library_id)
     super(library_id.to_s.upcase)
   end
@@ -99,7 +105,7 @@ class User < ActiveRecord::Base
   end
 
   def borrow_direct_eligible?
-    patron.university_id.present?
+    university_id.present?
   end
 
   private

--- a/db/migrate/20230807203550_add_univ_id_to_user.rb
+++ b/db/migrate/20230807203550_add_univ_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddUnivIdToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :univ_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_03_181415) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_203550) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "commenter"
     t.string "comment"
@@ -71,6 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_181415) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "library_id"
     t.string "student_type"
+    t.string "univ_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["library_id"], name: "index_users_on_library_id"
     t.index ["sunetid"], name: "unique_users_by_sunetid", unique: true


### PR DESCRIPTION
We don't currently have access to the `suUnivID` field [1], so this PR is a little optimistic that we'll have that in place.  We got the OK to fall back on the library id if we don't get it.

Fixes #1671 

[1] we previously were blessed with access, but lost access with the migration to shibboleth and have to start the whole process over.