### PR TITLE
Disable estimated deliveries during the migration

### DIFF
--- a/app/components/request_and_pickup_button_component.rb
+++ b/app/components/request_and_pickup_button_component.rb
@@ -15,7 +15,7 @@ class RequestAndPickupButtonComponent < ViewComponent::Base
   end
 
   def estimate_delivery?
-    Settings.features.estimate_delivery
+    Settings.features.estimate_delivery && !Settings.features.migration
   end
 
   def default_pickup_library

--- a/app/views/requests/_scheduler_text.html.erb
+++ b/app/views/requests/_scheduler_text.html.erb
@@ -3,7 +3,7 @@
     Earliest delivery
   </div>
 
-  <% if Settings.features.estimate_delivery %>
+  <% if Settings.features.estimate_delivery && !Settings.features.migration %>
     <div class="<%= content_column_class %> input-like-text" <%= "data-single-library-value='#{current_request.pickup_libraries.first}'".html_safe unless current_request.pickup_libraries.many? %>>
       <span data-text-object="<%= current_request.object_id %>" data-scheduler-text='true' aria-live='polite'></span>
       <%= f.hidden_field :estimated_delivery, data: { 'scheduler-field' => true } %>

--- a/spec/components/request_and_pickup_button_component_spec.rb
+++ b/spec/components/request_and_pickup_button_component_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RequestAndPickupButtonComponent, type: :component do
+RSpec.describe RequestAndPickupButtonComponent, type: :component, unless: Settings.features.migration do
   subject(:rendered) do
     with_controller_class RequestsController do
       render_inline(component)

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe 'Paging Schedule' do
   end
 
   describe 'Select dropdown', js: true do
+    before do
+      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
+    end
+
     it 'displays the estimate for the currently selected value and updates it when a new destination is selected' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
 
@@ -49,6 +53,8 @@ RSpec.describe 'Paging Schedule' do
 
   describe 'Estimated delivery', js: true do
     before do
+      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
+
       stub_current_user(create(:sso_user))
       stub_symphony_response(build(:symphony_page_with_single_item))
     end
@@ -80,6 +86,10 @@ RSpec.describe 'Paging Schedule' do
       ]
     end
 
+    before do
+      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
+    end
+
     it 'displays an estimate for the single possible destination' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'PAGE-EN')
 
@@ -90,6 +100,8 @@ RSpec.describe 'Paging Schedule' do
 
   describe 'form choice page', js: true do
     before do
+      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
+
       stub_bib_data_json(build(:scannable_holdings))
     end
 


### PR DESCRIPTION
`Settings.features.estimate_delivery ` is too broad and disables estimates for e.g. scanning, which is unaffected by the migration.

TODO: 
- [ ] fix up or make pending the cutover tests for estimated dates