### PR TITLE
Use Item#permanent_location instead of Item#permanent_location_code a…

### DIFF
--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -2,18 +2,20 @@
 
 module Folio
   Location = Data.define(:id, :campus, :library, :institution, :code, :discovery_display_name, :name, :details) do
+    # rubocop:disable Metrics/AbcSize
     def self.from_hash(dyn)
       new(
         id: dyn.fetch('id'),
-        campus: Campus.new(**dyn.fetch('campus')),
-        library: Library.new(**dyn.fetch('library')),
-        institution: Institution.new(id: dyn.fetch('institutionId')),
+        campus: (Campus.new(**dyn.fetch('campus')) if dyn['campus']),
+        library: (Library.new(**dyn.fetch('library')) if dyn['library']),
+        institution: (Institution.new(id: dyn.fetch('institutionId')) if dyn['institutionId']),
         code: dyn.fetch('code'),
-        discovery_display_name: dyn.fetch('discoveryDisplayName') || dyn.fetch('name'),
-        name: dyn.fetch('name'),
-        details: dyn.fetch('details') || {}
+        discovery_display_name: dyn['discoveryDisplayName'] || dyn['name'] || dyn.fetch('id'),
+        name: dyn['name'],
+        details: dyn.fetch('details', {})
       )
     end
+    # rubocop:enable Metrics/AbcSize
   end
   Library = Data.define(:id, :code)
   Campus = Data.define(:id, :code)

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -93,7 +93,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
       type { '' }
       material_type { build(:book_material_type) }
       loan_type { Folio::LoanType.new(id: '') }
-      permanent_location_code { 'GRE-STACKS' }
+      effective_location { build(:location, code: 'GRE-STACKS') }
       initialize_with { new(**attributes) }
     end
 
@@ -107,18 +107,15 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '3610512345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '3610587654321',
                 callnumber: 'ABC 321',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '12345679',
                 callnumber: 'ABC 456',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -137,8 +134,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 87654321',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -159,8 +155,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -181,7 +176,6 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 effective_location: build(:sal_temp_location),
-                permanent_location_code: 'SAL-TEMP',
                 type: 'NONCIRC')
         ]
       end
@@ -206,14 +200,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS')
+                effective_location: build(:spec_coll_location))
         ]
       end
 
@@ -237,8 +229,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS')
+                effective_location: build(:spec_coll_location))
         ]
       end
 
@@ -263,8 +254,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS')
+                effective_location: build(:spec_coll_location))
         ]
       end
 
@@ -285,14 +275,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -313,14 +301,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:scannable_location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:scannable_location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:scannable_location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:scannable_location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -341,8 +327,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Available',
-                effective_location: build(:green_location),
-                permanent_location_code: 'GRE-STACKS')
+                effective_location: build(:green_location))
         ]
       end
 
@@ -363,8 +348,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:page_lp_location),
-                permanent_location_code: 'SAL3-PAGE-LP')
+                effective_location: build(:page_lp_location))
         ]
       end
 
@@ -385,14 +369,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:page_mp_location),
-                permanent_location_code: 'SAL3-PAGE-MP'),
+                effective_location: build(:page_mp_location)),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:page_mp_location),
-                permanent_location_code: 'SAL3-PAGE-MP')
+                effective_location: build(:page_mp_location))
         ]
       end
 
@@ -412,34 +394,28 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '23456789',
                 callnumber: 'ABC 456',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '34567890',
                 callnumber: 'ABC 789',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '45678901',
                 callnumber: 'ABC 012',
                 effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS',
                 public_note: 'note for 45678901'),
           build(:item,
                 barcode: '56789012',
                 callnumber: 'ABC 345',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '67890123',
                 callnumber: 'ABC 678',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -460,7 +436,6 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK')
         ]
       end
@@ -482,7 +457,6 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 effective_location: build(:location, code: 'ART-STACKS'),
-                permanent_location_code: 'ART-STACKS',
                 type: 'STKS')
         ]
       end
@@ -504,63 +478,54 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '23456789',
                 callnumber: 'ABC 456',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
                 public_note: 'note for 23456789',
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '34567890',
                 callnumber: 'ABC 789',
                 effective_location: build(:mediated_location, code: 'ART-NEWBOOK'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
+                permanent_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '45678901',
                 callnumber: 'ABC 012',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 public_note: 'note for 45678901',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '56789012',
                 callnumber: 'ABC 345',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '67890123',
                 callnumber: 'ABC 678',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '78901234',
                 callnumber: 'ABC 901',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '89012345',
                 callnumber: 'ABC 234',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '90123456',
                 callnumber: 'ABC 567',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '01234567',
                 callnumber: 'ABC 890',
                 effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-                permanent_location_code: 'ART-LOCKED-LARGE',
                 type: 'LCKSTK')
         ]
       end
@@ -581,54 +546,44 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '23456789',
                 callnumber: 'ABC 456',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '34567890',
                 callnumber: 'ABC 789',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '45678901',
                 callnumber: 'ABC 012',
                 effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS',
                 public_note: 'note for 45678901'),
           build(:item,
                 barcode: '56789012',
                 callnumber: 'ABC 345',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '67890123',
                 callnumber: 'ABC 678',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '78901234',
                 callnumber: 'ABC 901',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '89012345',
                 callnumber: 'ABC 234',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '90123456',
                 callnumber: 'ABC 567',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS'),
+                effective_location: build(:spec_coll_location)),
           build(:item,
                 barcode: '01234567',
                 callnumber: 'ABC 890',
-                effective_location: build(:spec_coll_location),
-                permanent_location_code: 'SPEC-STACKS')
+                effective_location: build(:spec_coll_location))
         ]
       end
 
@@ -648,15 +603,13 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS'),
+                effective_location: build(:location, code: 'SAL3-STACKS')),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 due_date: '2015-01-01T12:59:00.000+00:00',
                 status: 'Checked out',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 
@@ -676,8 +629,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
-                permanent_location_code: 'SAL3-STACKS')
+                effective_location: build(:location, code: 'SAL3-STACKS'))
         ]
       end
 

--- a/spec/models/folio/holdings_spec.rb
+++ b/spec/models/folio/holdings_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Folio::Holdings do
                     callnumber: 'XX(14820051.1)',
                     public_note: nil,
                     effective_location: instance_double(Folio::Location),
-                    permanent_location_code:)
+                    permanent_location:)
   end
 
   describe 'Enumerable' do
     subject { holdings.to_a }
 
     context "when the request location doesn't match the effectiveLocation" do
-      let(:permanent_location_code) { 'MUS-RECORDINGS' }
+      let(:permanent_location) { instance_double(Folio::Location, code: 'MUS-RECORDINGS') }
 
       it { is_expected.to eq items }
     end

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Folio::Instance do
               "name": "Green Stacks",
               "details": {}
             },
-            "permanentLocation": { "code": "GRE-STACKS" },
+            "permanentLocation": { "id": "uuid", "code": "GRE-STACKS" },
             "holdingsRecord": { "effectiveLocation": { "code": "GRE-STACKS" } },
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "temporaryLoanTypeId": null
@@ -214,7 +214,7 @@ RSpec.describe Folio::Instance do
                   "name": "Spec U-Archives",
                   "details": {}
                 },
-                "permanentLocation": { "code": "SPEC-STACKS" },
+                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
                 "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
                 "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
                 "temporaryLoanTypeId": null
@@ -247,7 +247,7 @@ RSpec.describe Folio::Instance do
                   "name": "Spec SAL3 U-Archives",
                   "details": {}
                 },
-                "permanentLocation": { "code": "SPEC-STACKS" },
+                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
                 "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
                 "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
                 "temporaryLoanTypeId": null
@@ -280,7 +280,7 @@ RSpec.describe Folio::Instance do
                   "name": "Spec SAL3 U-Archives",
                   "details": {}
                 },
-                "permanentLocation": { "code": "SPEC-STACKS" },
+                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
                 "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
                 "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
                 "temporaryLoanTypeId": null
@@ -313,7 +313,7 @@ RSpec.describe Folio::Instance do
                   "name": "Spec SAL3 U-Archives",
                   "details": {}
                 },
-                "permanentLocation": { "code": "SPEC-STACKS" },
+                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
                 "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
                 "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
                 "temporaryLoanTypeId": null

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Folio::Item do
               "name": "SAL3 Stacks",
               "details": {}
             },
-            "permanentLocation": { "code": "SAL3-STACKS" },
+            "permanentLocation": { "id": "uuid", "code": "SAL3-STACKS" },
             "holdingsRecord": { "effectiveLocation": { "code": "SAL3-STACKS" } },
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "temporaryLoanTypeId": null
@@ -84,7 +84,7 @@ RSpec.describe Folio::Item do
               "name": "Green Stacks",
               "details": {}
             },
-            "permanentLocation": { "code": "SAL3-STACKS" },
+            "permanentLocation": { "id": "uuid", "code": "SAL3-STACKS" },
             "holdingsRecord": { "effectiveLocation": { "code": "SAL3-STACKS" } },
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "temporaryLoanTypeId": null


### PR DESCRIPTION
…nd make most `Folio::Location` parameters optional

It's not a great developer experience that these two objects differ, but I don't think we want to pull in even more permanent location data that we don't use.