### PR TITLE
Get the id for the location.

### DIFF
--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -125,6 +125,7 @@ class FolioGraphqlClient
                   }
                 }
                 permanentLocation {
+                  id
                   code
                 }
                 permanentLoanTypeId


### PR DESCRIPTION
ID is required when casting to the Location model

Fixes #1688 