### PR TITLE
Stop eagerly retrieveing dueDate for items

### DIFF
--- a/app/controllers/due_dates_controller.rb
+++ b/app/controllers/due_dates_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+##
+# Controller to display the due date in a lazy way, because getting due dates in the graphQL query
+# with all the other item data was too slow.
+class DueDatesController < ApplicationController
+  def show
+    item_id = params[:id]
+    due_date = FolioClient.new.due_date(item_id:).to_date
+    render partial: 'show', locals: { due_date:, item_id: }
+  end
+end

--- a/app/controllers/due_dates_controller.rb
+++ b/app/controllers/due_dates_controller.rb
@@ -5,8 +5,8 @@
 # with all the other item data was too slow.
 class DueDatesController < ApplicationController
   def show
-    item_id = params[:id]
-    due_date = FolioClient.new.due_date(item_id:).to_date
-    render partial: 'show', locals: { due_date:, item_id: }
+    instance_id = params[:id]
+    due_dates = FolioClient.new.due_date(instance_id:)
+    render partial: 'show', locals: { due_dates: }
   end
 end

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -47,7 +47,7 @@ module RequestsHelper
       else
         tag.span class: 'status pull-right availability unavailable' do
           # This content is lazily loaded, because the query to get due_date makes the initial query for items take a long time.
-          turbo_frame_tag "due_date_#{holding.id}", src: due_date_path(holding.id)
+          turbo_frame_tag "due_date_#{holding.id}"
         end
       end
     else

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -37,10 +37,18 @@ module RequestsHelper
     current_request.origin
   end
 
+  # rubocop:disable Metrics/MethodLength
   def label_for_item_selector_holding(holding)
     if holding.checked_out?
-      content_tag :span, class: 'status pull-right availability unavailable' do
-        "Due #{holding.due_date}"
+      if Settings.ils.bib_model == 'SearchworksItem'
+        content_tag :span, class: 'status pull-right availability unavailable' do
+          "Due #{holding.due_date}"
+        end
+      else
+        tag.span class: 'status pull-right availability unavailable' do
+          # This content is lazily loaded, because the query to get due_date makes the initial query for items take a long time.
+          turbo_frame_tag "due_date_#{holding.id}", src: due_date_path(holding.id)
+        end
       end
     else
       content_tag :span, class: "status pull-right availability #{holding.status_class}" do
@@ -48,6 +56,7 @@ module RequestsHelper
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def request_level_request_status(request = current_request)
     if request.ils_response.usererr_code

--- a/app/models/folio/holdings.rb
+++ b/app/models/folio/holdings.rb
@@ -8,6 +8,7 @@ module Folio
     include Enumerable
 
     # @param [Request] request the users request
+    # @param [Array<Folio::Item>] items
     def initialize(request, items)
       @request = request
       @items = items

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -58,7 +58,7 @@ module Folio
       contributor&.fetch('name')
     end
 
-    attr_reader :pub_date, :format, :items
+    attr_reader :id, :pub_date, :format, :items
 
     def isbn
       @isbn.join('; ')

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -28,6 +28,7 @@ module Folio
         end,
         electronic_access: json.fetch('electronicAccess', []),
         items: json.fetch('items', []).map { |item| Folio::Item.from_hash(item) }
+        # TODO: maybe instantiate stub items here with basic metadata
       )
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -46,13 +46,13 @@ module Folio
   #       See https://github.com/sul-dlss/searchworks_traject_indexer/blob/02192452815de3861dcfafb289e1be8e575cb000/lib/traject/config/sirsi_config.rb#L2379
   # NOTE, barcode and callnumber may be nil. see instance_hrid: 'in00000063826'
   class Item
-    attr_reader :barcode, :status, :type, :callnumber, :public_note, :effective_location, :permanent_location, :material_type,
-                :loan_type
+    attr_reader :id, :barcode, :status, :type, :callnumber, :public_note, :effective_location, :permanent_location,
+                :material_type, :loan_type
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(barcode:, status:, type:, callnumber:, public_note:,
-                   effective_location:, permanent_location: nil, material_type: nil, loan_type: nil,
-                   due_date: nil)
+    def initialize(id:, barcode:, status:, type:, callnumber:, public_note:,
+                   effective_location:, permanent_location: nil, material_type: nil, loan_type: nil)
+      @id = id
       @barcode = barcode
       @status = status
       @type = type
@@ -62,7 +62,6 @@ module Folio
       @permanent_location = permanent_location || effective_location
       @material_type = material_type
       @loan_type = loan_type
-      @due_date = due_date
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -113,10 +112,6 @@ module Folio
       status == STATUS_MISSING
     end
 
-    def due_date
-      Time.zone.parse(@due_date).strftime('%m/%d/%Y') if @due_date
-    end
-
     def hold?
       status == STATUS_HOLD
     end
@@ -131,9 +126,9 @@ module Folio
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def self.from_hash(dyn)
-      new(barcode: dyn['barcode'],
+      new(id: dyn.fetch('id'),
+          barcode: dyn['barcode'],
           status: dyn.dig('status', 'name'),
-          due_date: dyn['dueDate'],
           type: dyn.dig('materialType', 'name'),
           callnumber: [dyn.dig('effectiveCallNumberComponents', 'callNumber'), dyn['volume'], dyn['enumeration'],
                        dyn['chronology']].filter_map(&:presence).join(' '),

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -123,6 +123,8 @@ class FolioClient
     folio_graphql_client.instance(hrid:)
   end
 
+  delegate :due_date, to: :folio_graphql_client
+
   def circulation_rules
     get_json('/circulation-rules-storage').fetch('rulesAsText', '')
   end

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -160,11 +160,9 @@ class FolioGraphqlClient
         query:
           <<~GQL
             query DueDate {
-              instances(id: "#{instance_id}") {
-                items {
-                  id
-                  dueDate
-                }
+              availability(id: "#{instance_id}") {
+                id
+                dueDate
               }
             }
           GQL
@@ -174,9 +172,9 @@ class FolioGraphqlClient
 
     raise data['errors'].pluck('message').join("\n") if data.key?('errors')
 
-    data.dig('data', 'instances', 0, 'items').map do |row|
+    data.dig('data', 'availability').map do |row|
       next unless row['dueDate']
-      
+
       { id: row['id'], due_date: DateTime.parse(row['dueDate']).to_date }
     end
   end
@@ -237,16 +235,3 @@ class FolioGraphqlClient
                             'okapi_password' => @password })
   end
 end
-
-# Logs graphql calls
-class GraphqlLogSubscriber < ActiveSupport::LogSubscriber
-  def due_date(event)
-    info { "Due_date call (#{event.duration.round(1)}ms)" }
-  end
-
-  def logger
-    ActionController::Base.logger
-  end
-end
-
-GraphqlLogSubscriber.attach_to :graphql

--- a/app/views/application/_item_selector.html.erb
+++ b/app/views/application/_item_selector.html.erb
@@ -30,6 +30,22 @@
           <a href="javascript:;" class="sort sort-callnumber btn btn-default pull-left" data-sort="callnumber">Call number <i></i></a>
           <a href="javascript:;" class="sort sort-status btn btn-default pull-right" data-sort="status">Status <i></i></a>
         </div>
+        <% if f.object.bib_data.is_a?(Folio::Instance) # TODO: remove conditional after migration %>
+          <script>
+            document.addEventListener('turbo:load', () => {
+              // Trigger lazy load due dates
+              fetch('<%= due_date_path(f.object.bib_data.id) %>')
+                .then(response => {
+                  if (!response.ok) {
+                    throw new TypeError("Request failed")
+                  }
+                  return response.text()
+                })
+                .then(data => Turbo.renderStreamMessage(data))
+                .catch(error => console.error(error))
+            })
+          </script>
+        <% end %>
         <div id="item-selector" class="item-selector" data-limit-selected-items="<%= f.object.item_limit if f.object.item_limit.to_i > 1 %>" data-counter-target="[data-items-counter='true']">
           <div class='list'>
             <% f.object.all_holdings.sort_by(&:callnumber).each.with_index(1) do |holding, index| %>

--- a/app/views/due_dates/_show.html.erb
+++ b/app/views/due_dates/_show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "due_date_#{item_id}" do %>
+  Due <%= l due_date, format: :numeric %>
+<% end %>

--- a/app/views/due_dates/_show.html.erb
+++ b/app/views/due_dates/_show.html.erb
@@ -1,3 +1,7 @@
-<%= turbo_frame_tag "due_date_#{item_id}" do %>
-  Due <%= l due_date, format: :numeric %>
+<% due_dates.each do |item_data| %>
+  <turbo-stream action="replace" target="due_date_<%= item_data.fetch(:id) %>">
+    <template>
+      Due <%= l item_data.fetch(:due_date), format: :numeric  %>
+    </template>
+  </turbo-stream>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
       quick: '%a %b %-d'
       short: '%b %-d %Y'
       long: '%A, %b %-d %Y'
+      numeric: '%m/%d/%Y'
   time:
     am: a
     pm: p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
   end
 
   resources :requests, only: :new
+  resources :due_dates, only: :show
   resources :aeon_pages, only: :new
   resources :pages, concerns: [:admin_commentable, :creatable_via_get_redirect, :successable, :statusable]
   resources :scans, concerns: [:creatable_via_get_redirect, :successable, :statusable]

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -88,6 +88,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
     end
 
     factory :item, class: 'Folio::Item' do
+      id { SecureRandom.uuid }
       barcode { '3610512345678' }
       callnumber { 'ABC 123' }
       status { 'Available' }
@@ -609,7 +610,6 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
-                due_date: '2015-01-01T12:59:00.000+00:00',
                 status: 'Checked out',
                 effective_location: build(:location, code: 'SAL3-STACKS'))
         ]

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -309,11 +309,16 @@ RSpec.describe 'Item Selector' do
   end
 
   describe 'checked out items', js: true do
-    let(:graphql_client) { instance_double(FolioGraphqlClient, due_date: DateTime.parse('2015-01-01T00:00:00Z')) }
+    let(:holdings) { build(:checkedout_holdings) }
+    let(:graphql_client) do
+      instance_double(FolioGraphqlClient, due_date: [
+                        { id: holdings.items.second.id, due_date: Date.parse('2015-01-01') }
+                      ])
+    end
 
     before do
-      stub_bib_data_json(build(:checkedout_holdings))
-      allow(FolioGraphqlClient).to receive(:new).and_return(graphql_client)
+      stub_bib_data_json(holdings)
+      allow(FolioGraphqlClient).to receive(:new).and_return(graphql_client) if Settings.ils.bib_model == 'Folio::Instance'
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
     end
 

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -309,8 +309,11 @@ RSpec.describe 'Item Selector' do
   end
 
   describe 'checked out items', js: true do
+    let(:graphql_client) { instance_double(FolioGraphqlClient, due_date: DateTime.parse('2015-01-01T00:00:00Z')) }
+
     before do
       stub_bib_data_json(build(:checkedout_holdings))
+      allow(FolioGraphqlClient).to receive(:new).and_return(graphql_client)
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
     end
 

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -164,20 +164,34 @@ RSpec.describe RequestsHelper do
   end
 
   describe 'label_for_item_selector_holding' do
-    let(:subject) { Capybara.string(label_for_item_selector_holding(holding)) }
+    let(:subject) { Capybara.string(helper.label_for_item_selector_holding(holding)) }
 
     describe 'checked out items' do
-      let(:holding) do
-        instance_double(Searchworks::HoldingItem,
-                        checked_out?: true, due_date: Time.zone.today)
+      context 'for a Searchworks::HoldingsItem', if: Settings.ils.bib_model == 'SearchworksItem' do
+        let(:holding) do
+          instance_double(Searchworks::HoldingItem,
+                          checked_out?: true, due_date: Time.zone.today)
+        end
+
+        it 'includes the unavailable class' do
+          expect(subject).to have_css('.unavailable')
+        end
+
+        it 'includes the due date' do
+          expect(subject).to have_content("Due #{Time.zone.today}")
+        end
       end
 
-      it 'includes the unavailable class' do
-        expect(subject).to have_css('.unavailable')
-      end
+      context 'for a Folio::Item', if: Settings.ils.bib_model != 'SearchworksItem' do
+        let(:holding) { instance_double(Folio::Item, checked_out?: true, id: '123-123-123') }
 
-      it 'includes the due date' do
-        expect(subject).to have_content("Due #{Time.zone.today}")
+        it 'includes the unavailable class' do
+          expect(subject).to have_css('.unavailable')
+        end
+
+        it 'includes the due date' do
+          expect(subject).to have_css('turbo-frame[src="/due_dates/123-123-123"]')
+        end
       end
     end
 

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -189,8 +189,8 @@ RSpec.describe RequestsHelper do
           expect(subject).to have_css('.unavailable')
         end
 
-        it 'includes the due date' do
-          expect(subject).to have_css('turbo-frame[src="/due_dates/123-123-123"]')
+        it 'includes the destination frame for the due date' do
+          expect(subject).to have_css('turbo-frame[id="due_date_123-123-123"]')
         end
       end
     end

--- a/spec/models/folio/holdings_spec.rb
+++ b/spec/models/folio/holdings_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Folio::Holdings do
   let(:request) { HoldRecall.new(barcode: '36105237669143', item_id: '14820051', origin: 'MUSIC', origin_location: 'RECORDINGS') }
   let(:items) { [item] }
   let(:item) do
-    Folio::Item.new(barcode: '123',
+    Folio::Item.new(id: '123-123-123',
+                    barcode: '123',
                     status: 'In process',
                     type: 'multimedia',
                     callnumber: 'XX(14820051.1)',

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Folio::Instance do
         "electronicAccess": [],
         "items": [
           {
+            "id": "57550106-e809-5a43-92da-1503d84dcc18",
             "barcode": "36105124065330",
             "status": {
               "name": "Available"
@@ -182,6 +183,7 @@ RSpec.describe Folio::Instance do
             ],
             "items": [
               {
+                "id": "3593730d-2d84-542c-bb8d-1ecb39fb33fb",
                 "barcode": "6307113-1001",
                 "status": {
                   "name": "Available"
@@ -220,6 +222,7 @@ RSpec.describe Folio::Instance do
                 "temporaryLoanTypeId": null
               },
               {
+                "id": "3593730d-2d84-542c-bb8d-eeeeeeeeee",
                 "barcode": "36105116223418",
                 "status": {
                   "name": "Available"
@@ -253,6 +256,7 @@ RSpec.describe Folio::Instance do
                 "temporaryLoanTypeId": null
               },
               {
+                "id": "3593730d-2d84-542c-bb8d-fffffffffff",
                 "barcode": "36105116223426",
                 "status": {
                   "name": "Available"
@@ -286,6 +290,7 @@ RSpec.describe Folio::Instance do
                 "temporaryLoanTypeId": null
               },
               {
+                "id": "3593730d-2d84-542c-bb8d-aaaaaaaaaaaaa",
                 "barcode": "36105116223434",
                 "status": {
                   "name": "Available"

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "barcode": null,
             "status": {
               "name": "On order"
@@ -52,6 +53,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "barcode": "36105124065330",
             "status": {
               "name": "Available"
@@ -196,6 +198,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{gre_stacks},
@@ -215,6 +218,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{sal3_stacks},
@@ -234,6 +238,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{page_sp},
@@ -253,6 +258,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{gre_stacks},
@@ -272,6 +278,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Checked out" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{gre_stacks},
@@ -388,6 +395,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{gre_stacks},
@@ -407,6 +415,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{sal3_stacks},
@@ -426,6 +435,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{page_sp},
@@ -445,6 +455,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{gre_stacks},
@@ -464,6 +475,7 @@ RSpec.describe Folio::Item do
       let(:data) do
         <<~JSON
           {
+            "id": "123-123-123",
             "status": { "name": "Checked out" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
             "permanentLocation": #{gre_stacks},


### PR DESCRIPTION
Eagerly loading dueDate for every item was causing the query from the graphql server to take about 35 seconds for hrid: 'L284'.  Now the query time is under 17.5s.

Ref #1676 