### PR TITLE
Flip the timeout amounts

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 # Set a little higher for github actions, to avoid flappy tests
-Capybara.default_max_wait_time = ENV['CI'] ? 5 : 10
+Capybara.default_max_wait_time = ENV['CI'] ? 10 : 5
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
The intention was for CI to have more time than running tests locally