### PR TITLE
Improve performance by using cached location details

### DIFF
--- a/app/models/folio/campus.rb
+++ b/app/models/folio/campus.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
 module Folio
-  Campus = Data.define(:id, :code)
+  Campus = Data.define(:id, :code) do
+    def self.from_dynamic(dyn)
+      new(
+        id: dyn.fetch('id'),
+        code: dyn.fetch('code')
+      )
+    end
+  end
 end

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -1,16 +1,31 @@
 # frozen_string_literal: true
 
 module Folio
-  Location = Data.define(:id, :campus, :library, :library_id, :institution, :code, :discovery_display_name,
-                         :name, :primary_service_point_id, :details) do
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # Models a location from Folio
+  class Location
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(id:, campus_id:, library_id:, institution_id:, code:, discovery_display_name:,
+                   name:, primary_service_point_id:, details:)
+      @id = id
+      @library_id = library_id
+      @campus_id = campus_id
+      @institution_id = institution_id
+      @code = code
+      @discovery_display_name = discovery_display_name
+      @name = name
+      @primary_service_point_id = primary_service_point_id
+      @details = details
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    attr_reader :id, :campus_id, :library_id, :institution_id, :code, :discovery_display_name, :name, :primary_service_point_id, :details
+
     def self.from_hash(dyn)
       new(
         id: dyn.fetch('id'),
-        campus: (Campus.new(**dyn.fetch('campus')) if dyn['campus']),
-        library: (Library.new(**dyn.fetch('library').symbolize_keys) if dyn['library']),
+        campus_id: dyn.fetch('campusId'),
         library_id: dyn['libraryId'] || dyn.dig('library', 'id'),
-        institution: (Institution.new(id: dyn.fetch('institutionId')) if dyn['institutionId']),
+        institution_id: dyn.fetch('institutionId'),
         code: dyn.fetch('code'),
         discovery_display_name: dyn['discoveryDisplayName'] || dyn['name'] || dyn.fetch('id'),
         name: dyn['name'],
@@ -18,6 +33,13 @@ module Folio
         primary_service_point_id: dyn['primaryServicePoint'] # present in every location in json, but not from Graphql
       )
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def library
+      @library ||= Folio::Types.libraries.find_by(id: library_id)
+    end
+
+    def campus
+      @campus ||= Folio::Types.campuses.find_by(id: campus_id)
+    end
   end
 end

--- a/app/models/folio/request_abilities.rb
+++ b/app/models/folio/request_abilities.rb
@@ -60,7 +60,6 @@ module Folio
       !mediateable? && !hold_recallable? && any_holdings_pageable?
     end
 
-    # FOLIO
     def pickup_destinations
       return (default_pickup_service_points + additional_pickup_service_points).uniq if location_restricted_service_point_codes.empty?
 
@@ -97,7 +96,7 @@ module Folio
     # Retrieve the service points associated with specific locations
     def location_restricted_service_point_codes
       request.holdings.flat_map do |item|
-        Array(item.effective_location.details['pageServicePoints']).pluck('code')
+        Array(item.effective_location.details['pageServicePointCodes']&.split(','))
       end.compact.uniq
     end
 

--- a/app/services/folio/campuses_store.rb
+++ b/app/services/folio/campuses_store.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Folio
+  # A cache of campus data
+  class CampusesStore
+    def initialize(data_from_cache)
+      @data = data_from_cache.map { |lib_data| Folio::Campus.from_dynamic(lib_data) }
+    end
+
+    attr_reader :data
+
+    def find_by(id:)
+      data.find { |candidate| candidate.id == id }
+    end
+  end
+end

--- a/app/services/folio/circulation_rules/policy_service.rb
+++ b/app/services/folio/circulation_rules/policy_service.rb
@@ -75,9 +75,9 @@ module Folio
       def item_rule(item)
         index.search('material-type' => item.material_type.id,
                      'loan-type' => item.loan_type.id,
-                     'location-institution' => item.effective_location.institution.id,
-                     'location-campus' => item.effective_location.campus.id,
-                     'location-library' => item.effective_location.library.id,
+                     'location-institution' => item.effective_location.institution_id,
+                     'location-campus' => item.effective_location.campus_id,
+                     'location-library' => item.effective_location.library_id,
                      'location-location' => item.effective_location.id)
       end
 

--- a/app/services/folio/types.rb
+++ b/app/services/folio/types.rb
@@ -7,7 +7,7 @@ module Folio
   class Types
     class << self
       delegate  :policies, :circulation_rules, :criteria,
-                :locations, :libraries, :service_points, to: :instance
+                :locations, :libraries, :service_points, :campuses, to: :instance
     end
 
     def self.instance
@@ -46,6 +46,10 @@ module Folio
 
     def service_points
       @service_points ||= ServicePointStore.new(get_type('service_points'))
+    end
+
+    def campuses
+      @campuses ||= CampusesStore.new(get_type('campuses'))
     end
 
     def policies

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -91,56 +91,12 @@ class FolioGraphqlClient
                     name
                   }
                 }
-                effectiveLocation {
-                  id
-                  campusId
-                  libraryId
-                  institutionId
-                  code
-                  discoveryDisplayName
-                  name
-                  servicePoints {
-                    id
-                    code
-                    pickupLocation
-                  }
-                  library {
-                    id
-                    code
-                  }
-                  campus {
-                    id
-                    code
-                  }
-                  details {
-                    pageAeonSite
-                    pageMediationGroupKey
-                    pageServicePoints {
-                      id
-                      code
-                      name
-                    }
-                    scanServicePointCode
-                    availabilityClass
-                  }
-                }
-                permanentLocation {
-                  id
-                  code
-                  details {
-                    pagingSchedule
-                  }
-                }
+                effectiveLocationId
+                permanentLocationId
                 permanentLoanTypeId
                 temporaryLoanTypeId
                 holdingsRecord {
-                  effectiveLocation {
-                    id
-                    code
-                    details {
-                      pagingSchedule
-                    }
-                  }
+                  effectiveLocationId
                 }
               }
             }

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -8,69 +8,13 @@ if Settings.ils.bib_model == 'Folio::Instance'
       code { 'SAL3-STACKS' }
       name { 'Location name' }
       discovery_display_name { 'Discovery display name' }
-      campus { Folio::Campus.new(id: 'uuid', code: 'SUL') }
-      library { Folio::Library.new(id: 'uuid', code: 'LIB') }
+      campus_id { 'uuid' }
       library_id { 'uuid' }
       primary_service_point_id { nil }
-      institution { Folio::Institution.new(id: 'uuid') }
+      institution_id { 'uuid' }
       details { {} }
 
       initialize_with { new(**attributes) }
-    end
-
-    factory :mediated_location, parent: :location do
-      details { { 'pageMediationGroupKey' => 'ART', 'pageServicePoints' => [{ 'code' => 'ART' }] } }
-    end
-
-    factory :page_mp_location, parent: :location do
-      code { 'SAL3-PAGE-MP' }
-      details { { 'pageMediationGroupKey' => 'PAGE-MP', 'pageServicePoints' => [{ 'code' => 'EARTH-SCI' }] } }
-    end
-
-    factory :page_lp_location, parent: :location do
-      code { 'SAL3-PAGE-LP' }
-      details { { 'pageServicePoints' => [{ 'code' => 'MUSIC' }, { 'code' => 'MEDIA-CENTER' }] } }
-    end
-
-    factory :page_en_location, parent: :location do
-      code { 'SAL3-PAGE-EN' }
-      details { { 'pageServicePoints' => [{ 'code' => 'ENG' }] } }
-    end
-
-    factory :scannable_location, parent: :location do
-      code { 'SAL3-STACKS' }
-      details { { 'scanServicePointCode' => 'SAL3' } }
-    end
-
-    factory :sal_temp_location, parent: :location do
-      code { 'SAL-TEMP' }
-      details { { 'scanServicePointCode' => 'GREEN' } }
-    end
-
-    factory :mmstacks_location, parent: :location do
-      code { 'MEDIA-CAGE' }
-      library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'MEDIA-CENTER') }
-    end
-
-    factory :law_location, parent: :location do
-      code { 'LAW-STACKS1' }
-      library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW') }
-      campus { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW') }
-    end
-
-    factory :eal_sets_location, parent: :location do
-      code { 'EAL-SETS' }
-      library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'EAST-ASIA') }
-    end
-
-    factory :green_location, parent: :location do
-      code { 'GRE-STACKS' }
-      library { Folio::Library.new(id: 'f6b5519e-88d9-413e-924d-9ed96255f72e', code: 'GREEN') }
-    end
-
-    factory :spec_coll_location, parent: :location do
-      code { 'SPEC-STACKS' }
-      details { { 'pageAeonSite' => 'SPECUA' } }
     end
 
     factory :book_material_type, class: 'Folio::MaterialType' do
@@ -95,7 +39,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
       type { '' }
       material_type { build(:book_material_type) }
       loan_type { Folio::LoanType.new(id: '') }
-      effective_location { build(:location, code: 'GRE-STACKS') }
+      effective_location_id { Folio::Types.locations.find_by(code: 'GRE-STACKS').id }
       initialize_with { new(**attributes) }
     end
 
@@ -109,15 +53,15 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '3610512345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '3610587654321',
                 callnumber: 'ABC 321',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '12345679',
                 callnumber: 'ABC 456',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -136,7 +80,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 87654321',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -157,7 +101,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -177,7 +121,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:sal_temp_location),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL-TEMP').id,
                 type: 'NONCIRC')
         ]
       end
@@ -202,12 +146,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:spec_coll_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id)
         ]
       end
 
@@ -231,7 +175,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:spec_coll_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id)
         ]
       end
 
@@ -256,7 +200,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:spec_coll_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id)
         ]
       end
 
@@ -277,12 +221,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -303,12 +247,12 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:scannable_location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:scannable_location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -329,7 +273,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Available',
-                effective_location: build(:green_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'GRE-STACKS').id)
         ]
       end
 
@@ -350,7 +294,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:page_lp_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-PAGE-LP').id)
         ]
       end
 
@@ -371,12 +315,13 @@ if Settings.ils.bib_model == 'Folio::Instance'
                 barcode: '12345678',
                 callnumber: 'ABC 123',
                 status: 'Page',
-                effective_location: build(:page_mp_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-PAGE-MP').id),
+
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 status: 'Page',
-                effective_location: build(:page_mp_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-PAGE-MP').id)
         ]
       end
 
@@ -396,28 +341,28 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '23456789',
                 callnumber: 'ABC 456',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '34567890',
                 callnumber: 'ABC 789',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '45678901',
                 callnumber: 'ABC 012',
-                effective_location: build(:location, code: 'SAL3-STACKS'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id,
                 public_note: 'note for 45678901'),
           build(:item,
                 barcode: '56789012',
                 callnumber: 'ABC 345',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '67890123',
                 callnumber: 'ABC 678',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -437,7 +382,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK')
         ]
       end
@@ -458,7 +403,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'ART-STACKS'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-STACKS').id,
                 type: 'STKS')
         ]
       end
@@ -479,55 +424,55 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '23456789',
                 callnumber: 'ABC 456',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 public_note: 'note for 23456789',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '34567890',
                 callnumber: 'ABC 789',
-                effective_location: build(:mediated_location, code: 'ART-NEWBOOK'),
-                permanent_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-MEDIUM-R').id,
+                permanent_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '45678901',
                 callnumber: 'ABC 012',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 public_note: 'note for 45678901',
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '56789012',
                 callnumber: 'ABC 345',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '67890123',
                 callnumber: 'ABC 678',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '78901234',
                 callnumber: 'ABC 901',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '89012345',
                 callnumber: 'ABC 234',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '90123456',
                 callnumber: 'ABC 567',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK'),
           build(:item,
                 barcode: '01234567',
                 callnumber: 'ABC 890',
-                effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
+                effective_location_id: Folio::Types.locations.find_by(code: 'ART-LOCKED-LARGE').id,
                 type: 'LCKSTK')
         ]
       end
@@ -548,44 +493,44 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '23456789',
                 callnumber: 'ABC 456',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '34567890',
                 callnumber: 'ABC 789',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '45678901',
                 callnumber: 'ABC 012',
-                effective_location: build(:spec_coll_location),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id,
                 public_note: 'note for 45678901'),
           build(:item,
                 barcode: '56789012',
                 callnumber: 'ABC 345',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '67890123',
                 callnumber: 'ABC 678',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '78901234',
                 callnumber: 'ABC 901',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '89012345',
                 callnumber: 'ABC 234',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '90123456',
                 callnumber: 'ABC 567',
-                effective_location: build(:spec_coll_location)),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id),
           build(:item,
                 barcode: '01234567',
                 callnumber: 'ABC 890',
-                effective_location: build(:spec_coll_location))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SPEC-STACKS').id)
         ]
       end
 
@@ -605,13 +550,13 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS')),
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id),
           build(:item,
                 barcode: '87654321',
                 callnumber: 'ABC 321',
                 due_date: '2015-01-01T12:59:00.000+00:00',
                 status: 'Checked out',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 
@@ -631,7 +576,7 @@ if Settings.ils.bib_model == 'Folio::Instance'
           build(:item,
                 barcode: '12345678',
                 callnumber: 'ABC 123',
-                effective_location: build(:location, code: 'SAL3-STACKS'))
+                effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
         ]
       end
 

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Library Instructions' do
   let(:selected_items) do
     [double(:item, callnumber: 'ABC 123', barcode: '12345678', checked_out?: true, processing?: false, missing?: false, hold?: false,
-                   on_order?: false, hold_recallable?: true, effective_location: build(:location),
+                   on_order?: false, hold_recallable?: true,
+                   effective_location: build(:location),
                    material_type: build(:book_material_type), loan_type: double(id: nil))]
   end
 

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Mark As Complete', js: true do
                     current_location: nil,
                     callnumber: 'ABC 123',
                     hold?: true,
-                    effective_location: build(:mediated_location),
+                    effective_location: Folio::Types.locations.find_by(code: 'ART-LOCKED-OVERSIZE'),
                     material_type: build(:book_material_type),
                     loan_type: double(id: nil))
     ]

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Mediation table', js: true do
 
       before do
         stub_bib_data_json(build(:searchable_holdings))
-        allow(Symphony::CatalogInfo).to receive(:find).and_return(double(:current_location, current_location: 'ART-NEWBOOK'))
+        allow(Symphony::CatalogInfo).to receive(:find).and_return(double(:current_location, current_location: 'ART-LOCKED-MEDIUM-R'))
         visit(admin_path('ART'))
       end
 
@@ -127,7 +127,7 @@ RSpec.describe 'Mediation table', js: true do
         end
 
         within('tbody td table') do
-          expect(page).to have_css('td', text: 'ART-NEWBOOK')
+          expect(page).to have_css('td', text: 'ART-LOCKED-MEDIUM-R')
         end
       end
     end

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Paging Schedule' do
       [
         double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                        barcode: '123123124', checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?',
-                       type: 'STKS', effective_location: build(:page_en_location),
+                       type: 'STKS', effective_location: Folio::Types.locations.find_by(code: 'SAL3-PAGE-EN'),
                        material_type: build(:book_material_type), loan_type: double(id: nil))
       ]
     end

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
     build(:item,
           barcode: '3610512345678',
           callnumber: 'ABC 123',
-          effective_location: build(:location, code: 'SAL3-STACKS'))
+          effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-STACKS').id)
   end
 
   before do
@@ -35,7 +35,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
         build(:item,
               barcode: '3610512345678',
               callnumber: 'ABC 123',
-              effective_location: build(:page_en_location))
+              effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-PAGE-EN').id)
       end
 
       it 'simplfies the display of the text of the destination library if there is only one possible' do
@@ -64,7 +64,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
         build(:item,
               barcode: '3610512345678',
               callnumber: 'ABC 123',
-              effective_location: build(:mmstacks_location),
+              effective_location_id: Folio::Types.locations.find_by(code: 'MEDIA-CAGE').id,
               material_type: build(:multimedia_material_type))
       end
 

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RequestsHelper do
         build(:item,
               barcode: '3610512345678',
               callnumber: 'ABC 123',
-              effective_location: build(:page_en_location))
+              effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-PAGE-EN').id)
       end
 
       let(:bib_data) { double(:bib_data, title: 'Test title', request_holdings: [item]) }

--- a/spec/models/folio/holdings_spec.rb
+++ b/spec/models/folio/holdings_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe Folio::Holdings do
                     type: 'multimedia',
                     callnumber: 'XX(14820051.1)',
                     public_note: nil,
-                    effective_location: instance_double(Folio::Location),
-                    permanent_location:)
+                    effective_location_id: Folio::Types.locations.find_by(code: 'SAL3-PAGE-EN').id,
+                    permanent_location_id:)
   end
 
   describe 'Enumerable' do
     subject { holdings.to_a }
 
     context "when the request location doesn't match the effectiveLocation" do
-      let(:permanent_location) { instance_double(Folio::Location, code: 'MUS-RECORDINGS') }
+      let(:permanent_location_id) { Folio::Types.locations.find_by(code: 'MUS-RECORDINGS').id }
 
       it { is_expected.to eq items }
     end

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -97,109 +97,14 @@ RSpec.describe Folio::Item do
   end
 
   describe '#status_class' do
-    let(:gre_stacks) do
-      <<~JSON
-        {
-          "id": "4573e824-9273-4f13-972f-cff7bf504217",
-          "campus": {
-            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-            "code": "SUL"
-          },
-          "library": {
-            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN"
-          },
-          "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-          "code": "GRE-STACKS",
-          "discoveryDisplayName": "Green Library Stacks",
-          "name": "Green Stacks",
-          "details": {}
-        }
-      JSON
-    end
-
-    let(:page_sp) do
-      <<~JSON
-          {
-          "id": "3cbd5559-5ca9-473e-8d7d-98a67bff29f5",
-          "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
-          "libraryId": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-          "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-          "code": "SAL3-PAGE-SP",
-          "discoveryDisplayName": "For use in Special Collections Reading Room",
-          "name": "SAL3 PAGE-SP",
-          "servicePoints": [
-            {
-              "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
-              "code": "SAL3",
-              "pickupLocation": false
-            }
-          ],
-          "library": {
-            "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
-          },
-          "campus": {
-            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-            "code": "SUL"
-          },
-          "details": {
-            "pageAeonSite": null,
-            "pageMediationGroupKey": null,
-            "pageServicePoints": [
-              {
-                "id": "0e924af7-785c-46eb-a5e2-060394822016",
-                "code": "SPEC",
-                "name": "Special Collections Desk"
-              }
-            ],
-            "scanServicePointCode": null,
-            "availabilityClass": "Offsite"
-          }
-        }
-      JSON
-    end
-
-    let(:sal3_stacks) do
-      <<~JSON
-        {
-          "id": "1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2",
-          "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
-          "libraryId": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-          "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-          "code": "SAL3-STACKS",
-          "discoveryDisplayName": "Stacks",
-          "name": "SAL3 Stacks",
-          "servicePoints": [
-            {
-              "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
-              "code": "SAL3",
-              "pickupLocation": false
-            }
-          ],
-          "library": {
-            "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
-          },
-          "campus": {
-            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-            "code": "SUL"
-          },
-          "details": {
-            "availabilityClass": "Offsite"
-          }
-        }
-      JSON
-    end
-
     context 'with a non-circulating item' do
       let(:data) do
         <<~JSON
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{gre_stacks},
-            "effectiveLocation": #{gre_stacks},
+            "permanentLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
             "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
             "notes": []
           }
@@ -217,8 +122,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{sal3_stacks},
-            "effectiveLocation": #{sal3_stacks},
+            "permanentLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-STACKS').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -236,8 +141,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{page_sp},
-            "effectiveLocation": #{page_sp},
+            "permanentLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-PAGE-SP').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-PAGE-SP').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -255,8 +160,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{gre_stacks},
-            "effectiveLocation": #{gre_stacks},
+            "permanentLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -274,8 +179,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Checked out" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{gre_stacks},
-            "effectiveLocation": #{gre_stacks},
+            "permanentLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -289,109 +194,14 @@ RSpec.describe Folio::Item do
   end
 
   describe '#status_text' do
-    let(:gre_stacks) do
-      <<~JSON
-        {
-          "id": "4573e824-9273-4f13-972f-cff7bf504217",
-          "campus": {
-            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-            "code": "SUL"
-          },
-          "library": {
-            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN"
-          },
-          "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-          "code": "GRE-STACKS",
-          "discoveryDisplayName": "Green Library Stacks",
-          "name": "Green Stacks",
-          "details": {}
-        }
-      JSON
-    end
-
-    let(:page_sp) do
-      <<~JSON
-          {
-          "id": "3cbd5559-5ca9-473e-8d7d-98a67bff29f5",
-          "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
-          "libraryId": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-          "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-          "code": "SAL3-PAGE-SP",
-          "discoveryDisplayName": "For use in Special Collections Reading Room",
-          "name": "SAL3 PAGE-SP",
-          "servicePoints": [
-            {
-              "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
-              "code": "SAL3",
-              "pickupLocation": false
-            }
-          ],
-          "library": {
-            "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
-          },
-          "campus": {
-            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-            "code": "SUL"
-          },
-          "details": {
-            "pageAeonSite": null,
-            "pageMediationGroupKey": null,
-            "pageServicePoints": [
-              {
-                "id": "0e924af7-785c-46eb-a5e2-060394822016",
-                "code": "SPEC",
-                "name": "Special Collections Desk"
-              }
-            ],
-            "scanServicePointCode": null,
-            "availabilityClass": "Offsite"
-          }
-        }
-      JSON
-    end
-
-    let(:sal3_stacks) do
-      <<~JSON
-        {
-          "id": "1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2",
-          "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
-          "libraryId": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-          "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-          "code": "SAL3-STACKS",
-          "discoveryDisplayName": "Stacks",
-          "name": "SAL3 Stacks",
-          "servicePoints": [
-            {
-              "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
-              "code": "SAL3",
-              "pickupLocation": false
-            }
-          ],
-          "library": {
-            "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
-          },
-          "campus": {
-            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-            "code": "SUL"
-          },
-          "details": {
-            "availabilityClass": "Offsite"
-          }
-        }
-      JSON
-    end
-
     context 'with a non-circulating item' do
       let(:data) do
         <<~JSON
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{gre_stacks},
-            "effectiveLocation": #{gre_stacks},
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
             "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
             "notes": []
           }
@@ -409,8 +219,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{sal3_stacks},
-            "effectiveLocation": #{sal3_stacks},
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-STACKS').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -428,8 +238,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{page_sp},
-            "effectiveLocation": #{page_sp},
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-PAGE-SP').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'SAL3-PAGE-SP').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -447,8 +257,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Available" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{gre_stacks},
-            "effectiveLocation": #{gre_stacks},
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }
@@ -466,8 +276,8 @@ RSpec.describe Folio::Item do
           {
             "status": { "name": "Checked out" },
             "materialType": { "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book" },
-            "permanentLocation": #{gre_stacks},
-            "effectiveLocation": #{gre_stacks},
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
+            "effectiveLocationId": "#{Folio::Types.locations.find_by(code: 'GRE-STACKS').id}",
             "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
             "notes": []
           }

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -695,8 +695,9 @@ RSpec.describe Request do
 
   describe '#default_pickup_destination' do
     it 'sets an origin specific default' do
+      effective_location_id = Folio::Types.locations.find_by(code: 'LAW-STACKS1').id
       request = described_class.new(origin: 'LAW', origin_location: 'STACKS',
-                                    bib_data: double(request_holdings: [build(:item, effective_location: build(:law_location))]))
+                                    bib_data: double(request_holdings: [build(:item, effective_location_id:)]))
 
       expect(request.default_pickup_destination).to eq 'LAW'
     end


### PR DESCRIPTION
This improved the performance of https://requests-folio-dev.stanford.edu/pages/new?item_id=L284&origin=LANE-MED&origin_location=LANE-SAL3 to 30s from a baseline of 35-42s (lots of variation).

Fixes #1676
