### PR TITLE
Place recalls in a way that worked

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,15 +35,7 @@ Metrics/BlockLength:
     - 'spec/factories/**/*'
 
 Metrics/ClassLength:
-  Max: 120
-  Exclude:
-    - 'app/models/request.rb'
-    - 'app/controllers/admin_controller.rb'
-    - 'app/controllers/requests_controller.rb'
-    - 'app/jobs/submit_symphony_request_job.rb'
-    - 'app/services/symphony_client.rb'
-    - 'app/services/folio_client.rb'
-    - 'app/services/folio_graphql_client.rb'
+  Enabled: false
 
 Metrics/MethodLength:
   Exclude:

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -34,7 +34,7 @@ module Folio
                         SPEC-SAL3-U-ARCHIVES
                         SPEC-SAL3-U-ARCHIVES).freeze
 
-    # Statuses that FOLIO treats as valid for intiating a hold/recall
+    # Statuses that FOLIO treats as valid for initiating a hold/recall
     # See: https://github.com/folio-org/mod-circulation/blob/master/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java#L71-L94
     HOLD_RECALL_STATUSES = [
       STATUS_CHECKED_OUT,

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -1,46 +1,6 @@
 # frozen_string_literal: true
 
 module Folio
-  # Other statuses that we aren't using include "Unavailable" and "Intellectual item"
-  STATUS_CHECKED_OUT = 'Checked out'
-  STATUS_ON_ORDER = 'On order'
-  STATUS_AVAILABLE = 'Available'
-  STATUS_HOLD = 'Awaiting pickup'
-  STATUS_MISSING = 'Missing'
-  STATUS_IN_PROCESS_NR = 'In process (non-requestable)'
-  STATUS_IN_PROCESS = 'In process'
-  STATUS_AWAITING_PICKUP = 'Awaiting pickup'
-  STATUS_AWAITING_DELIVERY = 'Awaiting delivery'
-  STATUS_IN_TRANSIT = 'In transit'
-  STATUS_PAGED = 'Paged'
-  STATUS_RESTRICTED = 'Restricted'
-  STATUS_NONE = ''
-
-  PAGE_LOCATIONS = %w(HILA-SAL3-STACKS
-                      HILA-SAL3-STACKS
-                      SPEC-SAL3-FELTON
-                      SPEC-SAL3-GUNST
-                      SPEC-SAL3-MEDIA
-                      SPEC-SAL3-MSS
-                      SPEC-SAL3-RBC
-                      SPEC-SAL3-U-ARCHIVES
-                      SPEC-SAL3-U-ARCHIVES).freeze
-
-  # Statuses that FOLIO treats as valid for intiating a hold/recall
-  # See: https://github.com/folio-org/mod-circulation/blob/master/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java#L71-L94
-  HOLD_RECALL_STATUSES = [
-    STATUS_CHECKED_OUT,
-    STATUS_AWAITING_PICKUP,
-    STATUS_AWAITING_DELIVERY,
-    STATUS_IN_TRANSIT,
-    STATUS_MISSING,
-    STATUS_PAGED,
-    STATUS_ON_ORDER,
-    STATUS_IN_PROCESS,
-    STATUS_RESTRICTED,
-    STATUS_NONE
-  ].freeze
-
   # Represents an item returned from the /inventory-hierarchy/items-and-holdings Folio API
   # TODO: This wants a "type" attribute, but I don't know how we get the folio version of a holding type.
   #       See https://github.com/sul-dlss/searchworks_traject_indexer/blob/02192452815de3861dcfafb289e1be8e575cb000/lib/traject/config/sirsi_config.rb#L2379
@@ -48,6 +8,51 @@ module Folio
   class Item
     attr_reader :barcode, :status, :type, :callnumber, :public_note, :effective_location, :permanent_location, :material_type,
                 :loan_type
+
+    # Other statuses that we aren't using include "Unavailable" and "Intellectual item"
+    STATUS_CHECKED_OUT = 'Checked out'
+    STATUS_ON_ORDER = 'On order'
+    STATUS_AVAILABLE = 'Available'
+    STATUS_HOLD = 'Awaiting pickup'
+    STATUS_MISSING = 'Missing'
+    STATUS_IN_PROCESS_NR = 'In process (non-requestable)'
+    STATUS_IN_PROCESS = 'In process'
+    STATUS_AWAITING_PICKUP = 'Awaiting pickup'
+    STATUS_AWAITING_DELIVERY = 'Awaiting delivery'
+    STATUS_IN_TRANSIT = 'In transit'
+    STATUS_PAGED = 'Paged'
+    STATUS_RESTRICTED = 'Restricted'
+    STATUS_NONE = ''
+
+    PAGE_LOCATIONS = %w(HILA-SAL3-STACKS
+                        HILA-SAL3-STACKS
+                        SPEC-SAL3-FELTON
+                        SPEC-SAL3-GUNST
+                        SPEC-SAL3-MEDIA
+                        SPEC-SAL3-MSS
+                        SPEC-SAL3-RBC
+                        SPEC-SAL3-U-ARCHIVES
+                        SPEC-SAL3-U-ARCHIVES).freeze
+
+    # Statuses that FOLIO treats as valid for intiating a hold/recall
+    # See: https://github.com/folio-org/mod-circulation/blob/master/src/main/java/org/folio/circulation/domain/RequestTypeItemStatusWhiteList.java#L71-L94
+    HOLD_RECALL_STATUSES = [
+      STATUS_CHECKED_OUT,
+      STATUS_AWAITING_PICKUP,
+      STATUS_AWAITING_DELIVERY,
+      STATUS_IN_TRANSIT,
+      STATUS_MISSING,
+      STATUS_PAGED,
+      STATUS_ON_ORDER,
+      STATUS_IN_PROCESS,
+      STATUS_RESTRICTED,
+      STATUS_NONE
+    ].freeze
+
+    PAGEABLE_STATUSES = [
+      STATUS_AVAILABLE,
+      STATUS_RESTRICTED
+    ].freeze
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(barcode:, status:, type:, callnumber:, public_note:,

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -35,6 +35,10 @@ module Folio
       user_info.fetch('id')
     end
 
+    def patron_group
+      user_info.fetch('patronGroup')
+    end
+
     # always nil for a real patron, but filled in for a PseudoPatron
     def patron_comments; end
 
@@ -45,7 +49,7 @@ module Folio
     end
 
     def fee_borrower?
-      user_info.fetch('patronGroup') == Settings.folio.fee_borrower_patron_group
+      patron_group == Settings.folio.fee_borrower_patron_group
     end
 
     def standing
@@ -98,6 +102,10 @@ module Folio
 
     def blocked?
       patron_blocks.fetch('automatedPatronBlocks').present?
+    end
+
+    def exists?
+      user_info.present?
     end
 
     private

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -123,7 +123,7 @@ borrow_direct:
 features:
   estimate_delivery: true
   hold_recall_service: true
-  hold_recall_via_reshare: true
+  hold_recall_via_reshare: false
   scan_service: true
   mediator_email: true
 
@@ -718,11 +718,9 @@ scannable:
 scan_destinations:
   EAST_ASIA:
     patron_barcode: 'EAL-SCANREVIEW'
-    folio_pseudopatron: 45873e99-3048-4246-b189-315df10717e5
 
   GREEN:
     patron_barcode: 'GRE-SCANDELIVER'
-    folio_pseudopatron: 0ba81714-52d4-4f37-8b4d-f9d929af048d
     material_types:
     - book
     - periodical

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe SubmitFolioRequestJob do
         allow(patron).to receive(:blocked?).and_return(true)
       end
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         described_class.perform_now(request.id)
         expect(client).to have_received(:create_circulation_request).with(have_attributes(
                                                                             requester_id: '562a5cb0-e998-4ea2-80aa-34ac2b536238'

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe SubmitFolioRequestJob do
         )
       end
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
         expect(client).to have_received(:create_circulation_request).with(have_attributes(
                                                                             requester_id: 'HOLD@AR-PSEUDO',

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe SubmitFolioRequestJob do
         allow(client).to receive(:proxy_info).with(proxy_id).and_return(proxy_response)
       end
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         described_class.perform_now(request.id)
         expect(client).to have_received(:create_circulation_request).with(have_attributes(patron_comments: /PROXY PICKUP OK/))
       end

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SubmitFolioRequestJob do
       let(:request) { create(:hold_recall_with_holdings_folio, barcodes: ['12345678'], user:) }
       let(:request_policies) { [{ 'id' => 'policy-id', 'requestTypes' => ['Hold', 'Page'] }] }
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
         expect(client).to have_received(:create_circulation_request).with(have_attributes(
                                                                             request_type: 'Hold'

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe SubmitFolioRequestJob do
         )
       end
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(2)
         # once for each barcode
         expect(client).to have_received(:create_circulation_request).twice

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe SubmitFolioRequestJob do
         allow(client).to receive(:proxy_info).with(sponsor_id).and_return(proxy_response)
       end
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         described_class.perform_now(request.id)
         expect(client).to have_received(:create_circulation_request).with(have_attributes(patron_comments: /PROXY PICKUP OK/))
       end

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SubmitFolioRequestJob do
     context 'with an sso user' do
       let(:request) { create(:hold_recall_with_holdings_folio, barcodes: ['12345678'], user:) }
 
-      it 'calls the create_item_hold API method' do
+      it 'calls the create_circulation_request API method' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
         expect(client).to have_received(:create_circulation_request).with(have_attributes(
                                                                             request_type: 'Recall'


### PR DESCRIPTION
FOLIO's mod_patron item hold endpoint doesn't place recall requests and also doesn't tolerate request policies that don't allow the `Hold` request type.. so we have to use `mod-circulation` directly to place requests with the appropriate types (with the caveat that we have to figure out what the right type is ourselves...)