### PR TITLE
In FOLIO, SAL3 is a scan_destination, it just doesn't have a patron b…

### DIFF
--- a/app/jobs/submit_scan_request_job.rb
+++ b/app/jobs/submit_scan_request_job.rb
@@ -16,6 +16,6 @@ class SubmitScanRequestJob < ApplicationJob
     # This ensures that only scan rules with a destination get sent to the ILS.
     # We no longer want to send SAL3 requests to the ILS as this is handled by the ILLiad integration.
     # SAL1/2 requests still go to the ILS at this time.
-    scan.send_to_ils_later! if scan.scan_destination.present?
+    scan.send_to_ils_later! if scan.scan_destination&.dig(:patron_barcode).present?
   end
 end

--- a/spec/jobs/submit_scan_request_job_spec.rb
+++ b/spec/jobs/submit_scan_request_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SubmitScanRequestJob, type: :job do
       end
     end
 
-    context 'when the scan_destination is not present' do
+    context 'when the scan_destination does not have a barcode' do
       let(:scan) { create(:scan, :without_validations, origin: 'SAL3') }
 
       # SAL3 scans should not be sent to the ILS


### PR DESCRIPTION
…arcode associated with it.

Fixes https://github.com/sul-dlss/sul-requests/issues/1769