### PR TITLE
handling service points without associated library or location

### DIFF
--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -39,11 +39,7 @@ module Folio
 
     def library_id
       # Not every service point, e.g .RWC, has an associated location or library
-      location = Folio::Types.locations.find_by(primary_service_point_id: id)
-
-      return if location.nil?
-
-      @library_id ||= location.library_id
+      @library_id ||= Folio::Types.locations.find_by(primary_service_point_id: id)&.library_id
     end
   end
 end

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -26,6 +26,8 @@ module Folio
     end
 
     def library
+      return if library_id.nil?
+
       @library ||= Folio::Types.libraries.find_by(id: library_id)
     end
 
@@ -36,7 +38,12 @@ module Folio
     private
 
     def library_id
-      @library_id ||= Folio::Types.locations.find_by(primary_service_point_id: id).library_id
+      # Not every service point, e.g .RWC, has an associated location or library
+      location = Folio::Types.locations.find_by(primary_service_point_id: id)
+
+      return if location.nil?
+
+      @library_id ||= location.library_id
     end
   end
 end


### PR DESCRIPTION
Relates to https://github.com/sul-dlss/sul-requests/issues/1770 . 

For a service point like RWC, which has no associated library or location, the service point code which looks up library was running into an error because it was trying to get library_id on the location and the location returned was nil. This update ensures we don't run into this error. 