### PR TITLE
Refactor requestability to delegate to the item

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -17,6 +17,10 @@ class RequestsController < ApplicationController
 
   helper_method :current_request, :delegated_request?
 
+  class_attribute :bib_model_class, default: Settings.ils.bib_model.constantize
+
+  rescue_from bib_model_class::NotFound, with: :item_not_found
+
   def new
     current_request.assign_attributes(new_params)
     validate_request_type
@@ -183,5 +187,10 @@ class RequestsController < ApplicationController
   end
 
   class HoneyPotFieldError < StandardError
+  end
+
+  # Re-raise as ActiveRecord::RecordNotFound so we get a 404 in production
+  def item_not_found(exception)
+    raise ActiveRecord::RecordNotFound, exception
   end
 end

--- a/app/jobs/submit_folio_request_job.rb
+++ b/app/jobs/submit_folio_request_job.rb
@@ -85,14 +85,14 @@ class SubmitFolioRequestJob < ApplicationJob
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def create_item_circulation_request(barcode)
       item = folio_client.get_item(barcode)
-      create_log(barcode:, item_id: item['id'])
+      create_log(barcode:, item_id: item.id)
 
       request_data = FolioClient::CirculationRequest.new(
         request_level: 'Item',
         request_type: item.best_request_type,
         instance_id: request.bib_data.instance_id,
-        item_id: item['id'],
-        holdings_record_id: item['holdingsRecordId'],
+        item_id: item.id,
+        holdings_record_id: item.holdings_record_id,
         requester_id: patron_or_proxy_id,
         fulfillment_preference: 'Hold Shelf',
         pickup_service_point_id: pickup_location_id,

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -3,14 +3,16 @@
 module Folio
   # Bibliographic data from Folio.
   class Instance
+    class NotFound < StandardError; end
+
     # rubocop:disable Style/OptionalBooleanParameter
     def self.fetch(request, _live_lookup = true)
       # Append "a" to the item_id unless it already starts with a letter (e.g. "in00000063826")
       hrid = request.item_id.start_with?(/\d/) ? "a#{request.item_id}" : request.item_id
-
       data = FolioClient.new.find_instance_by(hrid:)
+      raise NotFound, "Instance hrid '#{hrid}' not found" unless data
 
-      Folio::Instance.from_dynamic(data) if data
+      Folio::Instance.from_dynamic(data)
     end
     # rubocop:enable Style/OptionalBooleanParameter
 

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -101,10 +101,12 @@ module Folio
       [availability_class, circ_class].compact.join(' ')
     end
 
-    def status_text
-      if !circulates?
-        'In-library use only'
-      elsif status == STATUS_AVAILABLE
+    def status_text(request)
+      if !requestable && temporary_location.present?
+        temporary_location.discovery_display_name
+      elsif !circulates?
+        'In-library use'
+      elsif status == STATUS_AVAILABLE && requestable_with?(request)
         'Available'
       else
         'Unavailable'
@@ -151,7 +153,7 @@ module Folio
                                end) || (Location.from_hash(dyn.dig('holdingsRecord', 'effectiveLocation')) if dyn.dig('holdingsRecord',
                                                                                                                       'effectiveLocation')),
           material_type: MaterialType.new(id: dyn.dig('materialType', 'id'), name: dyn.dig('materialType', 'name')),
-          loan_type: LoanType.new(id: dyn.fetch('tempooraryLoanTypeId', dyn.fetch('permanentLoanTypeId'))))
+          loan_type: LoanType.new(id: dyn.fetch('temporaryLoanTypeId', dyn.fetch('permanentLoanTypeId'))))
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -6,8 +6,8 @@ module Folio
   #       See https://github.com/sul-dlss/searchworks_traject_indexer/blob/02192452815de3861dcfafb289e1be8e575cb000/lib/traject/config/sirsi_config.rb#L2379
   # NOTE, barcode and callnumber may be nil. see instance_hrid: 'in00000063826'
   class Item
-    attr_reader :barcode, :status, :type, :callnumber, :public_note, :effective_location, :permanent_location, :material_type,
-                :loan_type
+    attr_reader :barcode, :status, :type, :callnumber, :public_note, :effective_location, :permanent_location, :temporary_location,
+                :material_type, :loan_type
 
     # Other statuses that we aren't using include "Unavailable" and "Intellectual item"
     STATUS_CHECKED_OUT = 'Checked out'
@@ -56,7 +56,7 @@ module Folio
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(barcode:, status:, callnumber:,
-                   effective_location:, permanent_location: nil,
+                   effective_location:, permanent_location: nil, temporary_location: nil,
                    type: nil, public_note: nil, material_type: nil, loan_type: nil,
                    due_date: nil)
       @barcode = barcode
@@ -66,6 +66,7 @@ module Folio
       @public_note = public_note
       @effective_location = effective_location
       @permanent_location = permanent_location || effective_location
+      @temporary_location = temporary_location
       @material_type = material_type
       @loan_type = loan_type
       @due_date = due_date
@@ -153,7 +154,7 @@ module Folio
       'Page' if pageable?
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
     def self.from_hash(dyn)
       new(barcode: dyn['barcode'],
           status: dyn.dig('status', 'name'),
@@ -168,10 +169,11 @@ module Folio
                                  Location.from_hash(dyn.fetch('permanentLocation'))
                                end) || (Location.from_hash(dyn.dig('holdingsRecord', 'effectiveLocation')) if dyn.dig('holdingsRecord',
                                                                                                                       'effectiveLocation')),
+          temporary_location: (Location.from_hash(dyn.fetch('temporaryLocation')) if dyn['temporaryLocation']),
           material_type: MaterialType.new(id: dyn.dig('materialType', 'id'), name: dyn.dig('materialType', 'name')),
           loan_type: LoanType.new(id: dyn.fetch('temporaryLoanTypeId', dyn.fetch('permanentLoanTypeId'))))
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     private
 

--- a/app/models/folio/request_abilities.rb
+++ b/app/models/folio/request_abilities.rb
@@ -53,7 +53,7 @@ module Folio
     end
 
     def pageable?
-      !mediateable? && !hold_recallable? && any_items_pageable?
+      !mediateable? && !hold_recallable? && any_items_requestable?
     end
 
     # FOLIO
@@ -107,6 +107,12 @@ module Folio
       return false if request.holdings.none?
 
       request.holdings.any?(&:pageable?)
+    end
+
+    def any_items_requestable?
+      return false if request.holdings.none?
+
+      request.holdings.any?(&:requestable?)
     end
 
     def all_items_scannable?

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -138,8 +138,10 @@ class FolioClient
 
   def get_item(barcode)
     response = get_json('/item-storage/items', params: { query: CqlQuery.new(barcode:).to_query })
+    item = response.dig('items', 0)
+    raise "Item not found for barcode #{barcode}" if item.blank?
 
-    response.dig('items', 0)
+    Folio::Item.from_hash(item)
   end
 
   def get_service_point(code)

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -163,6 +163,11 @@ class FolioGraphqlClient
                     scanServicePointCode
                   }
                 }
+                temporaryLocation {
+                  id
+                  code
+                  discoveryDisplayName
+                }
                 permanentLoanTypeId
                 temporaryLoanTypeId
                 holdingsRecord {

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe RequestsController do
     { item_id: '12345', barcode: '3610512345', origin: 'GREEN', origin_location: 'STACKS' }
   end
 
+  before do
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
+  end
+
   describe '#new' do
     describe 'required parameters' do
       it 'item id, library, and location' do
@@ -40,6 +44,18 @@ RSpec.describe RequestsController do
         expect(assigns[:request].origin_location).to eq 'STACKS'
         expect(assigns[:request].item_id).to eq '12345'
         expect(assigns[:request].requested_barcode).to eq '3610512345'
+      end
+    end
+
+    describe 'nonexistent item' do
+      before do
+        allow(Folio::Instance).to receive(:fetch).and_call_original
+      end
+
+      it 'raises an error' do
+        expect do
+          get(:new, params: { item_id: 'does_not_exist', origin: 'GREEN', origin_location: 'STACKS' })
+        end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -199,12 +199,12 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:spec_coll_location)),
         build(:item,
               barcode: '87654321',
               callnumber: 'ABC 321',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:spec_coll_location))
       ]
     end
@@ -228,7 +228,7 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:spec_coll_location))
       ]
     end
@@ -253,7 +253,7 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:spec_coll_location))
       ]
     end
@@ -274,12 +274,12 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:location, code: 'SAL3-STACKS')),
         build(:item,
               barcode: '87654321',
               callnumber: 'ABC 321',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
@@ -300,12 +300,12 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:scannable_location, code: 'SAL3-STACKS')),
         build(:item,
               barcode: '87654321',
               callnumber: 'ABC 321',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:scannable_location, code: 'SAL3-STACKS'))
       ]
     end
@@ -347,7 +347,7 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:page_lp_location))
       ]
     end
@@ -368,12 +368,12 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:page_mp_location)),
         build(:item,
               barcode: '87654321',
               callnumber: 'ABC 321',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:page_mp_location))
       ]
     end
@@ -666,12 +666,12 @@ FactoryBot.define do
         build(:item,
               barcode: '12345678',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:location, code: 'SAL3-STACKS')),
         build(:item,
               barcode: '12345679',
               callnumber: 'ABC 123',
-              status: 'Page',
+              status: 'Available',
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end

--- a/spec/factories/scans.rb
+++ b/spec/factories/scans.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     trait :with_holdings_barcodes do
       with_holdings
       after(:build) do |scan|
-        scan.barcodes = [scan.holdings.first.barcode, scan.holdings.to_a.last.barcode]
+        scan.barcodes = [scan.holdings.first.barcode, scan.holdings.to_a.last.barcode].uniq
       end
     end
   end

--- a/spec/features/admin_comment_spec.rb
+++ b/spec/features/admin_comment_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Admin Comments', js: true do
   end
 
   before do
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
     stub_current_user(user)
     create(
       :mediated_page_with_holdings,

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Library Instructions' do
   let(:selected_items) do
     [double(:item, callnumber: 'ABC 123', barcode: '12345678', checked_out?: true, processing?: false, missing?: false, hold?: false,
-                   on_order?: false, hold_recallable?: true,
+                   on_order?: false, hold_recallable?: true, aeon_pageable?: false, mediateable?: false,
                    effective_location: build(:location), permanent_location: build(:location),
                    material_type: build(:book_material_type), loan_type: double(id: nil))]
   end

--- a/spec/features/mark_as_complete_spec.rb
+++ b/spec/features/mark_as_complete_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'Mark As Complete', js: true do
                     current_location: nil,
                     callnumber: 'ABC 123',
                     hold?: true,
+                    pageable?: true,
+                    mediateable?: true,
                     effective_location: build(:mediated_location),
                     permanent_location: build(:mediated_location),
                     material_type: build(:book_material_type),

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Paging Schedule' do
     [
       double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                      pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
-                     status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location),
+                     status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
                      permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil)),
       double('item', callnumber: 'ABC 321', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                      pageable?: true, mediateable?: false, barcode: '9928812', checked_out?: false, status_class: 'active',
-                     status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location),
+                     status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
                      permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil))
     ]
   end
@@ -83,7 +83,8 @@ RSpec.describe 'Paging Schedule' do
         double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                        pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
                        status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:page_en_location),
-                       permanent_location: build(:page_en_location), material_type: build(:book_material_type), loan_type: double(id: nil))
+                       requestable?: true, permanent_location: build(:page_en_location), material_type: build(:book_material_type),
+                       loan_type: double(id: nil))
       ]
     end
 

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe 'Paging Schedule' do
   let(:all_items) do
     [
       double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
-                     barcode: '123123124', checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?',
-                     type: 'STKS', effective_location: build(:location), permanent_location: build(:location),
-                     material_type: build(:book_material_type), loan_type: double(id: nil)),
+                     pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
+                     status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location),
+                     permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil)),
       double('item', callnumber: 'ABC 321', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
-                     barcode: '9928812', checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?',
-                     type: 'STKS', effective_location: build(:location), permanent_location: build(:location),
-                     material_type: build(:book_material_type), loan_type: double(id: nil))
+                     pageable?: true, mediateable?: false, barcode: '9928812', checked_out?: false, status_class: 'active',
+                     status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location),
+                     permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil))
     ]
   end
 
@@ -81,9 +81,9 @@ RSpec.describe 'Paging Schedule' do
     let(:all_items) do
       [
         double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
-                       barcode: '123123124', checked_out?: false, status_class: 'active', status_text: 'Active', public_note: 'huh?',
-                       type: 'STKS', effective_location: build(:page_en_location), permanent_location: build(:page_en_location),
-                       material_type: build(:book_material_type), loan_type: double(id: nil))
+                       pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
+                       status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:page_en_location),
+                       permanent_location: build(:page_en_location), material_type: build(:book_material_type), loan_type: double(id: nil))
       ]
     end
 

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe 'Send Request Buttons' do
   let(:selected_items) do
     [
       double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,
-                    hold_recallable?: false, barcode: '12345678', type: 'STKS',
+                    pageable?: true, mediateable?: mediateable, hold_recallable?: false, barcode: '12345678', type: 'STKS',
                     effective_location: build(:location), permanent_location: build(:location),
                     material_type: build(:book_material_type), loan_type: double(id: nil))
     ]
   end
+  let(:mediateable) { false }
 
   let(:instance) do
     instance_double(Folio::Instance, title: 'Test title', request_holdings: selected_items, items: [])
@@ -114,6 +115,8 @@ RSpec.describe 'Send Request Buttons' do
   end
 
   describe 'Mediated Pages' do
+    let(:mediateable) { true }
+
     before do
       stub_bib_data_json(build(:single_mediated_holding))
     end

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Send Request Buttons' do
     [
       double(:item, callnumber: 'ABC 123', checked_out?: false, processing?: false, missing?: false, hold?: false, on_order?: false,
                     pageable?: true, mediateable?: mediateable, hold_recallable?: false, barcode: '12345678', type: 'STKS',
-                    effective_location: build(:location), permanent_location: build(:location),
+                    effective_location: build(:location), permanent_location: build(:location), requestable?: true,
                     material_type: build(:book_material_type), loan_type: double(id: nil))
     ]
   end

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -3,192 +3,209 @@
 require 'rails_helper'
 
 RSpec.describe SubmitFolioRequestJob do
+  let(:client) { instance_double(FolioClient, create_circulation_request: double) }
+  let(:patron) { Folio::Patron.new({ 'id' => patron_id, 'patronGroup' => patron_group_id, 'active' => true }) }
+  let(:patron_id) { '562a5cb0-e998-4ea2-80aa-34ac2b536238' }
+  let(:patron_group_id) { 'bdc2b6d4-5ceb-4a12-ab46-249b9a68473e' } # Undergrad
+
   before do
     skip "Must set Settings.ils.request_job=#{described_class}" unless Settings.ils.request_job == described_class.to_s
     allow(Request).to receive(:find).and_return(request)
     allow(FolioClient).to receive(:new).and_return(client)
   end
 
-  let(:client) do
-    instance_double(FolioClient, get_item: item, create_circulation_request: double, circulation_request_policy:,
-                                 request_policies:)
-  end
-  let(:item) do
-    { 'id' => 4, 'status' => { 'name' => status } }
-  end
-  let(:status) { 'Available' }
-  let(:expected_date) { DateTime.now.beginning_of_day.utc.iso8601 }
-  let(:patron_group_id) { 'bdc2b6d4-5ceb-4a12-ab46-249b9a68473e' } # Undergrad
-  let(:circulation_request_policy) { 'policy-id' }
-  let(:request_policies) { [{ 'id' => 'policy-id', 'requestTypes' => ['Hold', 'Page', 'Recall'] }] }
-
   context 'with a HoldRecall type request' do
+    let(:best_request_type) { 'Recall' }
     let(:user) { create(:sequence_sso_user) }
-    let(:patron) { Folio::Patron.new({ 'id' => '562a5cb0-e998-4ea2-80aa-34ac2b536238', 'patronGroup' => patron_group_id }) }
-    let(:status) { 'Checked out' }
+    let(:item) do
+      instance_double(Folio::Item, id: 'abc123-1-1', holdings_record_id: 'abc123-1', barcode: '12345678',
+                                   status: 'Checked out', best_request_type:)
+    end
 
     before do
       allow(request.user).to receive(:patron).and_return(patron)
       allow(patron).to receive(:blocked?).and_return(false)
+      allow(client).to receive(:get_item).with('12345678').and_return(item)
     end
 
     context 'with an sso user' do
       let(:request) { create(:hold_recall_with_holdings_folio, barcodes: ['12345678'], user:) }
 
-      it 'calls the create_circulation_request API method' do
+      it 'places a recall for the item as the patron' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            request_type: 'Recall'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Recall',
+            requester_id: patron_id,
+            item_id: 'abc123-1-1'
+          )
+        )
       end
     end
 
     context 'with a user without the recall ability' do
       let(:request) { create(:hold_recall_with_holdings_folio, barcodes: ['12345678'], user:) }
-      let(:request_policies) { [{ 'id' => 'policy-id', 'requestTypes' => ['Hold', 'Page'] }] }
+      let(:best_request_type) { 'Hold' }
 
-      it 'calls the create_circulation_request API method' do
+      it 'places a hold for the item as the patron' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            request_type: 'Hold'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Hold',
+            requester_id: patron_id,
+            item_id: 'abc123-1-1'
+          )
+        )
       end
     end
 
     context 'without barcode (title request)' do
+      let(:request) { create(:hold_on_order, barcodes: [], user:) }
+
       before do
         allow(client).to receive(:create_instance_hold)
       end
 
-      let(:request) { create(:hold_on_order, barcodes: [], user:) }
-
-      it 'calls the create_instance_hold API method' do
+      it 'places a title-level hold for the instance as the patron' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_instance_hold).with('562a5cb0-e998-4ea2-80aa-34ac2b536238',
-                                                                    'a43e597a-d4b4-50ec-ad16-7fd49920831a', FolioClient::HoldRequest)
+        expect(client).to have_received(:create_instance_hold)
+          .with(patron_id, 'a43e597a-d4b4-50ec-ad16-7fd49920831a', FolioClient::HoldRequest)
       end
     end
 
     context 'with an sso user with no patron group' do
+      let(:best_request_type) { 'Hold' }
       let(:user) { create(:sso_user) }
       let(:request) { create(:hold_recall_with_holdings_folio, barcodes: ['12345678'], user:) }
       let(:patron_group_id) { nil }
+      let(:pseudopatron) { instance_double(Folio::Patron, id: 'HOLD@GR-PSEUDO', patron_group_id:, blocked?: false) }
 
       before do
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@GR').and_return(
-          instance_double(Folio::Patron, id: 'HOLD@GR-PSEUDO', patron_group_id:, blocked?: false)
-        )
+        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@GR').and_return(pseudopatron)
       end
 
-      it 'places a hold as the pseudopatron' do
+      it 'places a hold for the item as a pseudopatron with patron comment' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: 'HOLD@GR-PSEUDO',
-                                                                            item_id: 4,
-                                                                            patron_comments: 'Some SSO User <some-sso-user@stanford.edu>'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Hold',
+            requester_id: 'HOLD@GR-PSEUDO',
+            item_id: 'abc123-1-1',
+            patron_comments: 'Some SSO User <some-sso-user@stanford.edu>'
+          )
+        )
       end
     end
   end
 
   context 'with a Page type request' do
+    let(:best_request_type) { 'Page' }
+    let(:user) { create(:sequence_sso_user) }
+    let(:item) do
+      instance_double(Folio::Item, id: 'abc123-1-1', holdings_record_id: 'abc123-1', barcode: '3610512345678',
+                                   status: 'Available', best_request_type:)
+    end
     let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user:) }
 
-    context 'with an sso user in good standing' do
-      let(:user) { create(:sequence_sso_user) }
-      let(:patron) do
-        Folio::Patron.new({ 'id' => '562a5cb0-e998-4ea2-80aa-34ac2b536238', 'active' => true, 'patronGroup' => patron_group_id })
-      end
+    before do
+      allow(request.user).to receive(:patron).and_return(patron)
+      allow(client).to receive(:get_item).with('3610512345678').and_return(item)
+    end
 
+    context 'with an sso user in good standing' do
       before do
-        allow(request.user).to receive(:patron).and_return(patron)
         allow(patron).to receive(:blocked?).and_return(false)
       end
 
-      it 'calls the create_circulation_request API method as the patron' do
+      it 'places a page request for the item as the patron' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: '562a5cb0-e998-4ea2-80aa-34ac2b536238'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: patron_id,
+            item_id: 'abc123-1-1'
+          )
+        )
       end
     end
 
     context 'with an sso user who has blocks' do
-      let(:user) { create(:sequence_sso_user) }
-      let(:patron) do
-        Folio::Patron.new({ 'id' => '562a5cb0-e998-4ea2-80aa-34ac2b536238', 'active' => true, 'patronGroup' => patron_group_id })
-      end
-
       before do
-        allow(request.user).to receive(:patron).and_return(patron)
         allow(patron).to receive(:blocked?).and_return(true)
       end
 
-      it 'calls the create_circulation_request API method as the patron' do
+      it 'places a page request for the item as the patron' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: '562a5cb0-e998-4ea2-80aa-34ac2b536238'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: patron_id,
+            item_id: 'abc123-1-1'
+          )
+        )
         expect(request.ils_response.usererr_code).to eq 'u003'
       end
     end
 
     context 'with a non-sso user' do
       let(:user) { create(:non_sso_user) }
+      let(:patron) { nil }
 
       before do
-        allow(request.user).to receive(:patron).and_return(nil)
         allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
 
-      it 'calls the create_circulation_request API method using a pseudopatron' do
+      it 'places a page request for the item using a pseudopatron with patron comments' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: 'HOLD@AR-PSEUDO',
-                                                                            item_id: 4,
-                                                                            patron_comments: 'Jane Stanford <jstanford@stanford.edu>'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: 'HOLD@AR-PSEUDO',
+            item_id: 'abc123-1-1',
+            patron_comments: 'Jane Stanford <jstanford@stanford.edu>'
+          )
+        )
       end
     end
 
     context 'with an sso user with no patron group' do
       let(:user) { create(:sso_user) }
-      let(:patron) do
-        Folio::Patron.new({ 'id' => '562a5cb0-e998-4ea2-80aa-34ac2b536238', 'patronGroup' => nil })
-      end
+      let(:patron_group_id) { nil }
 
       before do
-        allow(request.user).to receive(:patron).and_return(patron)
         allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
 
-      it 'calls the create_circulation_request API method as the pseudopatron' do
+      it 'places a page request for the item using a pseudopatron with patron comments' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: 'HOLD@AR-PSEUDO',
-                                                                            item_id: 4,
-                                                                            patron_comments: 'Some SSO User <some-sso-user@stanford.edu>'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: 'HOLD@AR-PSEUDO',
+            item_id: 'abc123-1-1',
+            patron_comments: 'Some SSO User <some-sso-user@stanford.edu>'
+          )
+        )
       end
     end
 
     context 'with a mix of failing and successful request items' do
-      let(:user) { create(:sequence_sso_user) }
       let(:request) { create(:page_with_single_holding_multiple_items, barcodes: ['12345678', '12345679'], user:) }
       let(:command) { described_class::Command.new(request, logger: Rails.logger) }
-      let(:patron) do
-        Folio::Patron.new({ 'id' => '562a5cb0-e998-4ea2-80aa-34ac2b536238', 'active' => true, 'patronGroup' => patron_group_id })
+      let(:item) do
+        instance_double(Folio::Item, id: 'abc123-1-2', holdings_record_id: 'abc123-1', barcode: '12345679',
+                                     status: 'Available', best_request_type:)
       end
 
       before do
-        allow(request.user).to receive(:patron).and_return(patron)
         allow(patron).to receive(:blocked?).and_return(false)
         # Force one barcode to throw an error
         allow(client).to receive(:get_item).with('12345678').and_return(nil)
+        allow(client).to receive(:get_item).with('12345679').and_return(item)
       end
 
       it 'receives only one circulation request if the other results in error' do
@@ -205,127 +222,155 @@ RSpec.describe SubmitFolioRequestJob do
   end
 
   context 'with a MediatedPage type request' do
+    let(:best_request_type) { 'Page' }
     let(:request) do
       create(
         :mediated_page_with_holdings,
         user:,
-        barcodes: %w(34567890),
+        barcodes: ['34567890'],
         created_at: 1.day.from_now,
         needed_date: Time.zone.now
       )
     end
+    let(:item) do
+      instance_double(Folio::Item, id: 'abc123-1-1', holdings_record_id: 'abc123-1', barcode: '34567890', status: 'Available',
+                                   best_request_type:)
+    end
+
+    before do
+      allow(request.user).to receive(:patron).and_return(patron)
+      allow(client).to receive(:get_item).with('34567890').and_return(item)
+    end
 
     context 'with a non-sso user' do
       let(:user) { create(:non_sso_user, name: 'Jim Doe', email: 'jimdoe@example.com') }
+      let(:patron) { nil }
 
       before do
-        allow(request.user).to receive(:patron).and_return(nil)
         allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
 
-      it 'calls the create_circulation_request API method as the pseudopatron' do
+      it 'places a page request for the item as a pseudopatron with patron comments' do
         expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(1)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: 'HOLD@AR-PSEUDO',
-                                                                            patron_comments: 'Jim Doe <jimdoe@example.com>'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: 'HOLD@AR-PSEUDO',
+            item_id: 'abc123-1-1',
+            patron_comments: 'Jim Doe <jimdoe@example.com>'
+          )
+        )
       end
     end
 
     context 'with an sso user with no patron group' do
       let(:user) { create(:sso_user) }
-      let(:patron) do
-        Folio::Patron.new({ 'id' => '562a5cb0-e998-4ea2-80aa-34ac2b536238', 'patronGroup' => nil })
-      end
+      let(:patron_group_id) { nil }
 
       before do
-        allow(request.user).to receive(:patron).and_return(patron)
+        allow(patron).to receive(:blocked?).and_return(false)
         allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
 
-      it 'calls the create_circulation_request API method as the pseudopatron' do
+      it 'places a page request for the item as a pseudopatron with patron comments' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(
-                                                                            requester_id: 'HOLD@AR-PSEUDO',
-                                                                            item_id: 4,
-                                                                            patron_comments: 'Some SSO User <some-sso-user@stanford.edu>'
-                                                                          ))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: 'HOLD@AR-PSEUDO',
+            item_id: 'abc123-1-1',
+            patron_comments: 'Some SSO User <some-sso-user@stanford.edu>'
+          )
+        )
       end
     end
   end
 
   context 'with a Scan type request' do
     context 'with a non-sso user' do
+      let(:best_request_type) { 'Hold' }
+      let(:user) { create(:non_sso_user, name: 'Jim Doe', email: 'jimdoe@example.com') }
+      let(:patron) { nil }
       let(:request) do
-        create(:scan, :with_holdings_barcodes, origin: 'SAL', origin_location: 'SAL-TEMP', bib_data: build(:scannable_only_holdings),
-                                               user: create(:sso_user))
+        create(:scan, :with_holdings_barcodes, origin: 'SAL', origin_location: 'SAL-TEMP', bib_data: build(:scannable_only_holdings), user:)
+      end
+      let(:item) do
+        instance_double(Folio::Item, id: 'abc123-1-1', holdings_record_id: 'abc123-1', barcode: '12345678', status: 'Available',
+                                     best_request_type:)
       end
 
       before do
-        allow(Folio::Patron).to receive(:find_by).and_return(nil)
         allow(Folio::Patron).to receive(:find_by).with(library_id: 'GRE-SCANDELIVER').and_return(
           instance_double(Folio::Patron, id: 'GRE-SCANDELIVER', patron_group_id:, blocked?: false)
         )
+        allow(client).to receive(:get_item).with('12345678').and_return(item)
       end
 
-      it 'calls the create_circulation_request API method' do
-        expect { described_class.perform_now(request.id) }.to change { request.folio_command_logs.count }.by(2)
-        # once for each barcode
-        expect(client).to have_received(:create_circulation_request).twice
+      it 'places a hold request for the item as a pseudopatron with patron comments' do
+        described_class.perform_now(request.id)
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Hold',
+            requester_id: 'GRE-SCANDELIVER',
+            item_id: 'abc123-1-1',
+            patron_comments: 'Jim Doe <jimdoe@example.com>'
+          )
+        )
       end
     end
   end
 
-  context 'with a proxy request' do
+  context 'with a proxy request (Page)' do
+    let(:best_request_type) { 'Page' }
+    let(:user) { create(:sequence_sso_user) }
     let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user:, proxy: true) }
+    let(:proxy_id) { '562a5cb0-e998-4ea2-80aa-34ac2b536238' }
+    let(:sponsor_id) { '2bd36e69-1f58-4f6b-9073-e8d932edeed2' }
+    let(:item) do
+      instance_double(Folio::Item, id: 'abc123-1-1', holdings_record_id: 'abc123-1', barcode: '3610512345678', status: 'Available',
+                                   best_request_type:)
+    end
 
-    context 'with a proxy user' do
-      let(:user) { create(:sequence_sso_user) }
-      let(:proxy_id) { '562a5cb0-e998-4ea2-80aa-34ac2b536238' }
-      let(:sponsor_id) { '2bd36e69-1f58-4f6b-9073-e8d932edeed2' }
+    before do
+      allow(Folio::Patron).to receive(:find_by).and_return(patron)
+      allow(client).to receive(:proxy_info).and_return(proxy_response)
+      allow(client).to receive(:get_item).with('3610512345678').and_return(item)
+      allow(patron).to receive(:blocked?).and_return(false)
+    end
+
+    context 'as the proxy user' do
       let(:patron) { Folio::Patron.new({ 'id' => proxy_id, 'active' => true, 'patronGroup' => patron_group_id }) }
+      let(:proxy_response) { { 'userId' => sponsor_id } }
 
-      let(:proxy_response) do
-        {
-          'userId' => sponsor_id
-        }
-      end
-
-      before do
-        allow_any_instance_of(Request).to receive(:user).and_return(user)
-        allow(user).to receive(:patron).and_return(patron)
-        allow(patron).to receive(:blocked?).and_return(false)
-        allow(client).to receive(:proxy_info).with(proxy_id).and_return(proxy_response)
-      end
-
-      it 'calls the create_circulation_request API method' do
+      it 'places a page request as the sponsor user with a proxy pickup comment' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(patron_comments: /PROXY PICKUP OK/))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: sponsor_id,
+            patron_comments: /PROXY PICKUP OK/
+          )
+        )
       end
     end
 
-    context 'with the sponsor' do
-      let(:user) { create(:sequence_sso_user) }
-      let(:sponsor_id) { '2bd36e69-1f58-4f6b-9073-e8d932edeed2' }
+    context 'as the sponsor' do
       let(:patron) { Folio::Patron.new({ 'id' => sponsor_id, 'active' => true, 'patronGroup' => patron_group_id }) }
-      let(:proxy_response) do
-        {}
-      end
+      let(:proxy_response) { {} }
 
-      before do
-        allow_any_instance_of(Request).to receive(:user).and_return(user)
-        allow(user).to receive(:patron).and_return(patron)
-        allow(patron).to receive(:blocked?).and_return(false)
-        allow(client).to receive(:proxy_info).with(sponsor_id).and_return(proxy_response)
-      end
-
-      it 'calls the create_circulation_request API method' do
+      it 'places a page request as the sponsor user with a proxy pickup comment' do
         described_class.perform_now(request.id)
-        expect(client).to have_received(:create_circulation_request).with(have_attributes(patron_comments: /PROXY PICKUP OK/))
+        expect(client).to have_received(:create_circulation_request).with(
+          have_attributes(
+            request_type: 'Page',
+            requester_id: sponsor_id,
+            patron_comments: /PROXY PICKUP OK/
+          )
+        )
       end
     end
   end

--- a/spec/jobs/submit_scan_request_job_spec.rb
+++ b/spec/jobs/submit_scan_request_job_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe SubmitScanRequestJob, type: :job do
   before do
     allow(Request.ils_job_class).to receive(:perform_later)
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
   end
 
   context 'when illiad response is success' do

--- a/spec/mailers/factories/request_status_mailer_factory_spec.rb
+++ b/spec/mailers/factories/request_status_mailer_factory_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RequestStatusMailerFactory do
 
   before do
     request.user = create(:anon_user)
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
   end
 
   describe 'user errors' do

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RequestStatusMailer do
     let(:mailer_method) { :request_status_for_page }
     let(:mail) { described_class.send(mailer_method, request) }
 
+    before do
+      allow(Settings.ils.bib_model.constantize).to receive(:fetch)
+    end
+
     describe '#request_status_for_u003' do
       let(:mailer_method) { :request_status_for_u003 }
 

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -5,6 +5,14 @@ require 'rails_helper'
 RSpec.describe Folio::Item do
   subject(:item) { described_class.from_hash(JSON.parse(data)) }
 
+  before do
+    allow(Folio::CirculationRules::PolicyService.instance).to receive(:item_request_policy).and_return(
+      {
+        'requestTypes' => %w[Page Hold Recall]
+      }
+    )
+  end
+
   describe '.from_hash' do
     context 'from a record without a barcode or callnumber' do
       let(:data) do

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe HoldRecall do
+  before do
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
+  end
+
   describe 'requestable' do
     it { is_expected.not_to be_requestable_with_name_email }
     it { is_expected.to be_requestable_with_library_id }

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe MediatedPage do
 
   before do
     allow_any_instance_of(PagingSchedule::Scheduler).to receive(:valid?).with(anything).and_return(true)
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
   end
 
   it 'has the properly assigned Rails STI attribute value' do

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Scan do
+  before do
+    allow(Folio::Instance).to receive(:fetch)
+  end
+
   it 'has the properly assigned Rails STI attribute value' do
     expect(subject.type).to eq 'Scan'
   end

--- a/spec/views/shared/_request_status_information.html.erb_spec.rb
+++ b/spec/views/shared/_request_status_information.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'shared/_request_status_information.html.erb' do
 
   before do
     allow(view).to receive_messages(current_request: request)
+    allow(Settings.ils.bib_model.constantize).to receive(:fetch)
   end
 
   describe 'display request destination' do


### PR DESCRIPTION
This PR fixes a couple of inconsistencies (typos, issues with fixtures) and does one main refactor: making `Folio::Item` the source of truth for requestability via various methods. This means that:
- `RequestAbilities` can use the items in the request to figure out whether the overall request is viable
- `SubmitFolioRequestJob` can use the items in the request to figure out how to submit the job
- The item selector view can use the items to figure out which ones should be requestable/checkable

As a result, the tests for `SubmitFolioRequestJob` were significantly expanded and check for more things (like whether the request is actually the right type, and who it is for).

This came out of/is pre-work for #1776, because we will need to do things like enable/disable request checkboxes and set the status text/icons on a per-item basis using this logic.