### PR TITLE
Item selector UX

### DIFF
--- a/app/assets/stylesheets/modules/icons.scss
+++ b/app/assets/stylesheets/modules/icons.scss
@@ -29,10 +29,7 @@
 
   &.deliver-from-offsite {
     @extend .sul-i-truck-1;
-
-    &::before {
-      color: $sul-available-icon-color;
-    }
+    color: $sul-available-icon-color;
   }
 
   &.unavailable {

--- a/app/assets/stylesheets/modules/icons.scss
+++ b/app/assets/stylesheets/modules/icons.scss
@@ -11,7 +11,15 @@
     }
   }
 
-  &.noncirc_page, &.noncirc.deliver-from-offsite {
+  &.hold-recall {
+    color: $sul-noncirc-icon-color;
+
+    &::before {
+      content: '⚠️';
+    }
+  }
+
+  &.noncirc.deliver-from-offsite {
     @extend .sul-i-truck-1;
 
     &::before {

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -116,6 +116,8 @@ module Folio
         'In-library use only'
       elsif status == STATUS_AVAILABLE && requestable?
         'Available'
+      elsif hold_recallable?
+        status
       else
         'Unavailable'
       end
@@ -206,7 +208,9 @@ module Folio
     private
 
     def availability_class
-      if effective_location.details['availabilityClass'] == 'Offsite'
+      if hold_recallable?
+        'hold-recall'
+      elsif effective_location.details['availabilityClass'] == 'Offsite'
         'deliver-from-offsite'
       elsif status == STATUS_AVAILABLE && requestable?
         'available'

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -108,10 +108,11 @@ module Folio
       [availability_class, circ_class].compact.join(' ')
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def status_text
-      if !requestable? && temporary_location.present?
-        temporary_location.discovery_display_name
-      elsif !circulates?
+      return temporary_location&.discovery_display_name || 'Unavailable' unless requestable?
+
+      if !circulates?
         'In-library use only'
       elsif status == STATUS_AVAILABLE && requestable?
         'Available'
@@ -121,6 +122,7 @@ module Folio
         'Unavailable'
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def processing?
       [STATUS_IN_PROCESS, STATUS_IN_PROCESS_NR].include?(status)

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -110,7 +110,9 @@ module Folio
     end
 
     def status_text
-      if !circulates?
+      if !requestable? && temporary_location.present?
+        temporary_location.discovery_display_name
+      elsif !circulates?
         'In-library use only'
       elsif status == STATUS_AVAILABLE && requestable?
         'Available'
@@ -206,7 +208,7 @@ module Folio
     def availability_class
       if effective_location.details['availabilityClass'] == 'Offsite'
         'deliver-from-offsite'
-      elsif status == STATUS_AVAILABLE
+      elsif status == STATUS_AVAILABLE && requestable?
         'available'
       else
         'unavailable'

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -13,7 +13,6 @@ module Folio
     STATUS_CHECKED_OUT = 'Checked out'
     STATUS_ON_ORDER = 'On order'
     STATUS_AVAILABLE = 'Available'
-    STATUS_HOLD = 'Awaiting pickup'
     STATUS_MISSING = 'Missing'
     STATUS_IN_PROCESS_NR = 'In process (non-requestable)'
     STATUS_IN_PROCESS = 'In process'
@@ -136,7 +135,7 @@ module Folio
     end
 
     def hold?
-      status == STATUS_HOLD
+      status == STATUS_AWAITING_PICKUP
     end
 
     def paged?

--- a/app/views/aeon_pages/_item_selector_radio_button.html.erb
+++ b/app/views/aeon_pages/_item_selector_radio_button.html.erb
@@ -1,3 +1,10 @@
-<%= barcode.radio_button_without_bootstrap nil, holding.barcode, { checked: f.object.requested_holdings.include?(holding), name: "CallNumber_#{index}", value: holding.callnumber, data: { barcode: holding.barcode, callnumber: holding.callnumber } }, holding.callnumber, nil %>
-<%= f.hidden_field "_aeon_barcode_#{holding.barcode}", disabled: !f.object.requested_holdings.include?(holding), name: "ItemNumber_#{index}", value: holding.barcode, class: 'aeon_barcode' %>
-<%= f.hidden_field "_aeon_request_#{index}", disabled: !f.object.requested_holdings.include?(holding), name: 'Request', value: index, class: 'aeon_request_index' %>
+<%= barcode.radio_button_without_bootstrap nil, holding.barcode, { checked:
+f.object.requested_holdings.include?(holding), disabled: !holding.requestable?,
+name: "CallNumber_#{index}", value: holding.callnumber, data: { barcode:
+holding.barcode, callnumber: holding.callnumber } }, holding.callnumber, nil %>
+<%= f.hidden_field "_aeon_barcode_#{holding.barcode}", disabled:
+!f.object.requested_holdings.include?(holding), name: "ItemNumber_#{index}",
+value: holding.barcode, class: 'aeon_barcode' %> <%= f.hidden_field
+"_aeon_request_#{index}", disabled:
+!f.object.requested_holdings.include?(holding), name: 'Request', value: index,
+class: 'aeon_request_index' %>

--- a/app/views/application/_item_selector_checkbox.html.erb
+++ b/app/views/application/_item_selector_checkbox.html.erb
@@ -1,1 +1,3 @@
-<%= barcode.check_box_without_bootstrap holding.barcode, checked: f.object.requested_holdings.include?(holding), data: { barcode: holding.barcode, callnumber: holding.callnumber } %>
+<%= barcode.check_box_without_bootstrap holding.barcode, checked:
+f.object.requested_holdings.include?(holding), disabled: !holding.requestable?,
+data: { barcode: holding.barcode, callnumber: holding.callnumber } %>

--- a/app/views/application/_item_selector_radio_button.html.erb
+++ b/app/views/application/_item_selector_radio_button.html.erb
@@ -1,1 +1,3 @@
-<%= barcode.radio_button_without_bootstrap nil, holding.barcode, checked: f.object.requested_holdings.include?(holding), data: { barcode: holding.barcode, callnumber: holding.callnumber } %>
+<%= barcode.radio_button_without_bootstrap nil, holding.barcode, checked:
+f.object.requested_holdings.include?(holding), disabled: !holding.requestable?,
+data: { barcode: holding.barcode, callnumber: holding.callnumber } %>

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -711,4 +711,30 @@ FactoryBot.define do
       new(**attributes)
     end
   end
+
+  factory :missing_holdings, class: 'Folio::Instance' do
+    id { '1234' }
+    title { 'One Missing item' }
+
+    format { ['Book'] }
+
+    items do
+      [
+        build(:item,
+              barcode: '12345678',
+              callnumber: 'ABC 123',
+              status: 'Missing',
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              barcode: '12345678',
+              callnumber: 'ABC 321',
+              status: 'Available',
+              effective_location: build(:location, code: 'SAL3-STACKS'))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
 end

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -680,4 +680,35 @@ FactoryBot.define do
       new(**attributes)
     end
   end
+
+  factory :mixed_crez_holdings, class: 'Folio::Instance' do
+    id { '1234' }
+    hrid { 'a1234' }
+    title { 'Mixed CREZ holdings' }
+    contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
+    pub_date { '2018' }
+
+    format { ['Book'] }
+
+    items do
+      [
+        build(:item,
+              barcode: '12345678',
+              callnumber: 'ABC 123',
+              status: 'Available',
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              barcode: '87654321',
+              callnumber: 'ABC 321',
+              status: 'Available',
+              effective_location: build(:location, code: 'GRE-CRES'),
+              permanent_location: build(:location, code: 'SAL3-STACKS'),
+              temporary_location: build(:location, code: 'GRE-CRES'))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
 end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -352,4 +352,23 @@ RSpec.describe 'Item Selector' do
     min_date = find_by_id('request_needed_date')['min']
     page.execute_script("$('#request_needed_date').prop('value', '#{min_date}')")
   end
+
+  context 'when some items are not requestable' do
+    before do
+      stub_bib_data_json(build(:mixed_crez_holdings))
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+    end
+
+    it 'allows selecting the requestable items' do
+      within('#item-selector') do
+        expect(page).to have_field('ABC 123', disabled: false)
+      end
+    end
+
+    it 'disables the checkbox for the non-requestable items' do
+      within('#item-selector') do
+        expect(page).to have_field('ABC 321', disabled: true)
+      end
+    end
+  end
 end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -384,4 +384,17 @@ RSpec.describe 'Item Selector' do
       end
     end
   end
+
+  context 'when items are hold/recallable' do
+    before do
+      stub_bib_data_json(build(:missing_holdings))
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+    end
+
+    it 'shows the item status as the status text' do
+      within('#item-selector') do
+        expect(page).to have_css('.hold-recall', text: 'Missing')
+      end
+    end
+  end
 end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -371,4 +371,17 @@ RSpec.describe 'Item Selector' do
       end
     end
   end
+
+  context 'when items are in a temporary location' do
+    before do
+      stub_bib_data_json(build(:mixed_crez_holdings))
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+    end
+
+    it 'shows the temporary location discovery display name as the status text if the item is not requestable' do
+      within('#item-selector') do
+        expect(page).to have_css('.unavailable', text: 'Discovery display name')
+      end
+    end
+  end
 end

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -290,8 +290,8 @@ RSpec.describe Folio::Item do
         JSON
       end
 
-      it 'is unavailable' do
-        expect(item.status_class).to eq('unavailable')
+      it 'is a hold recall' do
+        expect(item.status_class).to eq('hold-recall')
       end
     end
   end
@@ -482,8 +482,8 @@ RSpec.describe Folio::Item do
         JSON
       end
 
-      it 'is unavailable' do
-        expect(item.status_text).to eq('Unavailable')
+      it 'is checked out' do
+        expect(item.status_text).to eq('Checked out')
       end
     end
   end


### PR DESCRIPTION
This brings in a bunch of changes to make the UX for the item selector more predictable.

- disable checkboxes for items that aren't requestable
- if the item would be a hold/recall, make it a warning-y color and show a warning icon because we don't know when you'll be able to get it
- if the item would be a hold/recall, show its current status so you know if it's e.g. missing, waiting for someone else to pick it up, in transit, etc.
- if the item isn't requestable because it's in a temporary location (e.g. put on course reserve), show that location's display name so that you know that it's on reserve

Example:

![Screenshot 2023-09-14 at 17 13 54](https://github.com/sul-dlss/sul-requests/assets/4924494/784a6df0-e8f1-4cae-8c09-1b3093efacda)
