### PR TITLE
Prune/rename Symphony library codes from settings where no longer needed

### DIFF
--- a/app/models/folio/library.rb
+++ b/app/models/folio/library.rb
@@ -3,15 +3,16 @@
 module Folio
   # Model for FOLIO's library data
   class Library
-    attr_reader :id, :code
+    attr_reader :id, :code, :name
 
     def self.from_dynamic(dyn)
-      new(id: dyn.fetch('id'), code: dyn.fetch('code'))
+      new(id: dyn.fetch('id'), code: dyn.fetch('code'), name: dyn.fetch('name'))
     end
 
-    def initialize(id:, code:)
+    def initialize(id:, code:, name:)
       @id = id
       @code = code
+      @name = name
     end
 
     def primary_service_points

--- a/app/models/library_location.rb
+++ b/app/models/library_location.rb
@@ -24,18 +24,20 @@ class LibraryLocation
   end
 
   class << self
+    # Most library codes used in requests will be FOLIO codes
+    # Settings will be used for the RWC code which has a service point but no FOLIO library associated
     def library_name_by_code(code)
-      all_libraries[code]&.label
+      Folio::Types.libraries.find_by(code:)&.name || Settings.libraries[code]&.label
     end
 
     # This is a super-clunky way to convert data from RailsConfig to something
     # Enumerable, so we can use e.g. #select
-    def all_libraries
+    def all_settings_libraries
       Settings.libraries.map.to_h.with_indifferent_access
     end
 
     def pageable_libraries
-      all_libraries.select { |_, v| v.pageable }
+      all_settings_libraries.select { |_, v| v.pageable }
     end
   end
 end

--- a/app/views/aeon_pages/_info_modal.html.erb
+++ b/app/views/aeon_pages/_info_modal.html.erb
@@ -1,6 +1,6 @@
 <div id="aeon-info-overlay" class="aeon-overlay">
   <div class="modal-body">
-    <h1 class="dialog-title" id='dialogTitle'><%= t('.header', library: Settings.libraries[i18n_library_title_key].label) %></h1>
+    <h1 class="dialog-title" id='dialogTitle'><%= t('.header', library: LibraryLocation.library_name_by_code(i18n_library_title_key) ) %></h1>
     <p><%= t('.reading_room_info') %></p>
     <h2 class="dialog-how-to"><%= t('.how_to.header') %></h2>
     <p><%= t('.how_to.body') %></p>
@@ -15,7 +15,7 @@
       <% end %>
     </ol>
     <p class="dialog-more-info">
-      <%= t('.more_details_html', library: Settings.libraries[current_request.origin].label, reading_room_url: Settings.libraries[current_request.origin].reading_room_url) %>
+      <%= t('.more_details_html', library: LibraryLocation.library_name_by_code(current_request.origin), reading_room_url: Settings.libraries[current_request.origin].reading_room_url) %>
     </p>
     <div class="dialog-buttons">
       <% if current_request.finding_aid? %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -6,7 +6,7 @@
 
 <% LibraryLocation.pageable_libraries.each do |library_code, config| %>
   <div class="library-page-<%= library_code %>">
-    <%= render partial: 'messages_for_library', locals: { library_name: config.label, library_code: library_code, request_type: 'page'} %>
+    <%= render partial: 'messages_for_library', locals: { library_name: LibraryLocation.library_name_by_code(library_code), library_code: library_code, request_type: 'page'} %>
   </div>
 <% end %>
 

--- a/app/views/request_status_mailer/request_status_for_page.html.erb
+++ b/app/views/request_status_mailer/request_status_for_page.html.erb
@@ -4,7 +4,7 @@
     <%= render 'pickup_confirmation' %>
 
     <p>
-      The following item(s) will be delivered to <%= Settings.libraries[@request.destination]&.label || @request.destination %>:<br/>
+      The following item(s) will be delivered to <%= LibraryLocation.library_name_by_code(@request.destination) || @request.destination %>:<br/>
       Title: <%= @request.item_title %>
     </p>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,72 +120,50 @@ libraries:
       email: greencirc@stanford.edu
     label: Stanford Libraries
   ARS:
-    label: Archive of Recorded Sound
     contact_info:
       phone: (650) 723-9312
       email: soundarchive@stanford.edu
-    folio_pickup_service_point_code: ARS
     reading_room_url: https://library.stanford.edu/libraries/archive-recorded-sound
     hold_pseudopatron: HOLD@AS
     hours:
       library_slug: ars
       location_slug: archive-recorded-sound
   ART:
-    label: Art & Architecture Library (Bowes)
     contact_info:
       phone: "(650) 723-3408"
       email: artlibrary@stanford.edu
-    folio_pickup_service_point_code: ART
     hold_pseudopatron: HOLD@AR
     hours:
       library_slug: art
       location_slug: library-circulation
-  BIOLOGY:
-    label: Biology Library (Falconer)
-    hours:
-      library_slug: falconer
-      location_slug: library-circulation
   BUSINESS:
-    label: Business Library
     contact_info:
       phone: "(650) 725-2055"
       email: gsb_librarycirc@stanford.edu
-    folio_pickup_service_point_code: BUS-IDESK
     hold_pseudopatron: HOLD@BU # NOTE, in FOLIO the name is HOLD@JA
     hours:
       library_slug: business
       location_slug: library-i-desk
-  CHEMCHMENG:
-    label: Chemistry & ChemEng Library (Swain)
-    hours:
-      library_slug: swain
-      location_slug: library-circulation
   CLASSICS:
-    label: Classics Library
     hold_pseudopatron: HOLD@CL
     hours:
       library_slug: classics-library
       location_slug: library-circulation
   EARTH-SCI:
-    label: Earth Sciences Library (Branner)
-    folio_pickup_service_point_code: EARTH-SCI
     hold_pseudopatron: HOLD@ES
     hours:
       library_slug: branner
       location_slug: library-circulation
   EAST-ASIA:
-    label: East Asia Library
     contact_info:
       phone: (650) 725-3435
       email: eastasialibrary@stanford.edu
     reading_room_url: https://library.stanford.edu/libraries/east-asia-library
-    folio_pickup_service_point_code: EAST-ASIA
     hold_pseudopatron: HOLD@EA
     hours:
       library_slug: eal
       location_slug: library-circulation
   EDUCATION:
-    label: Education Library (at SAL1&2)
     instructions: The Education Library is closed for construction. Request items for pickup at another library.
     contact_info:
       phone: "(650) 723-2121"
@@ -196,111 +174,57 @@ libraries:
       location_slug: operations
     iplc_pickup_location_code: STA_GREEN
   ENG:
-    label: Engineering Library (Terman)
-    folio_pickup_service_point_code: ENG
     hold_pseudopatron: HOLD@EN
     hours:
       library_slug: englib
       location_slug: library-circulation
   GREEN:
-    label: Green Library
     contact_info:
       phone: "(650) 723-1493"
       email: greencirc@stanford.edu
-    folio_pickup_service_point_code: GREEN-LOAN
     hold_pseudopatron: HOLD@GR
     hours:
       library_slug: green
-      location_slug: library-circulation
-  HOPKINS:
-    label: Marine Biology Library (Miller)
-    contact_info:
-      phone: "(831) 655-6229"
-      email: HMS-Library@lists.stanford.edu
-    folio_pickup_service_point_code: MARINE-BIO
-    hold_pseudopatron: HOLD@MA
-    hours:
-      library_slug: hopkins
       location_slug: library-circulation
   LANE:
     hold_pseudopatron: HOLD@LN
     hours:
       library_slug: lane
       location_slug: library-circulation
-  LANE-MED:
-    label: Medical Library (Lane)
-    hold_pseudopatron: HOLD@LN
-    hours:
-      library_slug: lane
-      location_slug: library-circulation
-  LATHROP:
-    label: Lathrop Library
-    hours:
-      library_slug: lathrop
-      location_slug: tech-lounge
   LAW:
-    label: Law Library (Crown)
     contact_info:
       phone: "(650) 723-2477"
       email: circulation@law.stanford.edu
-    folio_pickup_service_point_code: LAW
     hold_pseudopatron: HOLD@LW
     hours:
       library_slug: law
       location_slug: library-circulation
   MARINE-BIO:
+    contact_info:
+      phone: "(831) 655-6229"
+      email: HMS-Library@lists.stanford.edu
     hold_pseudopatron: HOLD@MA
     hours:
       library_slug: hopkins
       location_slug: library-circulation
-  MATH-CS:
-    label: Math & Statistics Library
-    hours:
-      library_slug: mathstat
-      location_slug: library-circulation
-  MEDIA-MTXT:
-    label: Media Microtext
-    folio_pickup_service_point_code: MEDIA-CENTER
-    hold_pseudopatron: HOLD@MD
-    hours:
-      library_slug: green
-      location_slug: media-microtext-center
   MEDIA-CENTER:
-    label: Media Microtext
-    folio_pickup_service_point_code: MEDIA-CENTER
     hold_pseudopatron: HOLD@MD
     hours:
       library_slug: green
       location_slug: media-microtext-center
   MUSIC:
-    label: Music Library
     contact_info:
       phone: (650) 723-1211
       email: muslibcirc@stanford.edu
-    folio_pickup_service_point_code: MUSIC
     hold_pseudopatron: HOLD@MU
     hours:
       library_slug: music
       location_slug: library-circulation
-  RUMSEYMAP:
-    label: David Rumsey Map Center
-    instructions: Researchers can request to view these materials in the David Rumsey Map Center.
-    contact_info:
-      phone: (650) 498-8698
-      email: rumseymapcenter@stanford.edu
-    folio_pickup_service_point_code: RUMSEY-MAP
-    reading_room_url: https://library.stanford.edu/rumsey/about-center/visitor-policies
-    hold_pseudopatron: HOLD@RM
-    hours:
-      library_slug: Rumsey
-      location_slug: visitor-access
   RUMSEY-MAP:
-    label: David Rumsey Map Center
     instructions: Researchers can request to view these materials in the David Rumsey Map Center.
     contact_info:
       phone: (650) 498-8698
       email: rumseymapcenter@stanford.edu
-    folio_pickup_service_point_code: RUMSEY-MAP
     reading_room_url: https://library.stanford.edu/rumsey/about-center/visitor-policies
     hold_pseudopatron: HOLD@RM
     hours:
@@ -314,20 +238,17 @@ libraries:
       library_slug: srwc
       location_slug: lobby-desk
   SAL:
-    label: SAL1&2 (on-campus shelving)
     hold_pseudopatron: HOLD@SL
     hours:
       library_slug: sal12
       location_slug: operations
     pageable: true
   SAL3:
-    label: SAL3 (off-campus storage)
     hours:
       library_slug: sal3
       location_slug: operations
     pageable: true
   SAL-NEWARK:
-    label: SAL Newark (off-campus storage)
     hours:
       library_slug: newark
       location_slug: operations
@@ -337,29 +258,24 @@ libraries:
       phone: '(650) 723-3278'
       email: 'scan-and-deliver@stanford.edu'
   SCIENCE:
-    label: Science Library (Li and Ma)
     contact_info:
       phone: "(650) 723-1528"
       email: sciencelibrary@stanford.edu
-    folio_pickup_service_point_code: SCIENCE
     hold_pseudopatron: HOLD@CS
     hours:
       library_slug: science
       location_slug: library-circulation
   SPEC-COLL:
-    label: Special Collections
     instructions: Researchers can request to view these materials in the Special Collections Reading Room. Request materials at least 2 business days in advance. Maximum 5 items per day.
     contact_info:
       phone: "(650) 725-1022"
       email: specialcollections@stanford.edu
-    folio_pickup_service_point_code: SPEC
     reading_room_url: https://library.stanford.edu/spc/using-our-collections
     hold_pseudopatron: HOLD@SP
     hours:
       library_slug: spc
       location_slug: field-reading-room
   TANNER:
-    label: Philosophy Library (Tanner)
     hold_pseudopatron: HOLD@TA
     hours:
       library_slug: philosophy

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     name { 'Location name' }
     discovery_display_name { 'Discovery display name' }
     campus { Folio::Campus.new(id: 'uuid', code: 'SUL') }
-    library { Folio::Library.new(id: 'uuid', code: 'LIB') }
+    library { Folio::Library.new(id: 'uuid', code: 'LIB', name: 'library') }
     library_id { 'uuid' }
     primary_service_point_id { nil }
     institution { Folio::Institution.new(id: 'uuid') }
@@ -47,23 +47,23 @@ FactoryBot.define do
 
   factory :mmstacks_location, parent: :location do
     code { 'MEDIA-CAGE' }
-    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'MEDIA-CENTER') }
+    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'MEDIA-CENTER', name: 'media center') }
   end
 
   factory :law_location, parent: :location do
     code { 'LAW-STACKS1' }
-    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW') }
-    campus { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW') }
+    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW', name: 'law') }
+    campus { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW', name: 'law') }
   end
 
   factory :eal_sets_location, parent: :location do
     code { 'EAL-SETS' }
-    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'EAST-ASIA') }
+    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'EAST-ASIA', name: 'East Asia Library') }
   end
 
   factory :green_location, parent: :location do
     code { 'GRE-STACKS' }
-    library { Folio::Library.new(id: 'f6b5519e-88d9-413e-924d-9ed96255f72e', code: 'GREEN') }
+    library { Folio::Library.new(id: 'f6b5519e-88d9-413e-924d-9ed96255f72e', code: 'GREEN', name: 'Green Library') }
   end
 
   factory :spec_coll_location, parent: :location do

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe Folio::Instance do
               },
               "library": {
                 "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                "code": "GREEN"
+                "code": "GREEN",
+                "name": "Green Library"
               },
               "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
               "code": "GRE-STACKS",
@@ -206,7 +207,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-U-ARCHIVES",
@@ -239,7 +241,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -272,7 +275,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -305,7 +309,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -385,7 +390,8 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
+                  "code": "SPEC-COLL",
+                  "name": "Special Collections"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-U-ARCHIVES",
@@ -418,7 +424,8 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
+                  "code": "SPEC-COLL",
+                  "name": "Special Collections"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-SAL3-U-ARCHIVES",
@@ -451,7 +458,8 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
+                  "code": "SPEC-COLL",
+                  "name": "Special Collections"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-SAL3-U-ARCHIVES",
@@ -484,7 +492,9 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
+                  "code": "SPEC-COLL",
+                  "name": "Special Collections"
+
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-SAL3-U-ARCHIVES",
@@ -564,7 +574,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-U-ARCHIVES",
@@ -597,7 +608,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -630,7 +642,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -664,7 +677,8 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                    "code": "SPEC-COLL",
+                    "name": "Special Collections"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Folio::Item do
               },
               "library": {
                 "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                "code": "SAL3"
+                "code": "SAL3",
+                "name": "SAL3"
               },
               "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
               "code": "SAL3-STACKS",
@@ -84,7 +85,8 @@ RSpec.describe Folio::Item do
               },
               "library": {
                 "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                "code": "GREEN"
+                "code": "GREEN",
+                "name": "GREEN Library"
               },
               "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
               "code": "GRE-STACKS",
@@ -145,7 +147,8 @@ RSpec.describe Folio::Item do
           },
           "library": {
             "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN"
+            "code": "GREEN",
+            "name": "Green Library"
           },
           "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
           "code": "GRE-STACKS",
@@ -175,7 +178,8 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
+            "code": "SAL3",
+            "name": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -217,7 +221,8 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
+            "code": "SAL3",
+            "name": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -345,7 +350,8 @@ RSpec.describe Folio::Item do
           },
           "library": {
             "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN"
+            "code": "GREEN",
+            "name": "Green Library"
           },
           "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
           "code": "GRE-STACKS",
@@ -375,7 +381,8 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
+            "code": "SAL3",
+            "name": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -417,7 +424,8 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3"
+            "code": "SAL3",
+            "name": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -537,7 +545,8 @@ RSpec.describe Folio::Item do
           },
           "library": {
             "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN"
+            "code": "GREEN",
+            "name": "Green Library"
           },
           "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
           "code": "GRE-STACKS",

--- a/spec/models/library_location_spec.rb
+++ b/spec/models/library_location_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe LibraryLocation do
       expect(described_class.library_name_by_code('SAL3')).to eq 'SAL3 (off-campus storage)'
     end
 
+    it 'returns the label from Settings for a library like RWC without a FOLIO library code' do
+      expect(described_class.library_name_by_code('RWC')).to eq 'Academy Hall (SRWC)'
+    end
+
     it 'returns nil when there is no configured library' do
       expect(described_class.library_name_by_code('NOT-A-LIBRARY')).to be_nil
     end


### PR DESCRIPTION
What this pull request does:

Changes to the Settings file:
- For any library codes in the Settings file that have FOLIO codes but which also have additional information needed from Settings, this pull request removes the label information as the name should come from FOLIO.  The extra information not in FOLIO corresponds to the following properties : instructions, hold_pseudopatron, iplc_pickup_location_code, contact_info, hours, and reading_room_url. 
- For library codes that have been renamed, but which still need some of the extra info, the older Symphony code version has been removed and any info needed is maintained under the new FOLIO library code mapping.  These libraries are: MARINE-BIO (renamed from Hopkins), LANE (renamed from LANE-MED), MEDIA-CENTER (renamed from MEDIA-MTXT)and RUMSEY-MAP (renamed from RUMSEYMAP).
- Library codes with no equivalent FOLIO codes which are still needed remain as they were.  These are: RWC (which is not a library in FOLIO but which still needs its "folio_service_pickup_point" information as there is no other way to retrieve the related service point) and "SCAN".
- Library codes that are no longer used at all by Requests have been removed entirely.  These are CHEMCHENG, LATHROP, BIOLOGY, and MATH-CS.  Besides Lathrop, the other three codes no longer correspond to existing physical buildings.

Changes to code related to using FOLIO library data to retrieve the library name
- The FOLIO library model has been updated to also read in the "name" field from libraries.json and to return that info in an attribute. 
- LibraryLocation has been updated to look first for the FOLIO information, and if it doesn't exist, resort to the label in Settings. 
- The info model and request status views have been updated to use LibraryLocation to get the name for the library as opposed to relying on the label from Settings. 