### PR TITLE
Cast criterium letters to actual strings instead of intermediate representations

### DIFF
--- a/app/services/folio/circulation_rules/transform.rb
+++ b/app/services/folio/circulation_rules/transform.rb
@@ -88,7 +88,7 @@ module Folio
           when 'last-line'
             ->(policy) { -1 * policy[:line] }
           when Array
-            order = p.pluck(:letter)
+            order = p.pluck(:letter).map(&:to_s)
 
             lambda do |policy|
               # We're going through the list of criterium priorities and building up a binary representation for whether the


### PR DESCRIPTION
Apply circ-rules fix from SearchWorks in https://github.com/sul-dlss/SearchWorks/commit/ecb8b4981a01865ffec3e3ce6f6fbc34a3e189aa to sul-requests