### PR TITLE
Make :name argument optional in Folio::Library

### DIFF
--- a/app/models/folio/library.rb
+++ b/app/models/folio/library.rb
@@ -9,7 +9,7 @@ module Folio
       new(id: dyn.fetch('id'), code: dyn.fetch('code'), name: dyn.fetch('name'))
     end
 
-    def initialize(id:, code:, name:)
+    def initialize(id:, code:, name: nil)
       @id = id
       @code = code
       @name = name


### PR DESCRIPTION
Fixes #1877

When we instantiate `Folio::Library` with data from the FOLIO API (`FolioClient.new.find_instance_by(hrid: 'a3978751')`) the library information on the item contains only an `:id` and a `:code` so `:name` needs to be optional.