### PR TITLE
Remove :name from library spec data to match API response

### DIFF
--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     name { 'Location name' }
     discovery_display_name { 'Discovery display name' }
     campus { Folio::Campus.new(id: 'uuid', code: 'SUL') }
-    library { Folio::Library.new(id: 'uuid', code: 'LIB', name: 'library') }
+    library { Folio::Library.new(id: 'uuid', code: 'LIB') }
     library_id { 'uuid' }
     primary_service_point_id { nil }
     institution { Folio::Institution.new(id: 'uuid') }
@@ -47,23 +47,23 @@ FactoryBot.define do
 
   factory :mmstacks_location, parent: :location do
     code { 'MEDIA-CAGE' }
-    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'MEDIA-CENTER', name: 'media center') }
+    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'MEDIA-CENTER') }
   end
 
   factory :law_location, parent: :location do
     code { 'LAW-STACKS1' }
-    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW', name: 'law') }
-    campus { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW', name: 'law') }
+    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW') }
+    campus { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'LAW') }
   end
 
   factory :eal_sets_location, parent: :location do
     code { 'EAL-SETS' }
-    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'EAST-ASIA', name: 'East Asia Library') }
+    library { Folio::Library.new(id: '0acfabb7-0a71-47be-82c0-c0200dd47952', code: 'EAST-ASIA') }
   end
 
   factory :green_location, parent: :location do
     code { 'GRE-STACKS' }
-    library { Folio::Library.new(id: 'f6b5519e-88d9-413e-924d-9ed96255f72e', code: 'GREEN', name: 'Green Library') }
+    library { Folio::Library.new(id: 'f6b5519e-88d9-413e-924d-9ed96255f72e', code: 'GREEN') }
   end
 
   factory :spec_coll_location, parent: :location do

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -88,8 +88,7 @@ RSpec.describe Folio::Instance do
               },
               "library": {
                 "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                "code": "GREEN",
-                "name": "Green Library"
+                "code": "GREEN"
               },
               "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
               "code": "GRE-STACKS",
@@ -207,8 +206,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-U-ARCHIVES",
@@ -241,8 +239,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -275,8 +272,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -309,8 +305,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -390,8 +385,7 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL",
-                  "name": "Special Collections"
+                  "code": "SPEC-COLL"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-U-ARCHIVES",
@@ -424,8 +418,7 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL",
-                  "name": "Special Collections"
+                  "code": "SPEC-COLL"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-SAL3-U-ARCHIVES",
@@ -458,8 +451,7 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL",
-                  "name": "Special Collections"
+                  "code": "SPEC-COLL"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-SAL3-U-ARCHIVES",
@@ -492,9 +484,7 @@ RSpec.describe Folio::Instance do
                 },
                 "library": {
                   "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL",
-                  "name": "Special Collections"
-
+                  "code": "SPEC-COLL"
                 },
                 "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                 "code": "SPEC-SAL3-U-ARCHIVES",
@@ -574,8 +564,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-U-ARCHIVES",
@@ -608,8 +597,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -642,8 +630,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",
@@ -677,8 +664,7 @@ RSpec.describe Folio::Instance do
                   },
                   "library": {
                     "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL",
-                    "name": "Special Collections"
+                    "code": "SPEC-COLL"
                   },
                   "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
                   "code": "SPEC-SAL3-U-ARCHIVES",

--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe Folio::Item do
               },
               "library": {
                 "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                "code": "SAL3",
-                "name": "SAL3"
+                "code": "SAL3"
               },
               "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
               "code": "SAL3-STACKS",
@@ -85,8 +84,7 @@ RSpec.describe Folio::Item do
               },
               "library": {
                 "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                "code": "GREEN",
-                "name": "GREEN Library"
+                "code": "GREEN"
               },
               "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
               "code": "GRE-STACKS",
@@ -147,8 +145,7 @@ RSpec.describe Folio::Item do
           },
           "library": {
             "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN",
-            "name": "Green Library"
+            "code": "GREEN"
           },
           "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
           "code": "GRE-STACKS",
@@ -178,8 +175,7 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3",
-            "name": "SAL3"
+            "code": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -221,8 +217,7 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3",
-            "name": "SAL3"
+            "code": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -350,8 +345,7 @@ RSpec.describe Folio::Item do
           },
           "library": {
             "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN",
-            "name": "Green Library"
+            "code": "GREEN"
           },
           "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
           "code": "GRE-STACKS",
@@ -381,8 +375,7 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3",
-            "name": "SAL3"
+            "code": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -424,8 +417,7 @@ RSpec.describe Folio::Item do
           ],
           "library": {
             "id": "ddd3bce1-9f8f-4448-8d6d-b6c1b3907ba9",
-            "code": "SAL3",
-            "name": "SAL3"
+            "code": "SAL3"
           },
           "campus": {
             "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
@@ -545,8 +537,7 @@ RSpec.describe Folio::Item do
           },
           "library": {
             "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-            "code": "GREEN",
-            "name": "Green Library"
+            "code": "GREEN"
           },
           "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
           "code": "GRE-STACKS",


### PR DESCRIPTION
`:name` was added to the spec data in https://github.com/sul-dlss/sul-requests/commit/79411dd8460ecddeebc2f79f8052f383e4134155#diff-e769bbb8c1ba3711c5403b424ed9c218ffafba7f1890ee394717196f28ff4540 but the response we get from the graphql request for an instance does not include library name: https://github.com/sul-dlss/sul-requests/blob/main/app/services/folio_graphql_client.rb#L133