### PR TITLE
Request the folio instance hrid so it can be used in links for Aeon

### DIFF
--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -73,6 +73,7 @@ class FolioGraphqlClient
           query InstanceByHrid {
             instances(hrid: "#{hrid}") {
               id
+              hrid
               title
               identifiers {
                 value

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Folio::Instance do
     <<~JSON
       {
         "id": "57550106-e809-5a43-92da-1503d84dcc18",
+        "hrid": "a6959652",
         "title": "Coffee / Nebiyu Assefa and Joanna Brown",
         "identifiers": [
           {
@@ -141,6 +142,12 @@ RSpec.describe Folio::Instance do
     subject { data.isbn }
 
     it { is_expected.to eq '9780955506000; 095550600X' }
+  end
+
+  describe '#view_url' do
+    subject { data.view_url }
+
+    it { is_expected.to eq 'https://searchworks.stanford.edu/view/6959652' }
   end
 
   describe '#finding_aid' do


### PR DESCRIPTION
Fixes #1890

We use the hrid to make the "view in searchworks" link that we send
to Aeon when creating a page request, but we weren't actually
requesting it from graphql, so the links didn't go anywhere useful.

Also adds a test for this property to confirm we correctly strip
the leading 'a' from hrids when present.
