### PR TITLE
Refactor to move ILLiad param generation into Request subclasses

### DIFF
--- a/app/models/requests/scan.rb
+++ b/app/models/requests/scan.rb
@@ -31,6 +31,24 @@ class Scan < Request
     RequestStatusMailer.request_status_for_scan(self).deliver_later if notification_email_address.present?
   end
 
+  # rubocop:disable Metrics/MethodLength
+  def illiad_request_params
+    {
+      RequestType: 'Article',
+      SpecIns: 'Scan and Deliver Request',
+      PhotoJournalTitle: bib_data.title,
+      PhotoArticleAuthor: bib_data.author,
+      Location: origin,
+      ReferenceNumber: origin_location,
+      PhotoArticleTitle: section_title,
+      PhotoJournalInclusivePages: page_range,
+      CallNumber: holdings.first.try(:callnumber),
+      ILLNumber: holdings.first.try(:barcode),
+      ItemNumber: holdings.first.try(:barcode)
+    }
+  end
+  # rubocop:enable Metrics/MethodLength
+
   private
 
   def requested_item_is_not_scannable_only

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -292,6 +292,7 @@ FactoryBot.define do
   factory :scannable_holdings, class: 'Folio::Instance' do
     id { '1234' }
     title { 'SAL Item Title' }
+    contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
 
     format { ['Book'] }
 

--- a/spec/factories/scans.rb
+++ b/spec/factories/scans.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     origin { 'SAL3' }
     origin_location { 'STACKS' }
     section_title { 'Section Title for Scan 12345' }
+    page_range { '1-10' }
 
     trait :with_item_title do
       item_title { 'Title for Scan 12345' }

--- a/spec/models/illiad_request_spec.rb
+++ b/spec/models/illiad_request_spec.rb
@@ -2,36 +2,141 @@
 
 require 'rails_helper'
 
+# A fake Request type that can be sent to ILLiad
+class ExampleRequest < Request
+  def illiad_request_params
+    {}
+  end
+end
+
 RSpec.describe IlliadRequest do
-  subject { described_class.new(scan) }
+  subject { described_class.new(request) }
 
   let(:user) { create(:sso_user) }
-  let(:scan) { create(:scan, :with_holdings_barcodes, user:) }
+  let(:request) { ExampleRequest.new(user:) }
 
-  describe 'illiad request json' do
-    it 'includes the correct illiad routing info' do
-      expect(subject.illiad_transaction_request).to include('"Username":"some-sso-user"')
-      expect(subject.illiad_transaction_request).to include('"ProcessType":"Borrowing"')
-      expect(subject.illiad_transaction_request).to include('"RequestType":"Article"')
-      expect(subject.illiad_transaction_request).to include('"SpecIns":"Scan and Deliver Request"')
+  before do
+    allow(Settings).to receive(:sul_illiad).and_return('https://illiad.stanford.edu')
+    allow(Settings).to receive(:illiad_api_key).and_return('some-api-key')
+    stub_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+    subject.request!
+  end
+
+  it 'POSTs to the illiad api url' do
+    expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')).to have_been_made
+  end
+
+  describe 'request headers' do
+    it 'declares that it is sending JSON' do
+      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+      .with(headers: { 'Content-Type' => 'application/json' })).to have_been_made
+    end
+
+    it 'asks for a JSON response' do
+      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+      .with(headers: { 'Accept' => 'application/json; version=1' })).to have_been_made
+    end
+
+    it 'includes the api key' do
+      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+      .with(headers: { 'ApiKey' => 'some-api-key' })).to have_been_made
     end
   end
 
-  describe 'illiad transaction request and response' do
-    context 'valid response' do
-      it 'fires off a request to the illiad api' do
-        expect_any_instance_of(Faraday::Connection).to receive(:post)
-        subject.request!
-      end
+  describe 'request body' do
+    it 'includes the user sunetid' do
+      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+      .with(body: /"Username":"some-sso-user"/)).to have_been_made
     end
 
-    describe '#faraday_conn_w_req_headers' do
-      it 'has required headers' do
-        faraday_conn = subject.send(:faraday_conn_w_req_headers)
-        expect(faraday_conn.headers).to include('ApiKey')
-        expect(faraday_conn.headers).to include('Accept' => 'application/json; version=1')
-        expect(faraday_conn.headers).to include('Content-type' => 'application/json')
+    it 'includes the process type' do
+      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+      .with(body: /"ProcessType":"Borrowing"/)).to have_been_made
+    end
+  end
+
+  context 'with a scan' do
+    subject { described_class.new(scan) }
+
+    let(:scan) { create(:scan, :with_holdings_barcodes, user:) }
+
+    describe 'request body' do
+      it 'includes the request type' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"RequestType":"Article"/)).to have_been_made
       end
+
+      it 'includes the instructions' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"SpecIns":"Scan and Deliver Request"/)).to have_been_made
+      end
+
+      it 'includes the title' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"PhotoJournalTitle":"SAL Item Title"/)).to have_been_made
+      end
+
+      it 'includes the section title' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"PhotoArticleTitle":"Section Title for Scan 12345"/)).to have_been_made
+      end
+
+      it 'includes the author' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"PhotoArticleAuthor":"John Q. Public"/)).to have_been_made
+      end
+
+      it 'includes the first item call number' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"CallNumber":"ABC 123"/)).to have_been_made
+      end
+
+      it 'includes the first item barcode as the ILL number' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"ILLNumber":"12345678"/)).to have_been_made
+      end
+
+      it 'includes the first item barcode as the item number' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"ItemNumber":"12345678"/)).to have_been_made
+      end
+
+      it 'includes the requested page range' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"PhotoJournalInclusivePages":"1-10"/)).to have_been_made
+      end
+
+      it 'includes the library' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"Location":"SAL3"/)).to have_been_made
+      end
+
+      it 'includes the location' do
+        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
+        .with(body: /"ReferenceNumber":"STACKS"/)).to have_been_made
+      end
+    end
+  end
+
+  context 'with a hold/recall' do
+    subject { described_class.new(hold) }
+
+    let(:hold) { create(:hold_recall, :with_holdings_barcodes, user:) }
+
+    describe 'request body' do
+      it 'includes the request type'
+      it 'includes the instructions'
+      it 'includes the title'
+      it 'includes the author'
+      it 'includes the ISBN'
+      it 'includes the volume'
+      it 'includes the publisher'
+      it 'includes the place of publication'
+      it 'includes the date of publication'
+      it 'includes the edition'
+      it 'includes the OCLC number'
+      it 'includes the catalog view link'
+      it 'includes the not needed after date'
     end
   end
 end


### PR DESCRIPTION
This creates a seam for having different request types send their
data to ILLiad (not just scans) and expands the test coverage for
existing scan requests to ILLiad, in prep for #1889.
