### PR TITLE
Add support for FOLIO location codes in `origin_location`

### DIFF
--- a/app/models/concerns/default_request_options.rb
+++ b/app/models/concerns/default_request_options.rb
@@ -7,7 +7,8 @@ module DefaultRequestOptions
   ITEM_LIMITS = {
     'RUMSEY-MAP' => 5,
     'SPEC-COLL' => 5,
-    'PAGE-SP' => 5
+    'PAGE-SP' => 5,
+    'SAL3-PAGE-SP' => 5
   }.freeze
 
   def item_limit

--- a/app/models/library_location.rb
+++ b/app/models/library_location.rb
@@ -19,9 +19,6 @@ class LibraryLocation
   # In certain cases, this wasn't a Symphony location, so the location is a FOLIO location (e.g. BUSINESS/BUS-CRES)
   def folio_location_code
     @folio_location_code ||= FolioLocationMap.folio_code_for(library_code: library, home_location: location) || location
-  rescue FolioLocationMap::NotFound
-    Honeybadger.notify('Location code not found', context: { library:, location: })
-    nil
   end
 
   class << self

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -25,7 +25,7 @@ class MediatedPage < Request
   end
 
   def requires_needed_date?
-    return false if origin_location == 'PAGE-MP'
+    return false if origin_location == 'PAGE-MP' || origin_location == 'SAL3-PAGE-MP'
 
     true
   end

--- a/app/services/folio_location_map.rb
+++ b/app/services/folio_location_map.rb
@@ -7,14 +7,9 @@ class FolioLocationMap
   include Singleton
   RENAMES = { 'LANE' => 'LANE-MED' }.freeze
 
-  class NotFound < StandardError; end
-
   # @return a tuple of library code and location code
   def self.folio_code_for(library_code:, home_location:)
-    library_locations = instance.data.fetch(library_code)
-    library_locations[home_location]
-  rescue KeyError
-    raise NotFound
+    instance.data.dig(library_code, home_location)
   end
 
   def data

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,7 @@ module SULRequests
       'EDUCATION'  => { email: 'sul-requests-education@lists.stanford.edu'},
       'MARINE-BIO'    => { email: 'sul-requests-hopkins@lists.stanford.edu' },
       'PAGE-MP'    => { email: 'sul-requests-branner@lists.stanford.edu' },
+      'SAL3-PAGE-MP'    => { email: 'sul-requests-branner@lists.stanford.edu' },
       'SPEC-COLL'  => { email: 'sul-requests-spec@lists.stanford.edu' },
       'RUMSEY-MAP'  => { email: 'sul-requests-rumsey@lists.stanford.edu' }
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
       default: 'Request on-site access'
       MARINE-BIO: 'Request delivery to campus library'
       PAGE-MP: 'Request delivery to campus library'
+      SAL3-PAGE-MP: 'Request delivery to campus library'
   aeon_pages:
     new:
       header: Request access

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -336,6 +336,10 @@ libraries:
       location_slug: library-circulation
 
 locations:
+  SAL3-PAGE-MP:
+    contact_info:
+      phone: '(650) 723-2746'
+      email: 'brannerlibrary@stanford.edu'
   PAGE-MP:
     contact_info:
       phone: '(650) 723-2746'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,12 +35,15 @@ origin_admin_groups:
 
 origin_location_admin_groups:
   PAGE-MP: ['sul:requests-branner']
+  SAL3-PAGE-MP: ['sul:requests-branner']
 
 mediateable_origins:
   ART: {}
   EDUCATION: {}
   MARINE-BIO: {}
   PAGE-MP:
+    library_override: EARTH-SCI
+  SAL3-PAGE-MP:
     library_override: EARTH-SCI
   RUMSEY-MAP: {}
   SPEC-COLL: {}

--- a/spec/controllers/hold_recalls_controller_spec.rb
+++ b/spec/controllers/hold_recalls_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe HoldRecallsController do
   let(:hold_recall) { create(:hold_recall) }
   let(:normal_params) do
-    { item_id: '1234', barcode: '36105212925395', origin: 'SAL3', origin_location: 'STACKS', destination: 'GREEN' }
+    { item_id: '1234', barcode: '36105212925395', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'GREEN' }
   end
 
   before do
@@ -24,14 +24,14 @@ RSpec.describe HoldRecallsController do
     it 'sets defaults' do
       get :new, params: normal_params
       expect(assigns[:request].origin).to eq 'SAL3'
-      expect(assigns[:request].origin_location).to eq 'STACKS'
+      expect(assigns[:request].origin_location).to eq 'SAL3-STACKS'
       expect(assigns[:request].item_id).to eq '1234'
       expect(assigns[:request].needed_date).to eq Time.zone.today + 1.year
     end
 
     it 'raises an error if the item is not provided' do
       expect do
-        get :new, params: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART' }
+        get :new, params: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART' }
       end.to raise_error(HoldRecallsController::NotHoldRecallableError)
     end
   end

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe MediatedPagesController do
   let(:mediated_page) { create(:mediated_page) }
   let(:normal_params) do
-    { item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL', destination: 'ART' }
+    { item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE', destination: 'ART' }
   end
 
   before do
@@ -25,13 +25,13 @@ RSpec.describe MediatedPagesController do
     it 'sets defaults' do
       get :new, params: normal_params
       expect(assigns[:request].origin).to eq 'ART'
-      expect(assigns[:request].origin_location).to eq 'ARTLCKL'
+      expect(assigns[:request].origin_location).to eq 'ART-LOCKED-LARGE'
       expect(assigns[:request].item_id).to eq '1234'
     end
 
     it 'raises an error if the item is unmediateable' do
       expect do
-        get :new, params: { item_id: '1234', origin: 'GREEN', origin_location: 'STACKS', destination: 'ART' }
+        get :new, params: { item_id: '1234', origin: 'GREEN', origin_location: 'GRE-STACKS', destination: 'ART' }
       end.to raise_error(MediatedPagesController::UnmediateableItemError)
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe MediatedPagesController do
       it 'redirects to the login page passing a referrer param to continue creating the mediated page request' do
         post :create, params: {
           request: {
-            item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL', destination: 'ART'
+            item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE', destination: 'ART'
           }
         }
         expect(response).to redirect_to(
@@ -51,7 +51,7 @@ RSpec.describe MediatedPagesController do
             referrer: interstitial_path(
               redirect_to: create_mediated_pages_url(
                 request: {
-                  item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL', destination: 'ART'
+                  item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE', destination: 'ART'
                 }
               )
             )
@@ -64,7 +64,7 @@ RSpec.describe MediatedPagesController do
           request: {
             item_id: '1234',
             origin: 'ART',
-            origin_location: 'ARTLCKL',
+            origin_location: 'ART-LOCKED-LARGE',
             destination: 'ART',
             needed_date: Time.zone.today + 1.year,
             user_attributes: { name: 'Jane Stanford', email: 'jstanford@stanford.edu' }
@@ -84,7 +84,7 @@ RSpec.describe MediatedPagesController do
           request: {
             item_id: '1234',
             origin: 'ART',
-            origin_location: 'ARTLCKL',
+            origin_location: 'ART-LOCKED-LARGE',
             destination: 'ART',
             needed_date: Time.zone.today + 1.year,
             user_attributes: { library_id: '12345' }
@@ -100,7 +100,7 @@ RSpec.describe MediatedPagesController do
         it 'is forbidden' do
           get :create, params: {
             request: {
-              item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL', destination: 'ART'
+              item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE', destination: 'ART'
             }
           }
           expect(response).to have_http_status(:forbidden)
@@ -116,7 +116,7 @@ RSpec.describe MediatedPagesController do
           request: {
             item_id: '1234',
             origin: 'ART',
-            origin_location: 'ARTLCKL',
+            origin_location: 'ART-LOCKED-LARGE',
             destination: 'ART',
             needed_date: Time.zone.today + 1.year
           }
@@ -132,7 +132,7 @@ RSpec.describe MediatedPagesController do
             request: {
               item_id: '1234',
               origin: 'ART',
-              origin_location: 'ARTLCKL',
+              origin_location: 'ART-LOCKED-LARGE',
               destination: 'ART',
               needed_date: Time.zone.today + 1.year
             }
@@ -148,7 +148,7 @@ RSpec.describe MediatedPagesController do
             request: {
               item_id: '1234',
               origin: 'ART',
-              origin_location: 'ARTLCKL',
+              origin_location: 'ART-LOCKED-LARGE',
               destination: 'ART',
               needed_date: Time.zone.today + 1.year
             }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PagesController do
   let(:normal_params) do
-    { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART' }
+    { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART' }
   end
 
   before do
@@ -24,13 +24,13 @@ RSpec.describe PagesController do
     it 'sets defaults' do
       get :new, params: normal_params
       expect(assigns[:request].origin).to eq 'SAL3'
-      expect(assigns[:request].origin_location).to eq 'STACKS'
+      expect(assigns[:request].origin_location).to eq 'SAL3-STACKS'
       expect(assigns[:request].item_id).to eq '1234'
     end
 
     it 'raises an error when the item is not pageable' do
       expect do
-        get :new, params: { item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS', destination: 'ART' }
+        get :new, params: { item_id: '1234', origin: 'SPEC-COLL', origin_location: 'SPEC-SAL-STACKS', destination: 'ART' }
       end.to raise_error(PagesController::UnpageableItemError)
     end
   end
@@ -41,13 +41,13 @@ RSpec.describe PagesController do
 
       it 'redirects to the login page passing a referrer param to continue creating the page request' do
         post :create, params: {
-          request: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART' }
+          request: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART' }
         }
         expect(response).to redirect_to(
           login_path(
             referrer: interstitial_path(
               redirect_to: create_pages_url(
-                request: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART' }
+                request: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART' }
               )
             )
           )
@@ -56,7 +56,7 @@ RSpec.describe PagesController do
 
       it 'strips any unselected barcodes out of the request (to reduce request size to our auth service)' do
         post :create, params: {
-          request: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART', barcodes: {
+          request: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART', barcodes: {
             '12345' => '0', '54321' => '1', '56789' => '0', '98765' => '1'
           } }
         }
@@ -65,7 +65,7 @@ RSpec.describe PagesController do
           login_path(
             referrer: interstitial_path(
               redirect_to: create_pages_url(
-                request: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART', barcodes: {
+                request: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART', barcodes: {
                   '54321' => '1', '98765' => '1'
                 } }
               )
@@ -79,7 +79,7 @@ RSpec.describe PagesController do
           request: {
             item_id: '1234',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             destination: 'ART',
             user_attributes: { name: 'Jane Stanford', email: 'jstanford@stanford.edu' }
           }
@@ -98,7 +98,7 @@ RSpec.describe PagesController do
           request: {
             item_id: '1234',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             destination: 'ART',
             user_attributes: { library_id: '12345' }
           }
@@ -123,7 +123,7 @@ RSpec.describe PagesController do
             request: {
               item_id: '1234',
               origin: 'SAL3',
-              origin_location: 'STACKS',
+              origin_location: 'SAL3-STACKS',
               destination: 'ART'
             }
           }
@@ -136,7 +136,7 @@ RSpec.describe PagesController do
             request: {
               item_id: '1234',
               origin: 'SAL3',
-              origin_location: 'STACKS',
+              origin_location: 'SAL3-STACKS',
               destination: 'ART',
               proxy: 'true'
             }
@@ -151,7 +151,7 @@ RSpec.describe PagesController do
             request: {
               item_id: '1234',
               origin: 'SAL3',
-              origin_location: 'STACKS',
+              origin_location: 'SAL3-STACKS',
               destination: 'ART',
               proxy: 'false'
             }
@@ -165,7 +165,7 @@ RSpec.describe PagesController do
       describe 'via get' do
         it 'is forbidden' do
           get :create, params: {
-            request: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART' }
+            request: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART' }
           }
           expect(response).to have_http_status(:forbidden)
         end
@@ -177,7 +177,7 @@ RSpec.describe PagesController do
 
       it 'is allowed' do
         post :create, params: {
-          request: { item_id: '1234', origin: 'SAL3', origin_location: 'STACKS', destination: 'ART' }
+          request: { item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS', destination: 'ART' }
         }
         expect(response).to redirect_to successful_page_path(Page.last)
         expect(Page.last.origin).to eq 'SAL3'
@@ -191,7 +191,7 @@ RSpec.describe PagesController do
           request: {
             item_id: '1234',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             destination: 'ART',
             barcodes: { '3610512345678' => '1', '3610587654321' => '0', '12345679' => '1' }
           }
@@ -209,7 +209,7 @@ RSpec.describe PagesController do
           request: {
             item_id: '1234',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             destination: 'ART',
             user_attributes: { library_id: '5432123' }
           }

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -4,16 +4,16 @@ require 'rails_helper'
 
 RSpec.describe RequestsController do
   let(:scannable_params) do
-    { item_id: '12345', origin: 'SAL3', origin_location: 'STACKS' }
+    { item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS' }
   end
   let(:unscannable_params) do
-    { item_id: '12345', origin: 'SAL3', origin_location: 'PAGE-LP' }
+    { item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-PAGE-LP' }
   end
   let(:mediated_page_params) do
-    { item_id: '12345', origin: 'ART', origin_location: 'ARTLCKL' }
+    { item_id: '12345', origin: 'ART', origin_location: 'ART-LOCKED-LARGE' }
   end
   let(:hold_recall_params) do
-    { item_id: '12345', barcode: '3610512345', origin: 'GREEN', origin_location: 'STACKS' }
+    { item_id: '12345', barcode: '3610512345', origin: 'GREEN', origin_location: 'GRE-STACKS' }
   end
 
   before do
@@ -28,7 +28,7 @@ RSpec.describe RequestsController do
         end.to raise_error(ActionController::ParameterMissing)
 
         expect do
-          get(:new, params: { origin: 'GREEN', origin_location: 'STACKS' })
+          get(:new, params: { origin: 'GREEN', origin_location: 'GRE-STACKS' })
         end.to raise_error(ActionController::ParameterMissing)
 
         expect do
@@ -41,7 +41,7 @@ RSpec.describe RequestsController do
       it 'are set' do
         get :new, params: hold_recall_params
         expect(assigns[:request].origin).to eq 'GREEN'
-        expect(assigns[:request].origin_location).to eq 'STACKS'
+        expect(assigns[:request].origin_location).to eq 'GRE-STACKS'
         expect(assigns[:request].item_id).to eq '12345'
         expect(assigns[:request].requested_barcode).to eq '3610512345'
       end
@@ -54,7 +54,7 @@ RSpec.describe RequestsController do
 
       it 'raises an error' do
         expect do
-          get(:new, params: { item_id: 'does_not_exist', origin: 'GREEN', origin_location: 'STACKS' })
+          get(:new, params: { item_id: 'does_not_exist', origin: 'GREEN', origin_location: 'GRE-STACKS' })
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -106,7 +106,8 @@ RSpec.describe RequestsController do
 
     describe 'for mediated pages' do
       let(:request) do
-        build(:request, origin: 'ART', origin_location: 'ARTLCKL', barcodes: ['12345678'], bib_data: build(:single_mediated_holding))
+        build(:request, origin: 'ART', origin_location: 'ART-LOCKED-LARGE', barcodes: ['12345678'],
+                        bib_data: build(:single_mediated_holding))
       end
 
       it 'delegates the request object' do
@@ -121,7 +122,7 @@ RSpec.describe RequestsController do
 
     describe 'for aeon pages' do
       let(:request) do
-        build(:request, origin: 'SPEC-COLL', origin_location: 'STACKS', bib_data: build(:special_collections_single_holding))
+        build(:request, origin: 'SPEC-COLL', origin_location: 'SPEC-STACKS', bib_data: build(:special_collections_single_holding))
       end
 
       it 'delegates the request object' do

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe ScansController do
-  let(:scan) { create(:scan, :with_holdings, origin: 'SAL3', origin_location: 'STACKS', barcodes: ['12345678']) }
+  let(:scan) { create(:scan, :with_holdings, origin: 'SAL3', origin_location: 'SAL3-STACKS', barcodes: ['12345678']) }
   let(:scannable_params) do
-    { item_id: '12345', origin: 'SAL3', origin_location: 'STACKS' }
+    { item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS' }
   end
 
   before do
@@ -25,7 +25,7 @@ RSpec.describe ScansController do
     it 'sets defaults' do
       get :new, params: scannable_params
       expect(assigns[:request].origin).to eq 'SAL3'
-      expect(assigns[:request].origin_location).to eq 'STACKS'
+      expect(assigns[:request].origin_location).to eq 'SAL3-STACKS'
       expect(assigns[:request].item_id).to eq '12345'
     end
 
@@ -41,12 +41,12 @@ RSpec.describe ScansController do
       let(:user) { create(:anon_user) }
 
       it 'redirects to the login page passing a refferrer param to continue creating your request' do
-        post :create, params: { request: { item_id: '12345', origin: 'GREEN', origin_location: 'STACKS' } }
+        post :create, params: { request: { item_id: '12345', origin: 'GREEN', origin_location: 'GRE-STACKS' } }
         expect(response).to redirect_to(
           login_path(
             referrer: interstitial_path(
               redirect_to: create_scans_url(
-                request: { item_id: '12345', origin: 'GREEN', origin_location: 'STACKS' }
+                request: { item_id: '12345', origin: 'GREEN', origin_location: 'GRE-STACKS' }
               )
             )
           )
@@ -58,7 +58,7 @@ RSpec.describe ScansController do
           request: {
             item_id: '12345',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             user_attributes: { name: 'Jane Stanford', email: 'jstanford@stanford.edu' }
           }
         }
@@ -70,7 +70,7 @@ RSpec.describe ScansController do
           request: {
             item_id: '12345',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             user_attributes: { library_id: '12345' }
           }
         }
@@ -79,7 +79,7 @@ RSpec.describe ScansController do
 
       describe 'via get' do
         it 'is forbidden' do
-          get :create, params: { request: { item_id: '12345', origin: 'GREEN', origin_location: 'STACKS' } }
+          get :create, params: { request: { item_id: '12345', origin: 'GREEN', origin_location: 'GRE-STACKS' } }
           expect(response).to have_http_status(:forbidden)
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe ScansController do
           request: {
             item_id: '12345',
             origin: 'SAL3',
-            origin_location: 'STACKS',
+            origin_location: 'SAL3-STACKS',
             barcodes: ['87654321'],
             section_title: 'Some really important chapter'
           }
@@ -133,7 +133,7 @@ RSpec.describe ScansController do
 
       it 'is bounced to a page workflow' do
         params = {
-          request: { item_id: '12345', origin: 'SAL3', origin_location: 'STACKS', barcodes: { '12345678' => '1' } }
+          request: { item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS', barcodes: { '12345678' => '1' } }
         }
         post(:create, params:)
         expect(flash[:error]).to include 'Scan-to-PDF not available'

--- a/spec/factories/hold_recalls.rb
+++ b/spec/factories/hold_recalls.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :hold_recall do
     item_id { '1234' }
     origin { 'GREEN' }
-    origin_location { 'STACKS' }
+    origin_location { 'GRE-STACKS' }
     requested_barcode { '36105212925395' }
     destination { 'GREEN' }
     item_title { 'Title of HoldRecall 1234' }
@@ -14,7 +14,7 @@ FactoryBot.define do
   factory :hold_recall_with_holdings, class: 'HoldRecall' do
     item_id { '1234' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     requested_barcode { '12345678' }
     destination { 'GREEN' }
     item_title { 'Title of HoldRecall 1234' }
@@ -25,7 +25,7 @@ FactoryBot.define do
   factory :hold_recall_with_holdings_folio, class: 'HoldRecall' do
     item_id { '1234' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     requested_barcode { '12345678' }
     destination { 'GREEN-LOAN' }
     item_title { 'Title of HoldRecall 1234' }

--- a/spec/factories/mediated_pages.rb
+++ b/spec/factories/mediated_pages.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   factory :mediated_page do
     item_id { '1234' }
     origin { 'ART' }
-    origin_location { 'ARTLCKL' }
+    origin_location { 'ART-LOCKED-LARGE' }
     destination { 'ART' }
     item_title { 'Title of MediatedPage 1234' }
     needed_date { Time.zone.today }
@@ -26,7 +26,7 @@ FactoryBot.define do
   factory :page_mp_mediated_page, class: 'MediatedPage' do
     item_id { '1234' }
     origin { 'SAL3' }
-    origin_location { 'PAGE-MP' }
+    origin_location { 'SAL3-PAGE-MP' }
     destination { 'EARTH-SCI' }
     item_title { 'Title of MediatedPage 1234' }
     needed_date { Time.zone.today }
@@ -37,7 +37,7 @@ FactoryBot.define do
   factory :mediated_page_with_single_holding, parent: :mediated_page do
     item_id { '12345' }
     origin { 'ART' }
-    origin_location { 'ARTLCKL' }
+    origin_location { 'ART-LOCKED-LARGE' }
     destination { 'ART' }
     needed_date { Time.zone.today }
     request_comment { long_comment }
@@ -57,7 +57,7 @@ FactoryBot.define do
   factory :mediated_page_with_holdings, parent: :mediated_page do
     item_id { '1234' }
     origin { 'ART' }
-    origin_location { 'ARTLCKL' }
+    origin_location { 'ART-LOCKED-LARGE' }
     destination { 'ART' }
     needed_date { Time.zone.today }
     request_comment { long_comment }
@@ -67,7 +67,7 @@ FactoryBot.define do
 
   factory :mediated_page_with_symphony_errors, class: 'MediatedPage', parent: :request_with_symphony_errors do
     origin { 'ART' }
-    origin_location { 'ARTLCKL' }
+    origin_location { 'ART-LOCKED-LARGE' }
     destination { 'ART' }
     needed_date { Time.zone.today }
     user factory: [:sequence_sso_user]

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :page do
     item_id { '1234' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     destination { 'ART' }
     item_title { 'Title for Page 1234' }
     bib_data { build(:sal3_stacks_searchworks_item) }
@@ -14,7 +14,7 @@ FactoryBot.define do
   factory :page_with_holdings, class: 'Page' do
     item_id { '1234' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     destination { 'ART' }
     bib_data { build(:multiple_holdings) }
   end
@@ -22,7 +22,7 @@ FactoryBot.define do
   factory :page_with_single_holding_multiple_items, class: 'Page' do
     item_id { '1234' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     destination { 'ART' }
     bib_data { build(:single_holding_multiple_items) }
   end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :request do
     item_id { '123456' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     item_title { 'Title for Request 123456' }
     bib_data { FactoryBot.build(:multiple_holdings) }
 
@@ -20,21 +20,21 @@ FactoryBot.define do
   factory :request_with_holdings, class: 'Request' do
     item_id { '12345' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     bib_data { FactoryBot.build(:single_holding) }
   end
 
   factory :request_with_multiple_holdings, class: 'Request' do
     item_id { '12345' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     bib_data { FactoryBot.build(:multiple_holdings) }
   end
 
   factory :request_with_symphony_errors, class: 'Request' do
     item_id { '123456' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     item_title { 'Title for Request 123456' }
 
     after(:build) do |request|

--- a/spec/factories/scans.rb
+++ b/spec/factories/scans.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :scan do
     item_id { '12345' }
     origin { 'SAL3' }
-    origin_location { 'STACKS' }
+    origin_location { 'SAL3-STACKS' }
     section_title { 'Section Title for Scan 12345' }
     page_range { '1-10' }
 

--- a/spec/features/create_aeon_page_request_spec.rb
+++ b/spec/features/create_aeon_page_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Creating an Aeon request', js: true do
   before do
     stub_current_user(user)
     stub_bib_data_json(build(bib_data))
-    visit new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS')
+    visit new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'SPEC-STACKS')
   end
 
   describe 'info modal' do
@@ -54,7 +54,7 @@ RSpec.describe 'Creating an Aeon request', js: true do
         end
 
         it 'includes the origin location of the item' do
-          expect(page).to have_field(type: 'hidden', name: 'Location', with: 'STACKS')
+          expect(page).to have_field(type: 'hidden', name: 'Location', with: 'SPEC-STACKS')
         end
 
         it 'includes the title of the item' do

--- a/spec/features/create_hold_recall_spec.rb
+++ b/spec/features/create_hold_recall_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Creating a hold recall request' do
         item_id: '1234',
         barcode: '12345678',
         origin: 'SAL3',
-        origin_location: 'STACKS'
+        origin_location: 'SAL3-STACKS'
       )
 
       visit form_path
@@ -34,7 +34,7 @@ RSpec.describe 'Creating a hold recall request' do
         item_id: '1234',
         barcode: '12345678',
         origin: 'SAL3',
-        origin_location: 'STACKS'
+        origin_location: 'SAL3-STACKS'
       )
       click_link "I don't have a SUNet ID"
 
@@ -54,7 +54,7 @@ RSpec.describe 'Creating a hold recall request' do
     end
 
     it 'is possible without filling in any user information' do
-      visit new_hold_recall_path(item_id: '1234', barcode: '12345678', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_hold_recall_path(item_id: '1234', barcode: '12345678', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       first(:button, 'Send request').click
 
       expect(current_url).to eq successful_hold_recall_url(HoldRecall.last)
@@ -62,7 +62,7 @@ RSpec.describe 'Creating a hold recall request' do
     end
 
     it 'stores barcode in the url in the barcodes array' do
-      visit new_hold_recall_path(item_id: '1234', barcode: '12345678', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_hold_recall_path(item_id: '1234', barcode: '12345678', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       first(:button, 'Send request').click
 
       expect(HoldRecall.last.barcodes).to eq ['12345678']

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Creating a mediated page request' do
 
   describe 'by an anonmyous user' do
     it 'is possible to toggle between login and name-email form', js: true do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       click_link "I don't have a SUNet ID"
 
@@ -30,7 +30,7 @@ RSpec.describe 'Creating a mediated page request' do
     end
 
     it 'is possible if a name and email is filled out', js: true do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 
@@ -44,7 +44,7 @@ RSpec.describe 'Creating a mediated page request' do
     end
 
     it 'is possible if a library id is filled out', js: true do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 
@@ -69,7 +69,7 @@ RSpec.describe 'Creating a mediated page request' do
     before { stub_current_user(user) }
 
     it 'is possible without filling in any user information' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 
@@ -85,7 +85,7 @@ RSpec.describe 'Creating a mediated page request' do
 
     it 'has a comments field for commentable libraries' do
       skip 'No commentable libraries as of 2022-09-22'
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 
@@ -100,7 +100,7 @@ RSpec.describe 'Creating a mediated page request' do
     end
 
     it 'does not include a comments for requests that do not get them' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       expect(page).not_to have_field('Comments')
     end
@@ -110,7 +110,7 @@ RSpec.describe 'Creating a mediated page request' do
     before { stub_current_user(user) }
 
     it 'has a field for the planned date of visit' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
       date = 1.day.from_now.to_date
 
       fill_in 'I plan to visit on', with: date
@@ -142,7 +142,7 @@ RSpec.describe 'Creating a mediated page request' do
     end
 
     it 'persists to the database' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Creating a page request' do
 
   context 'when initiated by an anonmyous user' do
     it 'is possible if a name and email is filled out', js: true do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       click_link "I don't have a SUNet ID"
 
       expect(page).to have_css('input#request_user_attributes_library_id')
@@ -32,7 +32,7 @@ RSpec.describe 'Creating a page request' do
       end
 
       it 'creates a new user', js: true do
-        visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+        visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
         click_link "I don't have a SUNet ID"
 
         fill_in 'Library ID', with: '123456'
@@ -52,7 +52,7 @@ RSpec.describe 'Creating a page request' do
     before { stub_current_user(user) }
 
     it 'is possible without filling in any user information' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       first(:button, 'Send request').click
 
       expect(current_url).to eq successful_page_url(Page.last)
@@ -70,7 +70,7 @@ RSpec.describe 'Creating a page request' do
     end
 
     it 'allows the user to share with their proxy group' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       first(:button, 'Send request').click
 
       expect(page).to have_css('h1#dialogTitle', text: 'Share with your proxy group?')
@@ -82,7 +82,7 @@ RSpec.describe 'Creating a page request' do
     end
 
     it 'allows the user to keep the request private' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       first(:button, 'Send request').click
 
       expect(page).to have_css('h1#dialogTitle', text: 'Share with your proxy group?')
@@ -103,7 +103,7 @@ RSpec.describe 'Creating a page request' do
     end
 
     it 'persists to the database' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       within('#item-selector') do
         check('ABC 123')

--- a/spec/features/create_scan_spec.rb
+++ b/spec/features/create_scan_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Create Scan Request' do
   it 'does not display a destination pickup' do
     stub_current_user(create(:sso_user))
 
-    visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+    visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
     expect(page).not_to have_select('request_destination')
     expect(page).not_to have_content('Deliver to')
@@ -24,7 +24,7 @@ RSpec.describe 'Create Scan Request' do
   it 'does not include the highlighted section around destination and needed date' do
     stub_current_user(create(:sso_user))
 
-    visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+    visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
     expect(page).not_to have_css('.alert-warning.destination-note-callout')
   end
@@ -35,7 +35,7 @@ RSpec.describe 'Create Scan Request' do
     end
 
     it 'displays a copyright restrictions notice in a collapse' do
-      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_content 'Notice concerning copyright restrictions'
       expect(page).to have_content 'The copyright law of the United States'
@@ -44,14 +44,14 @@ RSpec.describe 'Create Scan Request' do
 
   describe 'by non SSO user' do
     it 'provides a link to page the item' do
-      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_link 'Request the physical item'
 
       click_link 'Request the physical item'
 
       expect(page).to have_css('h1#dialogTitle', text: 'Request & pickup service')
-      expect(current_url).to eq new_page_url(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      expect(current_url).to eq new_page_url(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
   end
 end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Home Page' do
 
     it 'has admin links for the library level mediation' do
       expect(page).to have_link('Art & Architecture Library (Bowes)', href: '/admin/ART')
-      expect(page).to have_link('Earth Sciences Library (Branner)', href: '/admin/PAGE-MP')
+      expect(page).to have_link('Earth Sciences Library (Branner)', href: '/admin/SAL3-PAGE-MP')
     end
   end
 end

--- a/spec/features/honey_pot_field_spec.rb
+++ b/spec/features/honey_pot_field_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Honey Pot Fields' do
 
   context 'Email field' do
     it 'raises an error if the field has been filled out' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       hidden_field = find_by_id('email', visible: :hidden)
       hidden_field.set('some-email')

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Item Selector' do
     before { stub_bib_data_json(build(:single_holding)) }
 
     it 'displays the item call number' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       expect(page).to have_css('.control-label', text: 'Call number')
       expect(page).to have_css('p', text: 'ABC 123')
       expect(page).not_to have_css('#item-selector')
@@ -20,7 +20,7 @@ RSpec.describe 'Item Selector' do
 
   describe 'for multiple items', js: true do
     describe 'where there are not enough to be searchable' do
-      let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS') }
+      let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS') }
 
       before do
         stub_bib_data_json(build(:multiple_holdings))
@@ -53,7 +53,7 @@ RSpec.describe 'Item Selector' do
 
     describe 'item limits' do
       describe 'for scans' do
-        let(:request_path) { new_scan_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS') }
+        let(:request_path) { new_scan_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS') }
 
         before do
           stub_bib_data_json(build(:scannable_holdings))
@@ -73,7 +73,7 @@ RSpec.describe 'Item Selector' do
       end
 
       describe 'for pages' do
-        let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS') }
+        let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS') }
 
         before do
           stub_bib_data_json(build(:many_holdings))
@@ -97,7 +97,7 @@ RSpec.describe 'Item Selector' do
       end
 
       describe 'for aeon pages', js: true do
-        let(:request_path) { new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'STACKS') }
+        let(:request_path) { new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'SPEC-STACKS') }
 
         before do
           stub_bib_data_json(build(:searchable_spec_holdings))
@@ -152,7 +152,7 @@ RSpec.describe 'Item Selector' do
         visit request_path
       end
 
-      let(:request_path) { new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL') }
+      let(:request_path) { new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE') }
 
       it 'limits items using the search box' do
         within('#item-selector') do
@@ -241,7 +241,7 @@ RSpec.describe 'Item Selector' do
     xit 'still limits selections' do
       skip('The CDN we load the date slider from seems to block Travis') if ENV['ci']
 
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_date
 
@@ -279,7 +279,7 @@ RSpec.describe 'Item Selector' do
     end
 
     it 'are addable and removable' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).not_to have_css('#breadcrumb-12345678', text: 'ABC 123')
       expect(page).not_to have_css('#breadcrumb-23456789', text: 'ABC 456')
@@ -311,7 +311,7 @@ RSpec.describe 'Item Selector' do
   describe 'checked out items', js: true do
     before do
       stub_bib_data_json(build(:checkedout_holdings))
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
 
     it 'has the due date' do
@@ -330,7 +330,7 @@ RSpec.describe 'Item Selector' do
   end
 
   describe 'public notes' do
-    let(:request_path) { new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL') }
+    let(:request_path) { new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE') }
 
     before do
       stub_bib_data_json(build(:searchable_holdings))
@@ -356,7 +356,7 @@ RSpec.describe 'Item Selector' do
   context 'when some items are not requestable' do
     before do
       stub_bib_data_json(build(:mixed_crez_holdings))
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
 
     it 'allows selecting the requestable items' do
@@ -375,7 +375,7 @@ RSpec.describe 'Item Selector' do
   context 'when items are in a temporary location' do
     before do
       stub_bib_data_json(build(:mixed_crez_holdings))
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
 
     it 'shows the temporary location discovery display name as the status text if the item is not requestable' do
@@ -388,7 +388,7 @@ RSpec.describe 'Item Selector' do
   context 'when items are hold/recallable' do
     before do
       stub_bib_data_json(build(:missing_holdings))
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
 
     it 'shows the item status as the status text' do

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Library Instructions' do
   end
 
   it 'returns the library instructions from the Settings' do
-    visit new_request_path(item_id: '12345', origin: 'EDUCATION', origin_location: 'STACKS')
+    visit new_request_path(item_id: '12345', origin: 'EDUCATION', origin_location: 'EDU-STACKS')
     within('p.needed-date-info-block') do
       expect(page).to have_content('The Education Library is closed for construction. Request items for pickup at another library.')
     end

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe 'Mediation table', js: true do
         create(:page_mp_mediated_page, created_at: cdate, barcodes: ['12345678'])
         req = create(:page_mp_mediated_page, created_at: cdate, barcodes: ['12345678'])
         req.approved!
-        visit admin_path('PAGE-MP')
+        visit admin_path('SAL3-PAGE-MP')
         page.execute_script("$('input#created_at').prop('value', '#{cdate}')")
         click_button('Go')
         # there are no mixed approvals
@@ -496,7 +496,7 @@ RSpec.describe 'Mediation table', js: true do
       stub_bib_data_json(build(:page_mp_holdings))
       request.save(validate: false)
 
-      visit admin_path('PAGE-MP')
+      visit admin_path('SAL3-PAGE-MP')
     end
 
     it 'has toggleable rows that display holdings' do

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'Viewing all requests' do
     end
 
     it 'displays the broadcast message' do
-      visit new_mediated_page_path(item_id: '1234', origin: message.library, origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: message.library, origin_location: 'ART-LOCKED-LARGE')
       expect(page).to have_content message.text
     end
   end

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Paging Schedule' do
     end
 
     it 'displays the estimate for the currently selected value and updates it when a new destination is selected' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_select('request_destination', selected: 'Green Library')
 
@@ -61,7 +61,7 @@ RSpec.describe 'Paging Schedule' do
     end
 
     it 'is persisted' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
       schedule_text = find('[data-scheduler-text]').text
@@ -93,7 +93,7 @@ RSpec.describe 'Paging Schedule' do
     end
 
     it 'displays an estimate for the single possible destination' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'PAGE-EN')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-PAGE-EN')
 
       expect(page).not_to have_select('request_destination')
       expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
@@ -108,7 +108,7 @@ RSpec.describe 'Paging Schedule' do
     end
 
     it 'shows the estimated delivery for Green Library' do
-      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       within('#deliveryDescription') do
         expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
@@ -122,7 +122,7 @@ RSpec.describe 'Paging Schedule' do
     end
 
     it 'shows the estimated delivery for the Scanning service' do
-      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
     end

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
 
   describe 'for multiple libraries' do
     it 'has a select dropdown to choose the library to deliver to' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_select('Deliver to')
 
@@ -39,7 +39,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
       end
 
       it 'simplfies the display of the text of the destination library if there is only one possible' do
-        visit new_request_path(item_id: '1234', origin: 'SAL3', origin_location: 'PAGE-EN')
+        visit new_request_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-PAGE-EN')
 
         expect(page).not_to have_css('select')
 
@@ -52,7 +52,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
   describe 'libraries that should include themself in the pickup list' do
     context 'a standard library' do
       it 'does not include the configured library in the drop down' do
-        visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+        visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
         expect(page).to have_css('#request_destination option', count: standard_pickup_lib_total)
         expect(page).not_to have_css('option', text: media_label)
@@ -69,7 +69,7 @@ RSpec.describe 'Pickup Libraries Dropdown' do
       end
 
       it 'appear in the drop down' do
-        visit new_request_path(item_id: '1234', origin: media_library, origin_location: 'MM-STACKS')
+        visit new_request_path(item_id: '1234', origin: media_library, origin_location: 'MEDIA-CAGE')
 
         expect(page).to have_css('#request_destination option', count: standard_pickup_lib_total + 1)
         expect(page).to have_css('option', text: media_label)

--- a/spec/features/requests_delegation_spec.rb
+++ b/spec/features/requests_delegation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Requests Delegation' do
       stub_bib_data_json(build(:green_holdings))
 
       expect do
-        visit new_request_path(item_id: '12345', origin: 'GREEN', origin_location: 'STACKS')
+        visit new_request_path(item_id: '12345', origin: 'GREEN', origin_location: 'GRE-STACKS')
       end.to raise_error(PagesController::UnpageableItemError)
     end
   end
@@ -16,27 +16,27 @@ RSpec.describe 'Requests Delegation' do
   describe 'non-scannable materials' do
     it 'is automatically delegated to the page request form' do
       stub_bib_data_json(build(:page_lp_holdings))
-      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'PAGE-LP')
+      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-PAGE-LP')
 
       expect(page).to have_css('h1#dialogTitle', text: 'Request & pickup service')
-      expect(current_url).to eq new_page_url(item_id: '12345', origin: 'SAL3', origin_location: 'PAGE-LP')
+      expect(current_url).to eq new_page_url(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-PAGE-LP')
     end
   end
 
   describe 'mediated page materials' do
     it 'automatically delegate to the mediated page request form' do
       stub_bib_data_json(build(:single_mediated_holding))
-      visit new_request_path(item_id: '12345', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_request_path(item_id: '12345', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       expect(page).to have_css('h1#dialogTitle', text: 'Request on-site access')
-      expect(current_url).to eq new_mediated_page_url(item_id: '12345', origin: 'ART', origin_location: 'ARTLCKL')
+      expect(current_url).to eq new_mediated_page_url(item_id: '12345', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
     end
   end
 
   describe 'scannable materials' do
     it 'is given the opportunity to request a scan or delivery' do
       stub_bib_data_json(build(:scannable_holdings))
-      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       expect(page).to have_css('h1#dialogTitle', text: 'Request options')
 

--- a/spec/features/requests_public_notes_spec.rb
+++ b/spec/features/requests_public_notes_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Public Notes', js: true do
     end
 
     it 'persists to the database as hash of barcode=>note pairs' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Send Request Buttons' do
     before { stub_current_user(create(:sso_user)) }
 
     it 'allows submit' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       click_button 'Send request'
 
@@ -35,7 +35,7 @@ RSpec.describe 'Send Request Buttons' do
 
   describe 'by anonymous user', js: true do
     it 'is possible to toggle between login and name-email form' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       click_link 'I don\'t have a SUNet ID'
 
       expect(page).to have_field('Name', type: 'text')
@@ -47,7 +47,7 @@ RSpec.describe 'Send Request Buttons' do
     end
 
     it 'disables the submit button (and adds a tooltip) when additional user validation is needed' do
-      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       click_link 'I don\'t have a SUNet ID'
 
       expect(page).to have_field('Library ID', type: 'text')
@@ -71,7 +71,7 @@ RSpec.describe 'Send Request Buttons' do
 
   describe 'for HOPKINS' do
     it 'allows to send request via SSO login or a SUNet ID' do
-      visit new_page_path(item_id: '1234', origin: 'HOPKINS', origin_location: 'STACKS')
+      visit new_page_path(item_id: '1234', origin: 'MARINE-BIO', origin_location: 'MAR-STACKS')
       expect(page).to have_css('button', text: /Send request.*login with SUNet ID/)
       expect(page).to have_css('a', text: 'I don\'t have a SUNet ID')
     end
@@ -80,7 +80,7 @@ RSpec.describe 'Send Request Buttons' do
   describe 'Scans' do
     before do
       stub_bib_data_json(build(:scannable_holdings))
-      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'STACKS')
+      visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
 
     it 'only allows to send request via SSO login' do
@@ -95,7 +95,7 @@ RSpec.describe 'Send Request Buttons' do
 
   describe 'HoldRecall', js: true do
     before do
-      visit new_hold_recall_path(item_id: '1234', barcode: '3610512345', origin: 'GREEN', origin_location: 'STACKS')
+      visit new_hold_recall_path(item_id: '1234', barcode: '3610512345', origin: 'GREEN', origin_location: 'GRE-STACKS')
     end
 
     it 'allows to send requests via SUNet ID' do
@@ -122,7 +122,7 @@ RSpec.describe 'Send Request Buttons' do
     end
 
     it 'allows users to submit without a SUNet ID' do
-      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ARTLCKL')
+      visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
       expect(page).to have_css('a', text: 'I don\'t have a SUNet ID')
     end
   end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RequestsHelper do
     end
 
     describe 'single library' do
-      let(:request) { build(:request, origin: 'SAL3', origin_location: 'PAGE-EN', bib_data:) }
+      let(:request) { build(:request, origin: 'SAL3', origin_location: 'SAL3-PAGE-EN', bib_data:) }
       let(:item) do
         build(:item,
               barcode: '3610512345678',
@@ -34,7 +34,7 @@ RSpec.describe RequestsHelper do
     end
 
     describe 'multiple libraries' do
-      let(:request) { create(:request, origin: 'SAL3', origin_location: 'PAGE-HP') }
+      let(:request) { create(:request, origin: 'SAL3', origin_location: 'SAL3-PAGE-HP') }
 
       it 'attempts to create a select list' do
         expect(form).to receive(:select).with(any_args).and_return('<select>')
@@ -42,7 +42,7 @@ RSpec.describe RequestsHelper do
       end
 
       context 'with a destination' do
-        let(:request) { create(:request, origin: 'SAL3', destination: 'ART', origin_location: 'PAGE-HP') }
+        let(:request) { create(:request, origin: 'SAL3', destination: 'ART', origin_location: 'SAL3-PAGE-HP') }
 
         it 'defaults to the destination library' do
           expect(form).to receive(:select).with(anything, anything, hash_including(selected: 'ART'), anything)
@@ -177,7 +177,7 @@ RSpec.describe RequestsHelper do
     end
 
     context 'when the item is available' do
-      let(:origin_location) { 'HOPKINS' }
+      let(:origin_location) { 'MARINE-BIO' }
       let(:holding) do
         Folio::Item.new(
           barcode: '123',
@@ -190,7 +190,7 @@ RSpec.describe RequestsHelper do
         )
       end
 
-      it { is_expected.to eq 'HOPKINS' }
+      it { is_expected.to eq 'MARINE-BIO' }
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -243,11 +243,11 @@ RSpec.describe Ability do
     let(:user) { create(:page_mp_origin_admin_user) }
 
     before do
-      request.origin_location = 'PAGE-MP'
-      hold_recall.origin_location = 'PAGE-MP'
-      mediated_page.origin_location = 'PAGE-MP'
-      page.origin_location = 'PAGE-MP'
-      scan.origin_location = 'PAGE-MP'
+      request.origin_location = 'SAL3-PAGE-MP'
+      hold_recall.origin_location = 'SAL3-PAGE-MP'
+      mediated_page.origin_location = 'SAL3-PAGE-MP'
+      page.origin_location = 'SAL3-PAGE-MP'
+      scan.origin_location = 'SAL3-PAGE-MP'
     end
 
     # can manage locations that they are an admin of

--- a/spec/models/concerns/mediateable_spec.rb
+++ b/spec/models/concerns/mediateable_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Mediateable' do
 
     it 'returns true if the item is in SAL3 and PAGE-MP location' do
       subject.origin = 'SAL3'
-      subject.origin_location = 'PAGE-MP'
+      subject.origin_location = 'SAL3-PAGE-MP'
       subject.bib_data = build(:page_mp_holdings)
       expect(subject).to be_mediateable
     end
@@ -20,14 +20,14 @@ RSpec.describe 'Mediateable' do
     describe 'ART Locked Stacks' do
       it 'returns true if the item is in a locked stacks location within ART' do
         subject.origin = 'ART'
-        subject.origin_location = 'ARTLCKL'
+        subject.origin_location = 'ART-LOCKED-LARGE'
         subject.bib_data = build(:single_mediated_holding)
         expect(subject).to be_mediateable
       end
 
       it 'returns false if the item is in a non-locked stacks location within ART' do
         subject.origin = 'ART'
-        subject.origin_location = 'STACKS'
+        subject.origin_location = 'ART-STACKS'
         subject.bib_data = build(:art_stacks_holding)
         expect(subject).not_to be_mediateable
       end

--- a/spec/models/concerns/pageable_spec.rb
+++ b/spec/models/concerns/pageable_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Pageable' do
     context 'when the LibraryLocation is not mediatable or hold recallable' do
       before do
         request.origin = 'SAL3'
-        request.origin_location = 'STACKS'
+        request.origin_location = 'SAL3-STACKS'
       end
 
       it { is_expected.to be_pageable }
@@ -22,7 +22,7 @@ RSpec.describe 'Pageable' do
 
     it 'is false if the LibraryLocation is mediatable' do
       request.origin = 'SPEC-COLL'
-      request.origin_location = 'STACKS'
+      request.origin_location = 'SPEC-STACKS'
       expect(request).not_to be_pageable
     end
   end

--- a/spec/models/concerns/scannable_spec.rb
+++ b/spec/models/concerns/scannable_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Scannable' do
   subject(:request) { build(:request, origin: library, origin_location: location, bib_data:) }
 
   let(:library) { 'SAL3' }
-  let(:location) { 'STACKS' }
+  let(:location) { 'SAL3-STACKS' }
   let(:item_type) { 'STKS' }
   let(:bib_data) { build(:scannable_holdings) }
 
@@ -26,7 +26,7 @@ RSpec.describe 'Scannable' do
     end
 
     context 'when the location is not scannable' do
-      let(:location) { 'PAGE-LP' }
+      let(:location) { 'SAL3-PAGE-LP' }
       let(:bib_data) { build(:page_lp_holdings) }
 
       it { is_expected.not_to be_scannable }

--- a/spec/models/folio/holdings_spec.rb
+++ b/spec/models/folio/holdings_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Folio::Holdings do
   subject(:holdings) { described_class.new(request, items) }
 
-  let(:request) { HoldRecall.new(barcode: '36105237669143', item_id: '14820051', origin: 'MUSIC', origin_location: 'RECORDINGS') }
+  let(:request) { HoldRecall.new(barcode: '36105237669143', item_id: '14820051', origin: 'MUSIC', origin_location: 'MUS-RECORDINGS') }
   let(:items) { [item] }
   let(:item) do
     Folio::Item.new(barcode: '123',
@@ -45,7 +45,7 @@ RSpec.describe Folio::Holdings do
     end
 
     context 'for a request with the permanent location' do
-      let(:request) { Page.new(item_id: '14820051', origin: 'SAL3', origin_location: 'STACKS') }
+      let(:request) { Page.new(item_id: '14820051', origin: 'SAL3', origin_location: 'SAL3-STACKS') }
 
       it 'excludes items with an effective location that does not match the requested location' do
         expect(holdings.to_a).to be_blank

--- a/spec/models/illiad_request_spec.rb
+++ b/spec/models/illiad_request_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe IlliadRequest do
 
       it 'includes the location' do
         expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"ReferenceNumber":"STACKS"/)).to have_been_made
+        .with(body: /"ReferenceNumber":"SAL3-STACKS"/)).to have_been_made
       end
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'SAL3',
-          origin_location: 'STACKS',
+          origin_location: 'SAL3-STACKS',
           barcodes:
         )
       end
@@ -62,7 +62,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS',
+          origin_location: 'SAL3-STACKS',
           needed_date: Time.zone.today - 1.day
         )
       end
@@ -295,7 +295,7 @@ RSpec.describe Request do
 
     context 'when the origin is PAGE-SP' do
       before do
-        request.origin_location = 'PAGE-SP'
+        request.origin_location = 'SAL3-PAGE-SP'
       end
 
       it { is_expected.to eq 5 }
@@ -317,7 +317,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS'
+          origin_location: 'GRE-STACKS'
         )
         expect(described_class.last.user).to eq User.last
       end
@@ -327,7 +327,7 @@ RSpec.describe Request do
         described_class.create(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS',
+          origin_location: 'GRE-STACKS',
           user_attributes: {
             name: 'Jane Stanford',
             email: 'jstanford@stanford.edu'
@@ -343,7 +343,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS',
+          origin_location: 'GRE-STACKS',
           user_attributes: {
             name: 'Jane Stanford',
             email: 'jstanford@stanford.edu'
@@ -359,7 +359,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS',
+          origin_location: 'GRE-STACKS',
           user_attributes: {
             name: 'Jane Stanford',
             email: 'jstanford@stanford.edu'
@@ -376,7 +376,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS',
+          origin_location: 'GRE-STACKS',
           user_attributes: {
             library_id: '12345',
             email: 'jstanford@stanford.edu'
@@ -395,7 +395,7 @@ RSpec.describe Request do
           described_class.create!(
             item_id: '1234',
             origin: 'GREEN',
-            origin_location: 'STACKS',
+            origin_location: 'GRE-STACKS',
             user_attributes: {
               name: 'Jane Stanford',
               email: 'jstanford@stanford.edu'
@@ -411,7 +411,7 @@ RSpec.describe Request do
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
-          origin_location: 'STACKS',
+          origin_location: 'GRE-STACKS',
           user_attributes: {
             library_id: '12345'
           }
@@ -429,14 +429,14 @@ RSpec.describe Request do
       end
 
       it 'fetches the item title' do
-        described_class.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'STACKS')
+        described_class.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'GRE-STACKS')
         expect(described_class.last.item_title).to eq 'When do you need an antacid? : a burning question'
       end
     end
 
     context 'when the title is present' do
       it 'does not fetch the title' do
-        described_class.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'STACKS', item_title: 'This title')
+        described_class.create!(item_id: '2824966', origin: 'GREEN', origin_location: 'GRE-STACKS', item_title: 'This title')
         expect(described_class.last.item_title).to eq 'This title'
       end
     end
@@ -455,7 +455,7 @@ RSpec.describe Request do
   describe '#delegate_request!' do
     before do
       stub_bib_data_json(build(:multiple_holdings))
-      subject.update(origin: 'SAL3', origin_location: 'STACKS')
+      subject.update(origin: 'SAL3', origin_location: 'SAL3-STACKS')
     end
 
     it 'delegates to a mediated page if it is mediateable' do
@@ -601,7 +601,7 @@ RSpec.describe Request do
     end
 
     it 'returns the subset of origin codes that are configured and mediated pages that exist in the database' do
-      expect(described_class.mediateable_origins.to_h.keys).to eq %w(ART PAGE-MP)
+      expect(described_class.mediateable_origins.to_h.keys).to eq %w(ART SAL3-PAGE-MP)
     end
   end
 
@@ -668,14 +668,14 @@ RSpec.describe Request do
 
   describe '#default_pickup_destination' do
     it 'sets an origin specific default' do
-      request = described_class.new(origin: 'LAW', origin_location: 'STACKS',
+      request = described_class.new(origin: 'LAW', origin_location: 'LAW-STACKS',
                                     bib_data: double(request_holdings: [build(:item, effective_location: build(:law_location))]))
 
       expect(request.default_pickup_destination).to eq 'LAW'
     end
 
     it 'falls back to a default location' do
-      request = described_class.new(origin: 'ART', origin_location: 'STACKS')
+      request = described_class.new(origin: 'ART', origin_location: 'ART-STACKS')
 
       expect(request.default_pickup_destination).to eq default_destination
     end

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MediatedPage do
       expect do
         described_class.create!(item_id: '1234',
                                 origin: 'GREEN',
-                                origin_location: 'STACKS',
+                                origin_location: 'GRE-STACKS',
                                 destination: 'ART',
                                 needed_date: Time.zone.today + 1.day)
       end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: This item is not mediatable')
@@ -30,7 +30,7 @@ RSpec.describe MediatedPage do
         described_class.create!(item_id: '1234',
                                 barcodes: ['12345678'],
                                 origin: 'ART',
-                                origin_location: 'ARTLCKL',
+                                origin_location: 'ART-LOCKED-LARGE',
                                 destination: 'GREEN',
                                 needed_date: Time.zone.today + 1.day,
                                 bib_data: build(:single_mediated_holding))
@@ -42,7 +42,7 @@ RSpec.describe MediatedPage do
         described_class.create!(item_id: '1234',
                                 barcodes: ['12345678'],
                                 origin: 'ART',
-                                origin_location: 'ARTLCKL',
+                                origin_location: 'ART-LOCKED-LARGE',
                                 destination: 'ART',
                                 bib_data: build(:single_mediated_holding))
       end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: I plan to visit on can't be blank")
@@ -52,7 +52,7 @@ RSpec.describe MediatedPage do
       expect do
         described_class.create!(item_id: '1234',
                                 origin: 'SAL3',
-                                origin_location: 'PAGE-MP',
+                                origin_location: 'SAL3-PAGE-MP',
                                 user:,
                                 destination: 'EARTH-SCI',
                                 item_title: 'foo',
@@ -115,7 +115,7 @@ RSpec.describe MediatedPage do
     describe 'for_origin' do
       it 'returns the records for a given origin' do
         expect(described_class.for_origin('ART').length).to eq 3
-        expect(described_class.for_origin('PAGE-MP').length).to eq 2
+        expect(described_class.for_origin('SAL3-PAGE-MP').length).to eq 2
       end
     end
   end
@@ -177,6 +177,11 @@ RSpec.describe MediatedPage do
       expect(subject).not_to be_requires_needed_date
     end
 
+    it 'is false when the origin location is SAL3-PAGE-MP' do
+      subject.origin_location = 'SAL3-PAGE-MP'
+      expect(subject).not_to be_requires_needed_date
+    end
+
     it 'is true when otherwise' do
       expect(subject).to be_requires_needed_date
     end
@@ -230,10 +235,10 @@ RSpec.describe MediatedPage do
     end
 
     it 'fetches email addresses for origin locations' do
-      subject.origin_location = 'PAGE-MP'
+      subject.origin_location = 'SAL3-PAGE-MP'
       expect(
         subject.mediator_notification_email_address
-      ).to eq SULRequests::Application.config.mediator_contact_info['PAGE-MP'][:email]
+      ).to eq SULRequests::Application.config.mediator_contact_info['SAL3-PAGE-MP'][:email]
     end
   end
 

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Page do
         described_class.create!(
           item_id: '1234',
           origin: 'ART',
-          origin_location: 'ARTLCKL',
+          origin_location: 'ART-LOCKED-LARGE',
           destination: 'ART',
           bib_data: build(:single_mediated_holding)
         )
@@ -29,7 +29,7 @@ RSpec.describe Page do
 
     it 'does not not allow pages to be created with destinations that are not valid pickup libraries of their origin' do
       expect do
-        described_class.create!(item_id: '1234', origin: 'SAL3', origin_location: 'PAGE-LP', destination: 'GREEN',
+        described_class.create!(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-PAGE-LP', destination: 'GREEN',
                                 bib_data: build(:page_lp_holdings))
       end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Destination is not a valid pickup library')
     end
@@ -60,7 +60,7 @@ RSpec.describe Page do
     let(:subject) do
       described_class.create(
         origin: 'SAL3',
-        origin_location: 'STACKS',
+        origin_location: 'SAL3-STACKS',
         destination:,
         item_id: 'abc123',
         item_title: 'foo',

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Scan do
     expect do
       described_class.create!(item_id: '1234',
                               origin: 'GREEN',
-                              origin_location: 'STACKS',
+                              origin_location: 'GRE-STACKS',
                               section_title: 'Some chapter title',
                               item_title: 'foo')
     end.to raise_error(

--- a/spec/views/hold_recalls/_header.html.erb_spec.rb
+++ b/spec/views/hold_recalls/_header.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'hold_recalls/_header.html.erb' do
   let(:origin) { 'GREEN' }
-  let(:origin_location) { 'STACKS' }
+  let(:origin_location) { 'GRE-STACKS' }
   let(:current_request) do
     double('request', origin_library_code: origin, origin_location:, holdings:)
   end

--- a/spec/views/mediated_pages/_header.html.erb_spec.rb
+++ b/spec/views/mediated_pages/_header.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'mediated_pages/_header.html.erb' do
   let(:origin) { 'GREEN' }
-  let(:origin_location) { 'STACKS' }
+  let(:origin_location) { 'GRE-STACKS' }
   let(:holdings) { [] }
   let(:current_request) do
     double('request', origin_library_code: origin, origin_location:, holdings:)
@@ -24,7 +24,7 @@ RSpec.describe 'mediated_pages/_header.html.erb' do
   end
 
   describe 'location level titles' do
-    let(:origin_location) { 'PAGE-MP' }
+    let(:origin_location) { 'SAL3-PAGE-MP' }
 
     it 'are returned when present' do
       render


### PR DESCRIPTION
- Include FOLIO location codes where Symphony location codes are being used
- Fallback on the provided location code (assuming it's a FOLIO code) if the Symphony mapping fails
- Update tests to use the FOLIO location codes (on the assumption we'll switch to FOLIO codes soon enough)

This sets us up for #1789, without having to refactor the world just yet.