### PR TITLE
Add real ldap groups to the settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ so your `config/settings/development.local.yml` file might look like:
 ```
 fake_ldap_attributes:
   (your sunet id):
-    eduPersonEntitlement: 'mine:mine'
-
-super_admin_groups: ['mine:mine']
+    eduPersonEntitlement: 'sul:requests-super-admin'
 ```
 
 this will assign you the relevant LDAP attributes when you run a server using `REMOTE_USER=(your sunet id) rails s`.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # LDAP Workgroups for site-adminstrators
-super_admin_groups: []
-site_admin_groups: []
+super_admin_groups: ['sul:requests-super-admin']
+site_admin_groups: ['sul:requests-site-admin']
+
 scan_pilot_groups:
   - 'stanford:student'
   - 'stanford:student:postdoc'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,3 @@
-super_admin_groups: ['FAKE-TEST-SUPER-ADMIN-GROUP']
-site_admin_groups: ['FAKE-TEST-SITE-ADMIN-GROUP']
-
 destination_admin_groups:
   FAKE-DESTINATION-LIBRARY: ['FAKE-DESTINATION-LIBRARY-TEST-LDAP-GROUP']
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,14 +5,14 @@ FactoryBot.define do
     sunetid { 'super-admin' }
     email { 'super-admin@stanford.edu' }
     after(:build) do |user|
-      user.ldap_group_string = 'FAKE-TEST-SUPER-ADMIN-GROUP'
+      user.ldap_group_string = 'sul:requests-super-admin'
     end
   end
 
   factory :site_admin_user, class: 'User' do
     sunetid { 'site-admin' }
     after(:build) do |user|
-      user.ldap_group_string = 'FAKE-TEST-SITE-ADMIN-GROUP'
+      user.ldap_group_string = 'sul:requests-site-admin'
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe User do
     end
 
     it 'returns true when the user is in a superadmin group' do
-      allow(subject).to receive_messages(ldap_groups: ['FAKE-TEST-SUPER-ADMIN-GROUP'])
+      allow(subject).to receive_messages(ldap_groups: ['sul:requests-super-admin'])
       expect(subject).to be_super_admin
     end
   end
@@ -184,7 +184,7 @@ RSpec.describe User do
     end
 
     it 'returns true when the user is in a site admin group' do
-      allow(subject).to receive_messages(ldap_groups: ['FAKE-TEST-SITE-ADMIN-GROUP'])
+      allow(subject).to receive_messages(ldap_groups: ['sul:requests-site-admin'])
       expect(subject).to be_site_admin
     end
   end


### PR DESCRIPTION
We always use these groups, so this makes it easier to approximate production from a development/test machine