### PR TITLE
Consolidate request tests

### DIFF
--- a/spec/models/illiad_request_spec.rb
+++ b/spec/models/illiad_request_spec.rb
@@ -47,91 +47,29 @@ RSpec.describe IlliadRequest do
     subject.request!
   end
 
-  it 'POSTs to the illiad api url' do
-    expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')).to have_been_made
-  end
-
   describe 'request headers' do
-    it 'declares that it is sending JSON' do
+    it 'posts to the ILLiad API sending JSON' do
       expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(headers: { 'Content-Type' => 'application/json' })).to have_been_made
-    end
-
-    it 'asks for a JSON response' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(headers: { 'Accept' => 'application/json; version=1' })).to have_been_made
-    end
-
-    it 'includes the api key' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(headers: { 'ApiKey' => 'some-api-key' })).to have_been_made
+      .with(headers: {
+              'Content-Type' => 'application/json',
+              'Accept' => 'application/json; version=1',
+              'ApiKey' => 'some-api-key'
+            })).to have_been_made
     end
   end
 
   describe 'request body' do
-    it 'includes the user sunetid' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"Username":"some-sso-user"/)).to have_been_made
+    let(:expected_body) do
+      '{"ProcessType":"Borrowing","AcceptAlternateEdition":false,"Username":"some-sso-user",' \
+        '"ISSN":"978-3-16-148410-0","LoanPublisher":"Walter de Gruyter GmbH","LoanPlace":"Berlin",' \
+        '"LoanDate":"2018","LoanEdition":"1st ed.","ESPNumber":"(OCoLC-M)1294477572",' \
+        '"CitedIn":"https://searchworks.stanford.edu/view/1234","CallNumber":"ABC 321",' \
+        '"ILLNumber":"12345678","ItemNumber":"12345678","PhotoJournalVolume":"T.1 2023"}'
     end
 
-    it 'includes the process type' do
+    it 'includes the expected payload' do
       expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"ProcessType":"Borrowing"/)).to have_been_made
-    end
-
-    it 'specifies that alternate editions are not acceptable by default' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"AcceptAlternateEdition":false/)).to have_been_made
-    end
-
-    it 'includes the call number' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"CallNumber":"ABC 321"/)).to have_been_made
-    end
-
-    it 'includes the barcode as the item number' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"ItemNumber":"12345678"/)).to have_been_made
-    end
-
-    it 'includes the enumeration' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"PhotoJournalVolume":"T.1 2023"/)).to have_been_made
-    end
-
-    it 'includes the publisher' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"LoanPublisher":"Walter de Gruyter GmbH"/)).to have_been_made
-    end
-
-    it 'includes the place of publication' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"LoanPlace":"Berlin"/)).to have_been_made
-    end
-
-    it 'includes the date of publication' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"LoanDate":"2018"/)).to have_been_made
-    end
-
-    it 'includes the edition' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"LoanEdition":"1st ed."/)).to have_been_made
-    end
-
-    it 'includes the OCLC number' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"ESPNumber":"\(OCoLC-M\)1294477572"/)).to have_been_made
-    end
-
-    it 'includes the catalog view link' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: %r{"CitedIn":"https://searchworks.stanford.edu/view/1234"})).to have_been_made
-    end
-
-    it 'includes the ISBN' do
-      expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-      .with(body: /"ISSN":"978-3-16-148410-0"/)).to have_been_made
+      .with(body: expected_body)).to have_been_made
     end
 
     context 'when the user is blocked' do
@@ -148,49 +86,19 @@ RSpec.describe IlliadRequest do
     let(:request) { create(:scan, :with_holdings_barcodes, user:) }
 
     describe 'request body' do
+      let(:expected_body) do
+        '{"ProcessType":"Borrowing","AcceptAlternateEdition":false,"Username":"some-sso-user",' \
+          '"ISSN":"","LoanEdition":"","ESPNumber":"",' \
+          '"CitedIn":"https://searchworks.stanford.edu/view/","CallNumber":"ABC 123",' \
+          '"ILLNumber":"12345678","ItemNumber":"12345678","RequestType":"Article",' \
+          '"SpecIns":"Scan and Deliver Request","PhotoJournalTitle":"SAL Item Title",' \
+          '"PhotoArticleAuthor":"John Q. Public","Location":"SAL3","ReferenceNumber":"SAL3-STACKS",' \
+          '"PhotoArticleTitle":"Section Title for Scan 12345","PhotoJournalInclusivePages":"1-10"}'
+      end
+
       it 'includes the request type' do
         expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"RequestType":"Article"/)).to have_been_made
-      end
-
-      it 'includes the instructions' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"SpecIns":"Scan and Deliver Request"/)).to have_been_made
-      end
-
-      it 'includes the title' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"PhotoJournalTitle":"SAL Item Title"/)).to have_been_made
-      end
-
-      it 'includes the section title' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"PhotoArticleTitle":"Section Title for Scan 12345"/)).to have_been_made
-      end
-
-      it 'includes the author' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"PhotoArticleAuthor":"John Q. Public"/)).to have_been_made
-      end
-
-      it 'includes the requested page range' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"PhotoJournalInclusivePages":"1-10"/)).to have_been_made
-      end
-
-      it 'includes the library' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"Location":"SAL3"/)).to have_been_made
-      end
-
-      it 'includes the location' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"ReferenceNumber":"SAL3-STACKS"/)).to have_been_made
-      end
-
-      it 'includes the barcode again as the ILL number' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"ILLNumber":"12345678"/)).to have_been_made
+        .with(body: expected_body)).to have_been_made
       end
     end
   end
@@ -199,34 +107,19 @@ RSpec.describe IlliadRequest do
     let(:request) { create(:hold_recall_checkedout) }
 
     describe 'request body' do
-      it 'includes the request type' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"RequestType":"Loan"/)).to have_been_made
+      let(:expected_body) do
+        '{"ProcessType":"Borrowing","AcceptAlternateEdition":false,"Username":"some-sso-user",' \
+          '"ISSN":"978-3-16-148410-0","LoanPublisher":"Walter de Gruyter GmbH","LoanPlace":"Berlin",' \
+          '"LoanDate":"2018","LoanEdition":"1st ed.","ESPNumber":"(OCoLC-M)1294477572",' \
+          '"CitedIn":"https://searchworks.stanford.edu/view/1234","CallNumber":"ABC 321",' \
+          '"ILLNumber":"87654321","ItemNumber":"87654321","PhotoJournalVolume":"T.1 2023","RequestType":"Loan",' \
+          '"SpecIns":"Hold/Recall Request","LoanTitle":"Checked out item",' \
+          '"LoanAuthor":"John Q. Public","NotWantedAfter":"2023-10-13","ItemInfo4":"GREEN"}'
       end
 
-      it 'includes the instructions' do
+      it 'includes the expected_payload' do
         expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: %r{"SpecIns":"Hold/Recall Request"})).to have_been_made
-      end
-
-      it 'includes the title' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"LoanTitle":"Checked out item"/)).to have_been_made
-      end
-
-      it 'includes the author' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"LoanAuthor":"John Q. Public"/)).to have_been_made
-      end
-
-      it 'includes the not needed after date' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"NotWantedAfter":"#{Time.zone.today.strftime('%Y-%m-%d')}"/)).to have_been_made
-      end
-
-      it 'includes the pickup location' do
-        expect(a_request(:post, 'https://illiad.stanford.edu/ILLiadWebPlatform/Transaction/')
-        .with(body: /"ItemInfo4":"GREEN"/)).to have_been_made
+        .with(body: expected_body)).to have_been_made
       end
     end
   end


### PR DESCRIPTION
These tests repeat the same test setup and just have different assertions about parts of the body. We can make the test faster and more cohesive by just expecting the whole of the body