### PR TITLE
Stop logging to honeybadger on every request

### DIFF
--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -14,13 +14,6 @@ class Page < (Settings.features.migration ? MediatedPage : Request)
     super << user.email
   end
 
-  # Ideally, we'll be able to drop the wildcard rule because no requests will make it here
-  after_create do
-    next if request_abilities.respond_to?(:send_honeybadger_notice_if_used) && !request_abilities&.send_honeybadger_notice_if_used
-
-    Honeybadger.notify("WARNING: Using default location rule for page #{id} (origin: #{origin}, origin_location: #{origin_location})")
-  end
-
   def default_needed_date
     [Time.zone.parse('2023-08-31'), Time.zone.now].max
   end


### PR DESCRIPTION
We no longer have send_honeybadger_notice_if_used in Folio::RequestAbilities, so every request is getting logged here.