### PR TITLE
Use different syntax for Patron lookup to avoid nil case

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,8 +110,13 @@ class User < ActiveRecord::Base
   end
 
   def patron
-    @patron ||= patron_model_class.find_by(sunetid:) if sunetid
-    @patron ||= patron_model_class.find_by(library_id:) if library_id
+    @patron ||= begin
+      if sso_user?
+        patron_model_class.find_by(sunetid:)
+      elsif library_id_user?
+        patron_model_class.find_by(library_id:)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Discovered this strange bug while pairing. Because of the current
syntax, user.patron can evaluate to nil even though the patron
is correctly looked up. Switching the if statement to this form
avoids that case.

Might be specific to local dev, but it was hard to tell.
