### PR TITLE
Provide the symphony origin library to LibraryLocation.new

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -57,7 +57,7 @@ class Request < ActiveRecord::Base
   end
 
   def library_location
-    @library_location ||= LibraryLocation.new(origin_library_code, origin_location)
+    @library_location ||= LibraryLocation.new(origin, origin_location)
   end
 
   def active_messages


### PR DESCRIPTION
This ensures that we don't provide FOLIO library codes to the
LibraryLocation class, which is supposed to do the symphony-to-FOLIO
lookup. If we do, it fails to find the right FOLIO location.

Tested with https://searchworks.stanford.edu/view/11878243

Partially reverts #1906
