### PR TITLE
Make sure the request status link in the ILB emails is correct

### DIFF
--- a/app/views/ilb_mailer/ilb_notification.text.erb
+++ b/app/views/ilb_mailer/ilb_notification.text.erb
@@ -8,7 +8,11 @@ However, there was a problem with the ILLiad API request:
 
 You can view the status and details of the request here:
 
-https://requests.stanford.edu/scans/<%= @request.id %>/status
+<% if @request.is_a? HoldRecall %>
+<%= status_hold_recall_url @request %>
+<% elsif @request.is_a? Scan %>
+<%= status_scan_url @request %>
+<% end %>
 
 Systems will try to improve the ILLiad request process, but in the meantime please create a transaction in ILLiad manually for:
 ILLiad Username: <%= @request.user.sunetid %>

--- a/spec/mailers/ilb_mailer_spec.rb
+++ b/spec/mailers/ilb_mailer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe IlbMailer do
-  let(:request) { create(:scan, :without_validations, :with_item_title, user:) }
+  let(:hold_recall) { create(:hold_recall_with_holdings, user:) }
+  let(:scan) { create(:scan, :without_validations, :with_holdings, user:) }
+  let(:request) { scan }
 
   describe 'ilb_notification' do
     let(:user) { build(:scan_eligible_user) }
@@ -44,12 +46,22 @@ RSpec.describe IlbMailer do
         expect(body).to include(' Section Title for Scan 12345')
       end
 
-      it 'has a link to the request information' do
-        expect(body).to include('https://requests.stanford.edu/scans/1/status')
-      end
-
       it 'has some more information about the user' do
         expect(body).to include('ILLiad Username: some-eligible-user')
+      end
+
+      context 'when the request is a scan' do
+        it 'has a link to the request information' do
+          expect(body).to include('http://example.com/scans/1/status')
+        end
+      end
+
+      context 'when the request is a hold/recall' do
+        let(:request) { hold_recall }
+
+        it 'has a link to the request status' do
+          expect(body).to include('http://example.com/hold_recalls/1/status')
+        end
       end
     end
   end


### PR DESCRIPTION
We used to assume it was a scan, but now it can be a hold/recall.
This switches to using the _url helpers, which work in emails as
long as the mail domain is correctly configured, which it is in
shared_configs.
