### PR TITLE
Clean-up Folio migration cruft

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,5 +34,5 @@ jobs:
       run: bin/setup
     - name: Ensure tmp/pids exists
       run: mkdir -p tmp/pids
-    - name: Run tests for FOLIO
+    - name: Run continuous integration tasks
       run: bundle exec rake

--- a/app/components/request_and_pickup_button_component.rb
+++ b/app/components/request_and_pickup_button_component.rb
@@ -15,7 +15,7 @@ class RequestAndPickupButtonComponent < ViewComponent::Base
   end
 
   def estimate_delivery?
-    Settings.features.estimate_delivery && !Settings.features.migration
+    Settings.features.estimate_delivery
   end
 
   def default_pickup_destination

--- a/app/controllers/mediated_pages_controller.rb
+++ b/app/controllers/mediated_pages_controller.rb
@@ -23,10 +23,7 @@ class MediatedPagesController < RequestsController
   end
 
   def validate_request_type
-    # TODO: Determine if the logic after the || should stick around
-    return if current_request.mediateable? || (Settings.features.migration && current_request.pageable? && params[:action] == 'update')
-
-    raise UnmediateableItemError
+    raise UnmediateableItemError unless current_request.mediateable?
   end
 
   class UnmediateableItemError < StandardError

--- a/app/controllers/mediated_pages_controller.rb
+++ b/app/controllers/mediated_pages_controller.rb
@@ -23,6 +23,7 @@ class MediatedPagesController < RequestsController
   end
 
   def validate_request_type
+    # TODO: Determine if the logic after the || should stick around
     return if current_request.mediateable? || (Settings.features.migration && current_request.pageable? && params[:action] == 'update')
 
     raise UnmediateableItemError

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -136,7 +136,6 @@ class RequestsController < ApplicationController
 
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   def check_if_proxy_sponsor
-    return if Settings.features.migration
     return unless current_request.user&.sso_user? && params[:request][:proxy].nil?
 
     return unless current_request.user&.sponsor? || (Settings.ils.patron_model == 'Folio::Patron' && current_request.user&.proxy?)

--- a/app/jobs/submit_folio_request_job.rb
+++ b/app/jobs/submit_folio_request_job.rb
@@ -164,6 +164,7 @@ class SubmitFolioRequestJob < ApplicationJob
     end
 
     def expiration_date
+      # TODO: Determine if page-checking logic is still needed
       @expiration_date ||= ((request.needed_date unless request.is_a?(Page)) || (Time.zone.today + 3.years)).to_time.utc.iso8601
     end
 

--- a/app/jobs/submit_folio_request_job.rb
+++ b/app/jobs/submit_folio_request_job.rb
@@ -8,7 +8,6 @@ class SubmitFolioRequestJob < ApplicationJob
   # we pass the ActiveRecord identifier to our job, rather than the ActiveRecord reference.
   #   This is recommended as a Sidekiq best practice (https://github.com/mperham/sidekiq/wiki/Best-Practices).
   #   It also helps reduce the size of the Redis database (used by Sidekiq), which stores its data in memory.
-  # rubocop:disable Metrics/AbcSize
   def perform(request_id, options = {})
     request = find_request(request_id)
 
@@ -21,10 +20,9 @@ class SubmitFolioRequestJob < ApplicationJob
 
     request.merge_ils_response_data(FolioResponse.new(response.with_indifferent_access))
     request.save(validate: false) # By placing this request in the ILS, the item is no longer in a requestable state, so avoid validation.
-    request.send_approval_status! unless Settings.features.migration
+    request.send_approval_status!
     logger.info("Completed SubmitFolioRequestJob for request #{request_id}")
   end
-  # rubocop:enable Metrics/AbcSize
 
   def find_request(request_id)
     Request.find(request_id)
@@ -164,8 +162,7 @@ class SubmitFolioRequestJob < ApplicationJob
     end
 
     def expiration_date
-      # TODO: Determine if page-checking logic is still needed
-      @expiration_date ||= ((request.needed_date unless request.is_a?(Page)) || (Time.zone.today + 3.years)).to_time.utc.iso8601
+      @expiration_date ||= (request.needed_date || (Time.zone.today + 3.years)).to_time.utc.iso8601
     end
 
     def request_comments

--- a/app/mailers/request_status_mailer.rb
+++ b/app/mailers/request_status_mailer.rb
@@ -86,8 +86,6 @@ class RequestStatusMailer < ApplicationMailer
   end
 
   def suffix
-    return 'success' if Settings.features.migration
-
     @suffix ||= if @request.ils_response.all_successful? || @request.via_borrow_direct? || @request.is_a?(MediatedPage)
                   'success'
                 else

--- a/app/models/concerns/request_validations.rb
+++ b/app/models/concerns/request_validations.rb
@@ -46,7 +46,7 @@ module RequestValidations
     errors.add(:needed_date, 'Date cannot be earlier than today') if needed_date < Time.zone.today
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity
   def library_id_exists
     return unless user
 
@@ -57,10 +57,7 @@ module RequestValidations
     # required when necessary, so if it's blank here, it's not required
     return if user.library_id.blank?
 
-    # If we're in migration-mode, the ILS isn't available to validate the library ID
-    return if Settings.features.migration
-
     errors.add(:library_id, 'This ID was not found in our records') unless user.patron&.exists?
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/app/models/request_approval_status.rb
+++ b/app/models/request_approval_status.rb
@@ -30,21 +30,15 @@ class RequestApprovalStatus
     item_list_with_status.join("\n")
   end
 
-  # rubocop:disable Metrics/AbcSize, Lint/DuplicateBranch
   def item_list_with_status
     request.holdings.map do |item|
-      # During the FOLIO migration, we want to show the normal success message
-      # instead of an error message as we're not talking to the ILS.
-      if Settings.features.migration && request.ils_response.blank?
-        succcess_text_for_item(item.callnumber)
-      elsif request.ils_response.success?(item.barcode)
+      if request.ils_response.success?(item.barcode)
         succcess_text_for_item(item.callnumber)
       else
         error_text_for_item(item)
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize, Lint/DuplicateBranch
 
   def pending?
     request.ils_response.blank?

--- a/app/models/requests/mediated_page.rb
+++ b/app/models/requests/mediated_page.rb
@@ -100,9 +100,6 @@ class MediatedPage < Request
   end
 
   def needed_date_is_valid
-    # We're using needed_date during the FOLIO migration, but it's advisory-only (and not worth updating tests to account for).
-    return unless Settings.features.migration && is_a?(Page)
-
     errors.add(:needed_date, 'The library is not open on that date') unless PagingSchedule.for(self).valid?(needed_date)
   rescue PagingSchedule::ScheduleNotFound
     nil

--- a/app/models/requests/page.rb
+++ b/app/models/requests/page.rb
@@ -3,7 +3,7 @@
 ###
 #  Request class for making simple page requests
 ###
-class Page < (Settings.features.migration ? MediatedPage : Request)
+class Page < Request
   validate :page_validator
   validates :destination, presence: true
   validate :destination_is_a_pickup_library
@@ -14,37 +14,13 @@ class Page < (Settings.features.migration ? MediatedPage : Request)
     super << user.email
   end
 
-  def default_needed_date
-    [Time.zone.parse('2023-08-31'), Time.zone.now].max
-  end
-
   def requires_needed_date?
-    Settings.features.migration ? true : false
-  end
-
-  def needed_date
-    return super unless Settings.features.migration
-
-    super || default_needed_date
+    false
   end
 
   private
 
-  def send_confirmation!
-    return unless Settings.features.migration
-
-    RequestStatusMailer.request_status_for_page(self).deliver_later if notification_email_address.present?
-  end
-
-  def mediated_page_validator
-    page_validator
-  end
-
   def page_validator
     errors.add(:base, 'This item is not pageable') unless pageable?
-  end
-
-  def needed_date_is_valid
-    true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,14 +12,10 @@ class User < ActiveRecord::Base
   attr_accessor :ip_address
 
   def proxy?
-    return false if Settings.features.migration
-
     patron&.proxy?
   end
 
   def sponsor?
-    return false if Settings.features.migration
-
     patron&.sponsor?
   end
 

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -21,7 +21,6 @@
       <th class='col-xs-2'>Location</th>
       <th class='col-xs-2'>Current</th>
       <th>Call number / Container</th>
-      <% if Settings.features.migration %><th>Barcode</th><% end %>
       <th>Status</th>
       <th>Approved by</th>
     </tr>
@@ -41,7 +40,6 @@
         <td class='col-xs-2'><%= item.home_location %></td>
         <td class='col-xs-2'><%= current_location_for_mediated_item(item) %></td>
         <td><%= item.callnumber %></td>
-        <% if Settings.features.migration %><td><%= item.barcode %></td><% end %>
         <td><span class='request-status'><%= status_text_for_item(item) %></span></td>
         <td data-behavior='approver-information'>
           <% if item.request_status.approved? %>

--- a/app/views/requests/_scheduler_text.html.erb
+++ b/app/views/requests/_scheduler_text.html.erb
@@ -3,7 +3,7 @@
     Earliest delivery
   </div>
 
-  <% if Settings.features.estimate_delivery && !Settings.features.migration %>
+  <% if Settings.features.estimate_delivery %>
     <div class="<%= content_column_class %> input-like-text" <%= "data-single-library-value='#{current_request.pickup_destinations.first}'".html_safe unless current_request.pickup_destinations.many? %>>
       <span data-text-object="<%= current_request.object_id %>" data-scheduler-text='true' aria-live='polite'></span>
       <%= f.hidden_field :estimated_delivery, data: { 'scheduler-field' => true } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,6 @@ en:
         needed_date: 'I plan to visit on'
       page:
         <<: *request_anchor
-        needed_date: 'Process by'
       scan:
         <<: *request_anchor
         authors: 'Author(s)'

--- a/spec/components/request_and_pickup_button_component_spec.rb
+++ b/spec/components/request_and_pickup_button_component_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RequestAndPickupButtonComponent, type: :component, unless: Settings.features.migration do
+RSpec.describe RequestAndPickupButtonComponent, type: :component do
   subject(:rendered) do
     with_controller_class RequestsController do
       render_inline(component)

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -117,8 +117,6 @@ RSpec.describe PagesController do
         end
 
         it 'prompts the user to decide whether the request should be for the proxy' do
-          pending('Unable to determine user types during the migration') if Settings.features.migration
-
           put :create, params: {
             request: {
               item_id: '1234',

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -65,8 +65,6 @@ RSpec.describe 'Creating a page request' do
       stub_current_user(user)
       allow(user).to receive(:sponsor?).and_return(true)
       stub_symphony_response(build(:symphony_page_with_single_item))
-
-      pending('Unable to determine user types during the migration') if Settings.features.migration
     end
 
     it 'allows the user to share with their proxy group' do

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -35,10 +35,6 @@ RSpec.describe 'Paging Schedule' do
   end
 
   describe 'Select dropdown', :js do
-    before do
-      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
-    end
-
     it 'displays the estimate for the currently selected value and updates it when a new destination is selected' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
@@ -54,8 +50,6 @@ RSpec.describe 'Paging Schedule' do
 
   describe 'Estimated delivery', :js do
     before do
-      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
-
       stub_current_user(create(:sso_user))
       stub_symphony_response(build(:symphony_page_with_single_item))
     end
@@ -88,10 +82,6 @@ RSpec.describe 'Paging Schedule' do
       ]
     end
 
-    before do
-      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
-    end
-
     it 'displays an estimate for the single possible destination' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-PAGE-EN')
 
@@ -102,8 +92,6 @@ RSpec.describe 'Paging Schedule' do
 
   describe 'form choice page', :js do
     before do
-      pending('We are not showing the paging schedule for pages during the migration') if Settings.features.migration
-
       stub_bib_data_json(build(:scannable_holdings))
     end
 

--- a/spec/mailers/factories/request_status_mailer_factory_spec.rb
+++ b/spec/mailers/factories/request_status_mailer_factory_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe RequestStatusMailerFactory do
   end
 
   describe 'user errors' do
-    before do
-      pending('During the FOLIO migration we do not have this information') if Settings.features.migration
-    end
-
     describe 'Error U003' do
       let(:request) { create(:page_with_holdings, symphony_response_data: { usererr_code: 'U003' }) }
 

--- a/spec/mailers/request_status_mailer_spec.rb
+++ b/spec/mailers/request_status_mailer_spec.rb
@@ -200,8 +200,6 @@ RSpec.describe RequestStatusMailer do
 
       describe 'failure' do
         before do
-          pending('During the FOLIO migration we are not sending these messages') if Settings.features.migration
-
           allow(request.ils_response).to receive(:all_successful?).and_return false
         end
 
@@ -214,8 +212,6 @@ RSpec.describe RequestStatusMailer do
         let(:request) { create(:page_with_holdings, barcodes: ['3610512345678'], user:) }
 
         before do
-          pending('During the FOLIO migration we are not sending these messages') if Settings.features.migration
-
           stub_symphony_response(build(:symphony_page_with_blocked_user))
         end
 

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Dashboard do
   end
 
   describe 'request type methods' do
-    before do
-      pending('During the migration, we count pages and mediated pages') if Settings.features.migration
-    end
-
     it 'returns the count of the different types of requests' do
       expect(subject.hold_recalls).to eq 0
       expect(subject.mediated_pages).to eq 1

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -572,10 +572,6 @@ RSpec.describe Request do
     describe 'for everybody else' do
       let(:user) { create(:sso_user) }
 
-      before do
-        pending('Page requests are not being approved during the FOLIO migration') if Settings.features.migration
-      end
-
       it 'sends an approval status email' do
         expect do
           subject.send_approval_status!

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -85,10 +85,6 @@ RSpec.describe Page do
     context 'when the library ID does not exist' do
       let(:user_exists) { false }
 
-      before do
-        pending('ILS is not available to look up users during the FOLIO migration') if Settings.features.migration
-      end
-
       it { expect(subject).not_to be_valid }
     end
   end
@@ -116,10 +112,6 @@ RSpec.describe Page do
 
     describe 'for everybody else' do
       let(:user) { create(:sso_user) }
-
-      before do
-        pending('Page requests are not being approved during the FOLIO migration') if Settings.features.migration
-      end
 
       it 'sends an approval status email' do
         expect do

--- a/spec/views/requests/status.html.erb_spec.rb
+++ b/spec/views/requests/status.html.erb_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'requests/status.html.erb' do
   it 'has the needed date' do
     request.needed_date = Time.zone.today
     render
-    expect(rendered).to have_css('dt', text: 'Process by')
+    expect(rendered).to have_css('dt', text: 'Needed on')
     expect(rendered).to have_css('dd', text: l(Time.zone.today, format: :long))
   end
 

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'requests/success.html.erb' do
   it 'has the needed date' do
     request.needed_date = Time.zone.today
     render
-    expect(rendered).to have_css('dt', text: 'Process by')
+    expect(rendered).to have_css('dt', text: 'Needed on')
     expect(rendered).to have_css('dd', text: l(Time.zone.today, format: :long))
   end
 


### PR DESCRIPTION
This change reverts changes made to support the ILS migration from Symphony to Folio

Fixes #1982

Includes:
* Remove `needed_date` concern from `Page` model
* Remove migration feature flag
