### PR TITLE
[DO NOT MERGE] Rename "Library ID" to "University ID"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fake_ldap_attributes:
 this will assign you the relevant LDAP attributes when you run a server using `REMOTE_USER=(your sunet id) rails s`.
 
 ### token encryption
-there is a token encryption library that handles encrypting and decrypting tokens given to users who only submit a Name/Email or Library ID for identification purposes. to keep these tokens secure we require a secret and a salt configured of moderate complexity and randomness (`SecureRandom.hex(128)` can be useful). once configured, these keys (or the tokens generated in the app) **MUST NOT** change, otherwise the tokens that users have been given will no longer be valid.
+there is a token encryption library that handles encrypting and decrypting tokens given to users who only submit a Name/Email or University ID for identification purposes. to keep these tokens secure we require a secret and a salt configured of moderate complexity and randomness (`SecureRandom.hex(128)` can be useful). once configured, these keys (or the tokens generated in the app) **MUST NOT** change, otherwise the tokens that users have been given will no longer be valid.
 ## testing
 the test suite (with RuboCop style enforcement) will be run with the default rake task (also run in CI):
 ```sh

--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -91,7 +91,7 @@ hr {
   display: none;
 }
 
-.with-library-id-error {
+.with-university-id-error {
   #sunetid-form {
     display: none;
   }

--- a/app/controllers/concerns/request_strong_params.rb
+++ b/app/controllers/concerns/request_strong_params.rb
@@ -21,7 +21,7 @@ module RequestStrongParams
                                                        :proxy,
                                                        barcodes: {},
                                                        public_notes: {},
-                                                       user_attributes: [:name, :email, :library_id])
+                                                       user_attributes: [:name, :email, :univ_id])
   end
 
   def update_params

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -57,7 +57,7 @@ class RequestsController < ApplicationController
   end
 
   def request_specific_user
-    user_attributes = params.dig(:request, :user_attributes)&.permit(:name, :email, :library_id).to_h.reject { |_k, v| v.blank? }
+    user_attributes = params.dig(:request, :user_attributes)&.permit(:name, :email, :univ_id).to_h.reject { |_k, v| v.blank? }
 
     User.new(**user_attributes, ip_address: request.remote_ip) if user_attributes.present?
   end
@@ -89,8 +89,8 @@ class RequestsController < ApplicationController
     params[:action].to_sym == :create && request.post?
   end
 
-  # if the patron is trying to submit a request and didn't provide a library id or name/email,
-  # authenticate them. Since we only provide the library id or name/email option for requests where
+  # if the patron is trying to submit a request and didn't provide a university id or name/email,
+  # authenticate them. Since we only provide the university id or name/email option for requests where
   # it will succeed, we should only end up here if the request requires authentication.
   #
   # if we ever validate patron data from the ILS, we'll need to add more logic here

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -91,8 +91,8 @@ module RequestsHelper
 
     if user.sso_user? || user.email_address.present?
       mail_to user.email_address, user.to_email_string
-    elsif user.library_id_user?
-      user.library_id
+    elsif user.univ_id_user?
+      user.univ_id
     end
   end
 end

--- a/app/javascript/additional_user_validation_fields.js
+++ b/app/javascript/additional_user_validation_fields.js
@@ -45,8 +45,8 @@ var additionalUserValidationFields = (function() {
     fieldsAreValid: function() {
       if (this.groupedUserFields().length > 0) { // If we have a name + email field
         return this.validateGroupUserFields();   // Validate name + email field are filled out only (they are always required when present)
-      } else {                                   // Else, we should only have a Library ID field
-        return this.validateSingleUserFields();  // Validate Library ID field because it should be required.
+      } else {                                   // Else, we should only have a University ID field
+        return this.validateSingleUserFields();  // Validate University ID field because it should be required.
       }
     },
 
@@ -66,7 +66,7 @@ var additionalUserValidationFields = (function() {
 
       if ( field.val().length < field.attr('minlength') ) {
         field[0].setCustomValidity(
-          'Stanford Library ID must have 10 digits (you have entered ' + field.val().length + ' ).'
+          'Stanford University ID must have between 8 and 10 digits (you have entered ' + field.val().length + ' ).'
         );
       } else {
         field[0].setCustomValidity('');
@@ -84,7 +84,7 @@ var additionalUserValidationFields = (function() {
     addTooltipToButtonWrapper: function() {
       this.buttonWrapper().attr('data-toggle', 'tooltip')
                           .attr('data-placement', 'top')
-                          .attr('data-title', 'Enter your Library ID or your name and email to complete you request.')
+                          .attr('data-title', 'Enter your University ID or your name and email to complete you request.')
                           .tooltip();
     },
 

--- a/app/jobs/submit_folio_request_job.rb
+++ b/app/jobs/submit_folio_request_job.rb
@@ -179,7 +179,7 @@ class SubmitFolioRequestJob < ApplicationJob
     def patron
       @patron ||= case request
                   when Scan
-                    Folio::Patron.find_by(library_id: scan_destination.patron_barcode)
+                    Folio::Patron.find_by(univ_id: scan_destination.patron_barcode)
                   when Page, MediatedPage, HoldRecall
                     if user.patron&.make_request_as_patron?
                       user.patron
@@ -192,7 +192,7 @@ class SubmitFolioRequestJob < ApplicationJob
     def find_hold_pseudo_patron_for(key)
       pseudopatron_barcode = Settings.libraries[key]&.hold_pseudopatron || raise("no hold pseudopatron for '#{key}'")
 
-      Folio::Patron.find_by(library_id: pseudopatron_barcode)
+      Folio::Patron.find_by(univ_id: pseudopatron_barcode)
     end
 
     def barcodes

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,8 +12,8 @@ class Ability
     @anonymous ||= Ability.new(User.new(name: 'generic', email: 'external-user@example.com'))
   end
 
-  def self.with_a_library_id
-    @with_a_library_id ||= Ability.new(User.new(library_id: '0000000000'))
+  def self.with_a_univ_id
+    @with_a_univ_id ||= Ability.new(User.new(univ_id: '000000000'))
   end
 
   def self.sso
@@ -63,18 +63,18 @@ class Ability
     can :new, Request
 
     # ... but only some types of users can actually submit the request successfully
-    if user.sso_user? || user.library_id_user? || user.name_email_user?
+    if user.sso_user? || user.univ_id_user? || user.name_email_user?
       can :create, MediatedPage
       can :create, Page
     end
 
-    if user.name_email_user? && !user.library_id_user?
+    if user.name_email_user? && !user.univ_id_user?
       cannot :create, Page, origin: 'BUSINESS'
       cannot :create, Page, origin: 'MEDIA-MTXT'
       cannot :create, Page, origin: 'MEDIA-CENTER'
     end
 
-    can :create, HoldRecall if user.library_id_user? || user.sso_user?
+    can :create, HoldRecall if user.univ_id_user? || user.sso_user?
     can :create, Scan if user.super_admin? || in_scan_pilot_group?(user)
 
     # ... and to check the status, you either need to be logged in or include a special token in the URL

--- a/app/models/concerns/request_validations.rb
+++ b/app/models/concerns/request_validations.rb
@@ -12,7 +12,7 @@ module RequestValidations
              :requested_item_is_not_scannable_only,
              on: :create
     validate :needed_date_is_not_in_the_past, on: :create, if: :needed_date
-    validate :library_id_exists, on: :create
+    validate :univ_id_exists, on: :create
   end
 
   protected
@@ -47,17 +47,17 @@ module RequestValidations
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def library_id_exists
+  def univ_id_exists
     return unless user
 
-    # Ensure we don't contact the ILS if we don't need to validate the library ID
+    # Ensure we don't contact the ILS if we don't need to validate the university ID
     return if user.sso_user? || (requestable_with_name_email? && user.name_email_user?)
 
-    # We require the library ID is on the client side when neccesary
+    # We require the university ID is on the client side when neccesary
     # required when necessary, so if it's blank here, it's not required
-    return if user.library_id.blank?
+    return if user.univ_id.blank?
 
-    errors.add(:library_id, 'This ID was not found in our records') unless user.patron&.exists?
+    errors.add(:univ_id, 'This ID was not found in our records') unless user.patron&.exists?
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -6,7 +6,7 @@ module Requestable
     Ability.anonymous.can?(:create, self)
   end
 
-  def requestable_with_library_id?
-    Ability.with_a_library_id.can?(:create, self)
+  def requestable_with_university_id?
+    Ability.with_a_univ_id.can?(:create, self)
   end
 end

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -33,11 +33,9 @@ class CurrentUser
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
   def update_ldap_attributes(user)
     user.name = ldap_name
     user.ldap_group_string = ldap_group_string
-    user.sucard_number = ldap_sucard_number
     user.univ_id = ldap_univ_id
     user.affiliation = ldap_affiliation
     user.email = ldap_email
@@ -45,7 +43,6 @@ class CurrentUser
 
     user.save if user.changed?
   end
-  # rubocop:enable Metrics/AbcSize
 
   def ldap_name
     ldap_attributes['displayName']
@@ -57,10 +54,6 @@ class CurrentUser
 
   def ldap_univ_id
     ldap_attributes['suUnivID']
-  end
-
-  def ldap_sucard_number
-    ldap_attributes['suCardNumber']
   end
 
   def ldap_affiliation

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -4,16 +4,16 @@ module Folio
   # Model for working with FOLIO Patron information
   class Patron
     # rubocop:disable Metrics/CyclomaticComplexity
-    def self.find_by(sunetid: nil, library_id: nil, **_kwargs)
-      # if no sunet or library_id they are probably a general public (name/email) user.
-      return unless sunetid || library_id.present?
+    def self.find_by(sunetid: nil, univ_id: nil, **_kwargs)
+      # if no sunet or univ_id they are probably a general public (name/email) user.
+      return unless sunetid || univ_id.present?
 
       response = folio_client.login_by_sunetid(sunetid) if sunetid.present?
-      response ||= folio_client.login_by_library_id(library_id) if library_id.present?
+      response ||= folio_client.login_by_university_id(univ_id) if univ_id.present?
 
       return new(response) if response.present?
 
-      Honeybadger.notify("Unable to find patron (looked up by sunetid: #{sunetid} / barcode: #{library_id}")
+      Honeybadger.notify("Unable to find patron (looked up by sunetid: #{sunetid} / university ID: #{univ_id}")
 
       nil
     rescue HTTP::Error

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -105,23 +105,23 @@ class Request < ActiveRecord::Base
 
     case
     when user.sso_user? then User.find_by_sunetid(user.sunetid)
-    when user.library_id_user? then find_existing_library_id_user
+    when user.univ_id_user? then find_existing_univ_id_user
     when user.name_email_user? then find_existing_email_user
     end
   end
 
-  def find_existing_library_id_user
+  def find_existing_univ_id_user
     if user.email
-      User.find_by(library_id: user.library_id, email: user.email)
+      User.find_by(univ_id: user.univ_id, email: user.email)
     else
-      User.find_by_library_id(user.library_id)
+      User.find_by_univ_id(user.univ_id)
     end
   end
 
   def find_existing_email_user
     return unless user.email
 
-    User.find_by(email: user.email, library_id: user.library_id).tap do |u|
+    User.find_by(email: user.email, univ_id: user.univ_id).tap do |u|
       next unless u
 
       u.update(name: user.name)
@@ -166,8 +166,8 @@ class Request < ActiveRecord::Base
     mediateable?
   end
 
-  def library_id_error?
-    errors[:library_id].present?
+  def univ_id_error?
+    errors[:univ_id].present?
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -46,10 +46,10 @@ class FolioClient
     response&.dig('users', 0)
   end
 
-  # Return the FOLIO user object given a library id (e.g. barcode)
+  # Return the FOLIO user object given a university ID
   # See https://s3.amazonaws.com/foliodocs/api/mod-users/p/users.html#users__userid__get
-  def login_by_library_id(library_id)
-    response = get_json('/users', params: { query: CqlQuery.new(barcode: library_id).to_query })
+  def login_by_university_id(university_id)
+    response = get_json('/users', params: { query: CqlQuery.new(externalSystemId: university_id).to_query })
     response&.dig('users', 0)
   end
 

--- a/app/views/requests/_no_sunet_form.html.erb
+++ b/app/views/requests/_no_sunet_form.html.erb
@@ -1,29 +1,29 @@
-<% if f.object.requestable_with_library_id? || f.object.requestable_with_name_email? %>
+<% if f.object.requestable_with_university_id? || f.object.requestable_with_name_email? %>
   <div id="no-sunetid-form" aria-hidden="false">
     <%= f.fields_for :user, (current_request.user unless current_request.user && current_request.user.sso_user?) || User.new do |uf| %>
-      <% if f.object.requestable_with_library_id? %>
-        <div class="form-group <%= "has-error" if f.object.library_id_error? %>">
-          <%= uf.label :library_id, 'Stanford Library ID', class: "control-label #{label_column_class} #{'required' unless f.object.requestable_with_name_email?}" %>
+      <% if f.object.requestable_with_university_id? %>
+        <div class="form-group <%= "has-error" if f.object.univ_id_error? %>">
+          <%= uf.label :univ_id, t('activerecord.attributes.user.univ_id'), class: "control-label #{label_column_class} #{'required' unless f.object.requestable_with_name_email?}" %>
           <div class='<%= content_column_class %>'>
             <%= uf.text_field_without_bootstrap(
-                  :library_id,
+                  :univ_id,
                   class: 'form-control',
-                  minlength: (10 unless f.object.requestable_with_name_email?),
+                  minlength: (8 unless f.object.requestable_with_name_email?),
                   maxlength: 10,
-                  'aria-describedby' => 'library-id-help',
+                  'aria-describedby' => 'university-id-help',
                   data: { behavior: 'single-user-field' },
                   autocomplete: 'off'
                 )
             %>
-            <% if f.object.library_id_error? %>
-              <div role="alert" id="library-id-help" class="alert alert-danger">
+            <% if f.object.univ_id_error? %>
+              <div role="alert" id="university-id-help" class="alert alert-danger">
                 <span class="bi bi-exclamation-circle-fill" aria-hidden="true"></span>
-                <%= f.object.errors[:library_id].join('. ') %>.<br/>
-                A Stanford Library ID has 10 digits. On some University ID cards, it has a prefix of <span class="suid-prefix" aria-label="8 0 6 0 9">80609</span>.
+                <%= f.object.errors[:university_id].join('. ') %>.<br/>
+                <%= Settings.university_id.help_text %>
               </div>
             <% else %>
-              <p id="library-id-help" class="help-block">
-                ID is a 10-digit number.
+              <p id="university-id-help" class="help-block">
+                <%= Settings.university_id.help_text %>
                 <% if f.object.requestable_with_name_email? %>
                   It's optional, but may help you track your request in My Library Account.
                 <% end %>

--- a/app/views/requests/_no_sunet_option.html.erb
+++ b/app/views/requests/_no_sunet_option.html.erb
@@ -1,4 +1,4 @@
-<% if f.object.requestable_with_library_id? || f.object.requestable_with_name_email? %>
+<% if f.object.requestable_with_university_id? || f.object.requestable_with_name_email? %>
   <hr />
   <p class='or-divider'>
     <% if current_user.sso_user? %>

--- a/app/views/requests/_submit_request_buttons.html.erb
+++ b/app/views/requests/_submit_request_buttons.html.erb
@@ -1,4 +1,4 @@
-<div class="login-send-group <%= 'with-library-id-error' if f.object.library_id_error? %>">
+<div class="login-send-group <%= 'with-university-id-error' if f.object.univ_id_error? %>">
   <%= render partial: 'sunet_form', locals: { f: f } %>
   <%= render partial: 'no_sunet_form', locals: { f: f } %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   activerecord:
     attributes:
       user:
-        library_id: 'Library ID'
+        univ_id: 'University ID'
       request: &request_anchor
         holdings: 'Item(s) requested'
         needed_date: 'Needed on'
@@ -46,6 +46,12 @@ en:
     help:
       scan:
         section_title: 'Limited to one article/chapter, not to exceed 50 pages or 10% of the work'
+    errors:
+      models:
+        user:
+          attributes:
+            univ_id:
+              invalid: 'must be an 8-, 9-, or 10-digit number'
   admin:
     index:
       hold_recalls: 'Hold recalls'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,6 +104,9 @@ features:
 background_jobs:
   enabled: false
 
+university_id:
+  help_text: 'This is an 8- to 10-digit number that serves as a replacement for the Library ID that was previously utilized.'
+
 embed:
   url: https://embed.stanford.edu
 

--- a/db/migrate/20240126165620_replace_library_id_with_univ_id.rb
+++ b/db/migrate/20240126165620_replace_library_id_with_univ_id.rb
@@ -1,0 +1,7 @@
+class ReplaceLibraryIdWithUnivId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :univ_id
+    remove_index :users, :library_id
+    remove_column :users, :library_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_07_203550) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_26_165620) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "commenter"
     t.string "comment"
@@ -69,12 +69,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_203550) do
     t.string "email"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.string "library_id"
     t.string "student_type"
     t.string "univ_id"
     t.index ["email"], name: "index_users_on_email"
-    t.index ["library_id"], name: "index_users_on_library_id"
     t.index ["sunetid"], name: "unique_users_by_sunetid", unique: true
+    t.index ["univ_id"], name: "index_users_on_univ_id"
   end
 
 end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe AdminController do
 
       before do
         allow(Folio::Patron).to receive(:find_by).and_call_original
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO')
         )
       end

--- a/spec/controllers/mediated_pages_controller_spec.rb
+++ b/spec/controllers/mediated_pages_controller_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe MediatedPagesController do
         expect(MediatedPage.last.user).to eq User.last
       end
 
-      it 'is allowed if the library ID field is filled out' do
-        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: '12345').and_return(
+      it 'is allowed if the university ID field is filled out' do
+        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: '123456789').and_return(
           instance_double(Folio::Patron, email: nil, exists?: true, proxy?: false)
         )
 
@@ -87,12 +87,12 @@ RSpec.describe MediatedPagesController do
             origin_location: 'ART-LOCKED-LARGE',
             destination: 'ART',
             needed_date: Time.zone.today + 1.year,
-            user_attributes: { library_id: '12345' }
+            user_attributes: { univ_id: '123456789' }
           }
         }
 
         expect(response.location).to match(/#{successful_mediated_page_url(MediatedPage.last)}\?token=/)
-        expect(User.last.library_id).to eq '12345'
+        expect(User.last.univ_id).to eq '123456789'
         expect(MediatedPage.last.user).to eq User.last
       end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe PagesController do
         expect(Page.last.user).to eq User.last
       end
 
-      it 'is allowed if the library ID field is filled out' do
-        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: '12345').and_return(
+      it 'is allowed if the university ID field is filled out' do
+        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: '12345678').and_return(
           instance_double(Folio::Patron, email: nil, exists?: true)
         )
 
@@ -100,12 +100,12 @@ RSpec.describe PagesController do
             origin: 'SAL3',
             origin_location: 'SAL3-STACKS',
             destination: 'ART',
-            user_attributes: { library_id: '12345' }
+            user_attributes: { univ_id: '12345678' }
           }
         }
 
         expect(response.location).to match(/#{successful_page_url(Page.last)}\?token=/)
-        expect(User.last.library_id).to eq '12345'
+        expect(User.last.univ_id).to eq '12345678'
         expect(Page.last.user).to eq User.last
       end
 
@@ -198,8 +198,8 @@ RSpec.describe PagesController do
         expect(Page.last.barcodes.sort).to eq(%w(12345679 3610512345678))
       end
 
-      it 'redirects to success page with token when the sso user supplies a library ID' do
-        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: '5432123').and_return(
+      it 'redirects to success page with token when the sso user supplies a university ID' do
+        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: '54321233').and_return(
           instance_double(Folio::Patron, email: nil, exists?: true)
         )
 
@@ -209,12 +209,12 @@ RSpec.describe PagesController do
             origin: 'SAL3',
             origin_location: 'SAL3-STACKS',
             destination: 'ART',
-            user_attributes: { library_id: '5432123' }
+            user_attributes: { univ_id: '54321233' }
           }
         }
 
         expect(response.location).to match(/#{successful_page_url(Page.last)}\?token=/)
-        expect(Page.last.user.library_id).to eq '5432123'
+        expect(Page.last.user.univ_id).to eq '54321233'
       end
 
       # NOTE: cannot trigger activejob from this spec to check RequestStatusMailer

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -67,8 +67,8 @@ FactoryBot.define do
     email { 'jstanford@stanford.edu' }
   end
 
-  factory :library_id_user, class: 'User' do
-    library_id { '12345678' }
+  factory :university_id_user, class: 'User' do
+    univ_id { '123456789' }
   end
 
   factory :anon_user, class: 'User'

--- a/spec/features/create_mediated_page_request_spec.rb
+++ b/spec/features/create_mediated_page_request_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe 'Creating a mediated page request' do
 
       click_on "I don't have a SUNet ID"
 
-      expect(page).to have_field('Library ID', type: 'text')
+      expect(page).to have_field('University ID', type: 'text')
       expect(page).to have_field('Name', type: 'text')
       expect(page).to have_field('Email', type: 'email')
       expect(page).to have_css('a', text: '‹ Go back (show the login option)')
-      expect(page).to have_css('input#request_user_attributes_library_id')
-      expect(page.evaluate_script('document.activeElement.id')).to eq 'request_user_attributes_library_id'
+      expect(page).to have_css('input#request_user_attributes_univ_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'request_user_attributes_univ_id'
 
       click_on '‹ Go back (show the login option)'
       expect(page).to have_css('a', text: "I don't have a SUNet ID")
@@ -43,24 +43,24 @@ RSpec.describe 'Creating a mediated page request' do
       expect_to_be_on_success_page
     end
 
-    it 'is possible if a library id is filled out', :js do
+    it 'is possible if a university id is filled out', :js do
       visit new_mediated_page_path(item_id: '1234', origin: 'ART', origin_location: 'ART-LOCKED-LARGE')
 
       fill_in_required_fields
 
       click_on "I don't have a SUNet ID"
 
-      expect(page).to have_css('input#request_user_attributes_library_id')
-      expect(page.evaluate_script('document.activeElement.id')).to eq 'request_user_attributes_library_id'
+      expect(page).to have_css('input#request_user_attributes_univ_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'request_user_attributes_univ_id'
 
-      fill_in 'Library ID', with: '123456'
+      fill_in 'University ID', with: '123456789'
       fill_in 'Name', with: 'Jane Stanford'
       fill_in 'Email', with: 'jstanford@stanford.edu'
 
       click_on 'Send request'
 
       expect(MediatedPage.last.user).to eq User.last
-      expect(User.last.library_id).to eq '123456'
+      expect(User.last.univ_id).to eq '123456789'
       expect_to_be_on_success_page
     end
   end

--- a/spec/features/create_page_request_spec.rb
+++ b/spec/features/create_page_request_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe 'Creating a page request' do
     stub_bib_data_json(build(:single_holding))
   end
 
-  context 'when initiated by an anonmyous user' do
+  context 'when initiated by an anonymous user' do
     it 'is possible if a name and email is filled out', :js do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       click_on "I don't have a SUNet ID"
 
-      expect(page).to have_css('input#request_user_attributes_library_id')
-      expect(page.evaluate_script('document.activeElement.id')).to eq 'request_user_attributes_library_id'
+      expect(page).to have_css('input#request_user_attributes_univ_id')
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'request_user_attributes_univ_id'
 
       fill_in 'Name', with: 'Jane Stanford'
       fill_in 'Email', with: 'jstanford@stanford.edu'
@@ -26,16 +26,16 @@ RSpec.describe 'Creating a page request' do
       expect_to_be_on_success_page
     end
 
-    context 'when both library ID and email are provided by the user' do
+    context 'when both university ID and email are provided by the user' do
       before do
-        User.create!(library_id: '1011', email: 'tcramer1@stanford.edu')
+        User.create!(univ_id: '0123456789', email: 'tcramer1@stanford.edu')
       end
 
       it 'creates a new user', :js do
         visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
         click_on "I don't have a SUNet ID"
 
-        fill_in 'Library ID', with: '123456'
+        fill_in 'University ID', with: '1234567890'
         fill_in 'Name', with: 'Tim Cramer'
         fill_in 'Email', with: 'tcramer1@stanford.edu'
 

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -50,16 +50,16 @@ RSpec.describe 'Send Request Buttons' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
       click_on 'I don\'t have a SUNet ID'
 
-      expect(page).to have_field('Library ID', type: 'text')
+      expect(page).to have_field('University ID', type: 'text')
       expect(page).to have_field('Name', type: 'text')
       expect(page).to have_field('Email', type: 'email')
 
       expect(page).to have_css('input[value="Send request"][disabled].disabled')
 
-      fill_in 'Library ID', with: '12345'
+      fill_in 'University ID', with: '12345678'
       expect(page).to have_css('input[value="Send request"].disabled')
 
-      fill_in 'Library ID', with: ''
+      fill_in 'University ID', with: ''
       expect(page).to have_css('input[value="Send request"].disabled')
 
       fill_in 'Name', with: 'Jane Stanford'
@@ -102,9 +102,9 @@ RSpec.describe 'Send Request Buttons' do
       expect(page).to have_css('button', text: /Send request.*login with SUNet ID/m)
     end
 
-    it 'allows to send requests via LibraryID' do
+    it 'allows to send requests via University ID' do
       click_on 'I don\'t have a SUNet ID'
-      expect(page).to have_field('Library ID', type: 'text')
+      expect(page).to have_field('University ID', type: 'text')
     end
 
     it 'does not allow to send requests via Name and Email' do

--- a/spec/features/status_page_spec.rb
+++ b/spec/features/status_page_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe 'Status Page' do
   end
 
   describe 'by users with tokens' do
-    let(:user) { create(:library_id_user) }
+    let(:user) { create(:university_id_user) }
 
     before do
-      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).and_return(
+      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).and_return(
         instance_double(Folio::Patron, exists?: true)
       )
     end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe RequestsHelper do
   describe 'requester info' do
     let(:sso_user) { User.create(sunetid: 'jstanford', email: 'jstanford@stanford.edu') }
     let(:non_sso_user) { User.create(name: 'Joe', email: 'joe@xyz.com') }
-    let(:library_id_user) { User.create(library_id: '123456') }
+    let(:university_id_user) { User.create(univ_id: '12345678') }
 
     it 'constructs requester info for SSO user' do
       expect(requester_info(sso_user)).to eq '<a href="mailto:jstanford@stanford.edu">jstanford@stanford.edu</a>'
@@ -84,7 +84,7 @@ RSpec.describe RequestsHelper do
     end
 
     it 'constructs requester info for a library id user' do
-      expect(requester_info(library_id_user)).to eq '123456'
+      expect(requester_info(university_id_user)).to eq '12345678'
     end
   end
 

--- a/spec/jobs/submit_folio_request_job_spec.rb
+++ b/spec/jobs/submit_folio_request_job_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe SubmitFolioRequestJob do
       let(:pseudopatron) { instance_double(Folio::Patron, id: 'HOLD@GR-PSEUDO', patron_group_id:, blocked?: false) }
 
       before do
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@GR').and_return(pseudopatron)
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'HOLD@GR').and_return(pseudopatron)
       end
 
       it 'places a hold for the item as a pseudopatron with patron comment' do
@@ -152,7 +152,7 @@ RSpec.describe SubmitFolioRequestJob do
       let(:patron) { nil }
 
       before do
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
@@ -175,7 +175,7 @@ RSpec.describe SubmitFolioRequestJob do
       let(:patron_group_id) { nil }
 
       before do
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
@@ -270,7 +270,7 @@ RSpec.describe SubmitFolioRequestJob do
       let(:patron) { nil }
 
       before do
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
       end
@@ -294,7 +294,7 @@ RSpec.describe SubmitFolioRequestJob do
 
       before do
         allow(patron).to receive(:blocked?).and_return(false)
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'HOLD@AR').and_return(
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'HOLD@AR').and_return(
           instance_double(Folio::Patron, id: 'HOLD@AR-PSEUDO', patron_group_id:, blocked?: false)
         )
         allow(request.bib_data).to receive(:items).and_return([item])
@@ -328,7 +328,7 @@ RSpec.describe SubmitFolioRequestJob do
       end
 
       before do
-        allow(Folio::Patron).to receive(:find_by).with(library_id: 'GRE-SCANDELIVER').and_return(
+        allow(Folio::Patron).to receive(:find_by).with(univ_id: 'GRE-SCANDELIVER').and_return(
           instance_double(Folio::Patron, id: 'GRE-SCANDELIVER', patron_group_id:, blocked?: false)
         )
         allow(request.bib_data).to receive(:items).and_return([item])

--- a/spec/jobs/submit_iplc_listener_job_spec.rb
+++ b/spec/jobs/submit_iplc_listener_job_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe SubmitIplcListenerJob, type: :job do
-  let(:user) { create(:library_id_user) }
+  let(:user) { create(:university_id_user) }
   let(:request) { create(:hold_recall_with_holdings, user:) }
   let(:sw_item) { double('SeachWorksItem', isbn: %w[12345 54321]) }
 
   before do
     Sidekiq.logger.level = Logger::UNKNOWN
-    allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).at_least(:once).and_return(
+    allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).at_least(:once).and_return(
       double(exists?: true, email: 'patron@example.com')
     )
     allow(request).to receive(:bib_data).and_return(sw_item)

--- a/spec/jobs/submit_reshare_request_job_spec.rb
+++ b/spec/jobs/submit_reshare_request_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SubmitReshareRequestJob, type: :job do
-  let(:user) { create(:library_id_user) }
+  let(:user) { create(:university_id_user) }
   let(:patron) do
     instance_double(Folio::Patron, exists?: true, email: nil, patron_group_name: 'undergrad',
                                    patron_group_id: 'bdc2b6d4-5ceb-4a12-ab46-249b9a68473e', ilb_eligible?: true)
@@ -13,7 +13,7 @@ RSpec.describe SubmitReshareRequestJob, type: :job do
 
   before do
     Sidekiq.logger.level = Logger::UNKNOWN
-    allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).and_return(patron)
+    allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).and_return(patron)
     allow(request).to receive(:bib_data).and_return(sw_item)
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe Ability do
       end
     end
 
-    describe 'who fills out the library ID field' do
-      let(:user) { build(:library_id_user) }
+    describe 'who fills out the university ID field' do
+      let(:user) { build(:university_id_user) }
       let(:page) { build(:page, user:) }
       let(:mediated_page) { build(:mediated_page, user:) }
       let(:scan) { build(:scan, :without_validations, user:) }

--- a/spec/models/current_user_spec.rb
+++ b/spec/models/current_user_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe CurrentUser do
       expect(subject.ldap_groups).to eq ['ldap:group1', 'ldap:group2']
     end
 
-    it 'has the suCardNumber id from LDAP and translates it to the library_id' do
-      allow_any_instance_of(described_class).to receive_messages(user_id: 'some-user')
-      allow(rails_req).to receive(:env).and_return('suCardNumber' => '12345987654321')
-      expect(subject).to be_a User
-      expect(subject.library_id).to eq '987654321'
-      expect(subject).not_to be_changed
-    end
-
     describe 'email' do
       it 'is the mail from ldap attributes' do
         allow_any_instance_of(described_class).to receive_messages(user_id: 'some-user')

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Request do
 
   describe 'requestable' do
     it { is_expected.not_to be_requestable_with_name_email }
-    it { is_expected.not_to be_requestable_with_library_id }
+    it { is_expected.not_to be_requestable_with_university_id }
   end
 
   describe '#paging_origin_library' do
@@ -304,7 +304,7 @@ RSpec.describe Request do
 
   describe 'nested attributes for' do
     before do
-      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: '12345').and_return(
+      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: '12345678').and_return(
         instance_double(Folio::Patron, exists?: true)
       )
     end
@@ -370,26 +370,25 @@ RSpec.describe Request do
       end
 
       it 'does not duplicate user records when both library ID and email is provided' do
-        expect(User.where(library_id: '12345', email: 'jstanford@stanford.edu').length).to eq 0
-        User.create(library_id: '12345', email: 'jstanford@stanford.edu')
-        expect(User.where(library_id: '12345', email: 'jstanford@stanford.edu').length).to eq 1
+        expect(User.where(univ_id: '12345678', email: 'jstanford@stanford.edu').length).to eq 0
+        User.create(univ_id: '12345678', email: 'jstanford@stanford.edu')
+        expect(User.where(univ_id: '12345678', email: 'jstanford@stanford.edu').length).to eq 1
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
           origin_location: 'GRE-STACKS',
           user_attributes: {
-            library_id: '12345',
+            univ_id: '12345678',
             email: 'jstanford@stanford.edu'
           }
         )
-        expect(User.where(library_id: '12345', email: 'jstanford@stanford.edu').length).to eq 1
+        expect(User.where(univ_id: '12345678', email: 'jstanford@stanford.edu').length).to eq 1
       end
 
-      it 'does not use existing user records when a name+email is provded' do
-        bad_id = '54321'
-        # User is already created with a bad library ID
-        User.create(library_id: bad_id, email: 'jstanford@stanford.edu')
-        expect(User.where(library_id: bad_id, email: 'jstanford@stanford.edu').length).to eq 1
+      it 'does not use existing user records when a name+email is provided' do
+        # User is already created with a university ID
+        User.create(univ_id: '0123456789', email: 'jstanford@stanford.edu')
+        expect(User.where(univ_id: '0123456789', email: 'jstanford@stanford.edu').length).to eq 1
         # User comes in and just adds a name+email with the same email address as the bad ID
         expect do
           described_class.create!(
@@ -404,19 +403,19 @@ RSpec.describe Request do
         end.to change(User, :count).by(1)
       end
 
-      it 'does not duplicate library ids' do
-        expect(User.where(library_id: '12345').length).to eq 0
-        User.create(library_id: '12345')
-        expect(User.where(library_id: '12345').length).to eq 1
+      it 'does not duplicate univ ids' do
+        expect(User.where(univ_id: '12345678').length).to eq 0
+        User.create(univ_id: '12345678')
+        expect(User.where(univ_id: '12345678').length).to eq 1
         described_class.create!(
           item_id: '1234',
           origin: 'GREEN',
           origin_location: 'GRE-STACKS',
           user_attributes: {
-            library_id: '12345'
+            univ_id: '12345678'
           }
         )
-        expect(User.where(library_id: '12345').length).to eq 1
+        expect(User.where(univ_id: '12345678').length).to eq 1
       end
     end
   end
@@ -520,7 +519,7 @@ RSpec.describe Request do
     end
 
     context 'for proxy requests' do
-      let(:user) { create(:library_id_user) }
+      let(:user) { create(:university_id_user) }
 
       before do
         allow(user).to receive_message_chain(:patron, :proxy_email_address).and_return('some@lists.stanford.edu')
@@ -554,13 +553,13 @@ RSpec.describe Request do
     let(:user) {}
 
     before do
-      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).and_return(
+      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).and_return(
         instance_double(Folio::Patron, exists?: true, email: '')
       )
     end
 
-    describe 'for library id users' do
-      let(:user) { create(:library_id_user) }
+    describe 'for university id users' do
+      let(:user) { create(:university_id_user) }
 
       it 'does not send an approval status email' do
         expect do

--- a/spec/models/requests/hold_recall_spec.rb
+++ b/spec/models/requests/hold_recall_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HoldRecall do
 
   describe 'requestable' do
     it { is_expected.not_to be_requestable_with_name_email }
-    it { is_expected.to be_requestable_with_library_id }
+    it { is_expected.to be_requestable_with_university_id }
   end
 
   it 'has the properly assigned Rails STI attribute value' do
@@ -17,12 +17,12 @@ RSpec.describe HoldRecall do
   end
 
   describe 'send_approval_status!' do
-    describe 'for library id users' do
-      let(:user) { create(:library_id_user) }
+    describe 'for university id users' do
+      let(:user) { create(:university_id_user) }
       let(:subject) { create(:hold_recall, user:) }
 
       before do
-        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).at_least(:once).and_return(
+        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).at_least(:once).and_return(
           double(exists?: true, email: nil)
         )
       end
@@ -76,8 +76,8 @@ RSpec.describe HoldRecall do
       end
     end
 
-    context 'when the patron is a library id user' do
-      let(:user) { create(:library_id_user) }
+    context 'when the patron is a university id user' do
+      let(:user) { create(:university_id_user) }
       let(:patron) do
         instance_double(Folio::Patron, exists?: true, email: nil, patron_group_name: 'graduate',
                                        patron_group_id: 'ad0bc554-d5bc-463c-85d1-5562127ae91b',
@@ -85,7 +85,7 @@ RSpec.describe HoldRecall do
       end
 
       before do
-        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).and_return(patron)
+        allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).and_return(patron)
       end
 
       it 'submits the request to the ILS' do

--- a/spec/models/requests/mediated_page_spec.rb
+++ b/spec/models/requests/mediated_page_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe MediatedPage do
 
   describe 'requestable' do
     it { is_expected.to be_requestable_with_name_email }
-    it { is_expected.to be_requestable_with_library_id }
+    it { is_expected.to be_requestable_with_university_id }
   end
 
   describe '#requires_needed_date?' do
@@ -193,11 +193,11 @@ RSpec.describe MediatedPage do
       subject.submit!
     end
 
-    describe 'for library id users' do
+    describe 'for university id users' do
       let!(:subject) { create(:mediated_page) }
 
       it 'sends a mediator email, but does not send a confirmation email' do
-        subject.user = create(:library_id_user)
+        subject.user = create(:university_id_user)
         expect do
           expect(subject.submit!).to be true
         end.to have_enqueued_mail

--- a/spec/models/requests/page_spec.rb
+++ b/spec/models/requests/page_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe Page do
       before { subject.origin = 'MEDIA-MTXT' }
 
       it { is_expected.not_to be_requestable_with_name_email }
-      it { is_expected.to be_requestable_with_library_id }
+      it { is_expected.to be_requestable_with_university_id }
     end
 
     context 'other libraries' do
       it { is_expected.to be_requestable_with_name_email }
-      it { is_expected.to be_requestable_with_library_id }
+      it { is_expected.to be_requestable_with_university_id }
     end
   end
 
@@ -53,8 +53,8 @@ RSpec.describe Page do
     expect(subject.type).to eq 'Page'
   end
 
-  describe 'library id validation' do
-    let(:user) { create(:library_id_user) }
+  describe 'university id validation' do
+    let(:user) { create(:university_id_user) }
     let(:destination) { 'GREEN-LOAN' }
 
     let(:subject) do
@@ -71,18 +71,18 @@ RSpec.describe Page do
     end
 
     before do
-      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).at_least(:once).and_return(
+      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).at_least(:once).and_return(
         double(exists?: user_exists)
       )
     end
 
-    context 'when the library ID exists' do
+    context 'when the university ID exists' do
       let(:user_exists) { true }
 
       it { expect(subject).to be_valid }
     end
 
-    context 'when the library ID does not exist' do
+    context 'when the university ID does not exist' do
       let(:user_exists) { false }
 
       it { expect(subject).not_to be_valid }
@@ -95,13 +95,13 @@ RSpec.describe Page do
     let(:user) {}
 
     before do
-      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(library_id: user.library_id).and_return(
+      allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(univ_id: user.univ_id).and_return(
         instance_double(Folio::Patron, exists?: true, email: '')
       )
     end
 
-    describe 'for library id users' do
-      let(:user) { create(:library_id_user) }
+    describe 'for university id users' do
+      let(:user) { create(:university_id_user) }
 
       it 'does not send an approval status email' do
         expect do

--- a/spec/models/requests/scan_spec.rb
+++ b/spec/models/requests/scan_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Scan do
 
   describe 'requestable' do
     it { is_expected.not_to be_requestable_with_name_email }
-    it { is_expected.not_to be_requestable_with_library_id }
+    it { is_expected.not_to be_requestable_with_university_id }
   end
 
   describe '#item_limit' do
@@ -68,8 +68,8 @@ RSpec.describe Scan do
   end
 
   describe 'send_approval_status!' do
-    describe 'for library id users' do
-      let(:subject) { create(:scan, :without_validations, user: create(:library_id_user), item_title: 'foo') }
+    describe 'for university id users' do
+      let(:subject) { create(:scan, :without_validations, user: create(:university_id_user), item_title: 'foo') }
 
       it 'does not send an approval status email' do
         expect do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,41 +12,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#sucard_number=' do
-    it 'sets the library_id omitings the first 5 digits' do
-      expect(subject.library_id).to be_blank
-      subject.sucard_number = '12345987654321'
-      expect(subject.library_id).to eq '987654321'
-    end
-  end
-
-  describe '#library_id' do
-    it 'upcases the library id to match symphony' do
-      subject.library_id = 'somelibid'
-      expect(subject.library_id).to eq 'SOMELIBID'
-    end
-  end
-
-  describe '#barcode' do
-    it 'uses the library id' do
-      subject.library_id = 'somelibid'
-      expect(subject.barcode).to eq 'SOMELIBID'
-    end
-
-    context 'with a patron' do
-      let(:patron) { instance_double(Folio::Patron, barcode: '123456789') }
-
-      it 'uses the patron barcode from the ILS' do
-        allow(described_class.patron_model_class).to receive(:find_by).with(sunetid: 'some-user').and_return(patron)
-
-        subject.sunetid = 'some-user'
-        subject.library_id = 'somelibid'
-
-        expect(subject.barcode).to eq '123456789'
-      end
-    end
-  end
-
   describe '#email_address' do
     describe 'for SSO users' do
       before do
@@ -80,9 +45,9 @@ RSpec.describe User do
       end
     end
 
-    describe 'for library ID users' do
+    describe 'for university ID users' do
       it 'is blank' do
-        subject.library_id = '123456'
+        subject.univ_id = '12345678'
         expect(subject.email_address).to be_blank
       end
     end
@@ -114,9 +79,9 @@ RSpec.describe User do
       end
     end
 
-    describe 'for library id users' do
+    describe 'for university id users' do
       it 'is blank' do
-        subject.library_id = '123456'
+        subject.univ_id = '123456789'
         expect(subject.to_email_string).to be_blank
       end
     end
@@ -144,14 +109,14 @@ RSpec.describe User do
     end
   end
 
-  describe '#library_id_user?' do
-    it 'is true when the user has supplied a library ID' do
-      subject.library_id = '12345'
-      expect(subject).to be_library_id_user
+  describe '#univ_id_user?' do
+    it 'is true when the user has supplied a university ID' do
+      subject.univ_id = '123456789'
+      expect(subject).to be_univ_id_user
     end
 
-    it 'is false when the user has not supplied a library ID' do
-      expect(subject).not_to be_library_id_user
+    it 'is false when the user has not supplied a university ID' do
+      expect(subject).not_to be_univ_id_user
     end
   end
 
@@ -162,7 +127,7 @@ RSpec.describe User do
       expect(subject).to be_name_email_user
     end
 
-    it 'is false when the user has not supplied a library ID' do
+    it 'is false when the user has not supplied a university ID' do
       expect(subject).not_to be_name_email_user
     end
   end

--- a/spec/views/requests/success.html.erb_spec.rb
+++ b/spec/views/requests/success.html.erb_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'requests/success.html.erb' do
 
     context 'for requests on behalf of a proxy group' do
       let(:request) { build_stubbed(:page, user:, item_title: 'Test title') }
-      let(:user) { create(:library_id_user, email: 'some-address@example.com') }
+      let(:user) { create(:university_id_user, email: 'some-address@example.com') }
 
       before do
         request.proxy = true


### PR DESCRIPTION
Connects to sul-dlss/SearchWorks#3773

This commit helps us move the access portfolio beyond using library barcode numbers, leaning instead on the university-assigned and -managed "university ID."
