### PR TITLE
FOLIO items may not have barcodes; fall back on the item UUID if there isn't a barcode

### DIFF
--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -60,7 +60,7 @@ module Folio
                    due_date: nil, id: nil, holdings_record_id: nil, suppressed_from_discovery: false)
       @id = id
       @holdings_record_id = holdings_record_id
-      @barcode = barcode
+      @barcode = barcode.presence || id
       @status = status
       @type = type
       @callnumber = callnumber

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -743,6 +743,36 @@ FactoryBot.define do
     end
   end
 
+  factory :empty_barcode_holdings, class: 'Folio::Instance' do
+    id { '1234' }
+    title { 'Empty Barcode Item Title' }
+    contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
+    pub_date { '2018' }
+
+    format { ['Book'] }
+
+    items do
+      [
+        build(:item,
+              id: 'uuid-a',
+              barcode: '12345678',
+              callnumber: 'ABC 123',
+              status: 'Available',
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              id: 'uuid-b',
+              barcode: '',
+              callnumber: 'ABC 456',
+              status: 'Available',
+              effective_location: build(:location, code: 'SAL3-STACKS'))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
+
   factory :missing_holdings, class: 'Folio::Instance' do
     id { '1234' }
     title { 'One Missing item' }

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -353,6 +353,30 @@ RSpec.describe 'Item Selector' do
     page.execute_script("$('#request_needed_date').prop('value', '#{min_date}')")
   end
 
+  context 'when some items have empty barcodes' do
+    before do
+      stub_bib_data_json(build(:empty_barcode_holdings))
+      visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
+    end
+
+    it 'allows selecting the items with and without barcodes' do
+      within('#item-selector') do
+        check('ABC 123')
+        check('ABC 456')
+      end
+
+      within('#sunetid-form') do
+        click_on 'Send request'
+      end
+
+      expect_to_be_on_success_page
+      expect(page).to have_css('dd', text: 'ABC 123')
+      expect(page).to have_css('dd', text: 'ABC 456')
+
+      expect(Page.last.barcodes).to contain_exactly('12345678', 'uuid-b')
+    end
+  end
+
   context 'when some items are not requestable' do
     before do
       stub_bib_data_json(build(:mixed_crez_holdings))


### PR DESCRIPTION
Fixes SW-4281

Irina adds:
> We found 323 items without a barcode where an item is attached to a holding with multiple items (the request does go through if there is only one item without a barcode).
> Most of them fall into two categories:
> 1.Items that are part of the acquisitions workflow where an item record is created when the order is placed, but the barcode is added only when we receive the piece. 
> 2. Items created by EAL staff for “East Asia Big Sets” SAL location (e.g., https://searchworks.stanford.edu/view/11612016).
Both categories need to be requestable.
