### PR TITLE
Preserve parameters during interstitial redirect

### DIFF
--- a/app/views/interstitial/show.html.erb
+++ b/app/views/interstitial/show.html.erb
@@ -4,5 +4,5 @@
 <script type='text/javascript'>
   var div = document.getElementById('redirectNote');
   div.innerHTML = 'Processing...';
-  window.location.href = '<%= @redirect_to %>';
+  window.location.href = '<%= @redirect_to.html_safe %>';
 </script>

--- a/app/views/interstitial/show.html.erb
+++ b/app/views/interstitial/show.html.erb
@@ -4,6 +4,8 @@
 <script type='text/javascript'>
   var div = document.getElementById('redirectNote');
   div.innerHTML = 'Processing...';
+
+  <%# Decode ampersands only, see https://github.com/sul-dlss/sul-requests/issues/1934 %>
   const redirectUrl = '<%= @redirect_to %>'.replaceAll('&amp;', '&');
   window.location.href = redirectUrl;
 </script>

--- a/app/views/interstitial/show.html.erb
+++ b/app/views/interstitial/show.html.erb
@@ -4,5 +4,6 @@
 <script type='text/javascript'>
   var div = document.getElementById('redirectNote');
   div.innerHTML = 'Processing...';
-  window.location.href = '<%= @redirect_to.html_safe %>';
+  const redirectUrl = '<%= @redirect_to %>'.replaceAll('&amp;', '&');
+  window.location.href = redirectUrl;
 </script>

--- a/spec/features/interstitial_redirect_spec.rb
+++ b/spec/features/interstitial_redirect_spec.rb
@@ -16,10 +16,4 @@ RSpec.describe 'Interstitial page redirect' do
 
     expect(page).to have_css('#redirectNote a', text: 'Click here if you are not redirected.')
   end
-
-  it 'redirects using unescaped parameters' do
-    redirect_to = "#{root_url}test?param1=foo&param2=bar"
-    visit interstitial_path(redirect_to:)
-    expect(page.body).to include("window.location.href = '#{redirect_to}'")
-  end
 end

--- a/spec/features/interstitial_redirect_spec.rb
+++ b/spec/features/interstitial_redirect_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe 'Interstitial page redirect' do
 
     expect(page).to have_css('#redirectNote a', text: 'Click here if you are not redirected.')
   end
+
+  it 'redirects using unescaped parameters' do
+    redirect_to = "#{root_url}test?param1=foo&param2=bar"
+    visit interstitial_path(redirect_to:)
+    expect(page.body).to include("window.location.href = '#{redirect_to}'")
+  end
 end


### PR DESCRIPTION
Fixes #1934. 

This seems to occur in both Rails 7.0 and 7.1:
https://app.honeybadger.io/projects/49963/faults/101591418/01HDEW0GXPZ486GB2K9862T6WT
https://app.honeybadger.io/projects/49963/faults/101723263/01HE0QQMPMVWHHTNX50KW496GQ

As suggested in #1934 it appears this was happening when going through `bounce_request_through_sso`, when the interstitial show ERB was escaping the URL in the script tag. This led to the parameter rewriting behavior. All previous tests passed because none had parameters that would be escaped.

As for safety, the only uses of interstitial use internally created `redirect_to` paths. This is my first time dealing with this in rails, if there is a better way, I am happy to hear it.