### PR TITLE
update shelving order to match searchworks

### DIFF
--- a/app/assets/stylesheets/modules/item-selector.scss
+++ b/app/assets/stylesheets/modules/item-selector.scss
@@ -86,3 +86,6 @@
   }
 }
 
+.index {
+  display: none;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,6 +56,49 @@ module ApplicationHelper
     params.except(:controller, :action).to_unsafe_h
   end
 
+  def sort_holdings(holdings_object)
+    holdings_object.sort_by { |item| digit_match(item) }
+  end
+
+  def enumeration_month(enumeration)
+    monthconversion = { 'jan' => 1, 'feb' => 2, 'mar' => 3, 'apr' => 4, 'may' => 5, 'june' => 6,
+                        'july' => 7, 'aug' => 8, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12 }
+    hasmonth = enumeration.downcase.scan(/(#{monthconversion.keys.join('|')})/)
+
+    return 0 if hasmonth.empty?
+
+    monthconversion[hasmonth.last[0]]
+  end
+
+  def enumeration_year_volume(enumeration_numbers, defaultvalues, enumeration)
+    enumeration_numbers.each do |number|
+      if number.length == 4
+        defaultvalues[:year] = number.to_i
+      else
+        defaultvalues[:volume] = number.to_i
+        volume_letter_check = /#{defaultvalues[:volume]}([A-Za-z])/.match(enumeration)
+        defaultvalues[:volume_letter] = volume_letter_check[1] if volume_letter_check.present?
+      end
+    end
+    defaultvalues
+  end
+
+  def digit_match(item)
+    enumeration = item.enumeration
+    defaultvalues = { year: 4000, volume: 0, volume_letter: '' }
+    return [item.callnumber_no_enumeration] unless enumeration
+
+    enumeration_numbers = item.enumeration.split(/\D+/)
+
+    return [item.callnumber_no_enumeration] if enumeration_numbers.empty?
+
+    month = enumeration_month(enumeration)
+    enum_y_v = enumeration_year_volume(enumeration_numbers, defaultvalues, enumeration)
+
+    # sorts by callnumber without year, volume, sorts year desc, volume asc, volume letter asc (28A, 28B), and month descending
+    [item.callnumber_no_enumeration, -enum_y_v[:year], enum_y_v[:volume], enum_y_v[:volume_letter], -month]
+  end
+
   private
 
   def markdown_renderer

--- a/app/javascript/item_selector/item_selector_filtering.js
+++ b/app/javascript/item_selector/item_selector_filtering.js
@@ -4,7 +4,7 @@ import itemSelector from '../item_selector'
 var itemSelectorFiltering = (function() {
   var listOptions = {
     page: 10000,
-    valueNames: ['callnumber', 'status']
+    valueNames: ['callnumber', 'status', 'index']
   };
 
   return $.extend({}, itemSelector, {
@@ -25,7 +25,7 @@ var itemSelectorFiltering = (function() {
       // List.js dynamically injects behavior, so we need to check
       // if the list is sortable before setting the default sort
       if($.isFunction(list.sort)) {
-        list.sort('callnumber', { order: 'asc'});
+        list.sort('index', { order: 'asc'});
       }
     },
 

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -7,7 +7,7 @@ module Folio
   # NOTE, barcode and callnumber may be nil. see instance_hrid: 'in00000063826'
   class Item
     attr_reader :id, :barcode, :status, :type, :callnumber, :public_note, :effective_location, :permanent_location, :temporary_location,
-                :material_type, :loan_type, :holdings_record_id, :enumeration
+                :material_type, :loan_type, :holdings_record_id, :enumeration, :callnumber_no_enumeration
 
     # Other statuses that we aren't using include "Unavailable" and "Intellectual item"
     STATUS_CHECKED_OUT = 'Checked out'
@@ -57,7 +57,8 @@ module Folio
     def initialize(barcode:, status:, callnumber:,
                    effective_location:, permanent_location: nil, temporary_location: nil,
                    type: nil, public_note: nil, material_type: nil, loan_type: nil, enumeration: nil,
-                   due_date: nil, id: nil, holdings_record_id: nil, suppressed_from_discovery: false)
+                   due_date: nil, id: nil, holdings_record_id: nil, suppressed_from_discovery: false,
+                   callnumber_no_enumeration: nil)
       @id = id
       @holdings_record_id = holdings_record_id
       @barcode = barcode.presence || id
@@ -71,6 +72,7 @@ module Folio
       @material_type = material_type
       @loan_type = loan_type
       @enumeration = enumeration
+      @callnumber_no_enumeration = callnumber_no_enumeration
       @due_date = due_date
       @suppressed_from_discovery = suppressed_from_discovery
     end
@@ -192,6 +194,7 @@ module Folio
           status: dyn.dig('status', 'name'),
           due_date: dyn['dueDate'],
           enumeration: dyn['enumeration'],
+          callnumber_no_enumeration: dyn.dig('effectiveCallNumberComponents', 'callNumber'),
           type: dyn.dig('materialType', 'name'),
           callnumber: [dyn.dig('effectiveCallNumberComponents', 'callNumber'), dyn['volume'], dyn['enumeration'],
                        dyn['chronology']].filter_map(&:presence).join(' '),

--- a/app/views/application/_item_selector.html.erb
+++ b/app/views/application/_item_selector.html.erb
@@ -27,12 +27,12 @@
           </div>
         <% end %>
         <div class='btn-group btn-group-xs sort-headings clearfix'>
-          <a href="javascript:;" class="sort sort-callnumber btn btn-default pull-left" data-sort="callnumber">Call number <i></i></a>
+          <a href="javascript:;" class="sort sort-callnumber btn btn-default pull-left" data-sort="index">Call number <i></i></a>
           <a href="javascript:;" class="sort sort-status btn btn-default pull-right" data-sort="status">Status <i></i></a>
         </div>
         <div id="item-selector" class="item-selector" data-limit-selected-items="<%= f.object.item_limit if f.object.item_limit.to_i > 1 %>" data-counter-target="[data-items-counter='true']">
           <div class='list'>
-            <% f.object.all_holdings.sort_by(&:callnumber).each.with_index(1) do |holding, index| %>
+            <% sort_holdings(f.object.all_holdings).each.with_index(1) do |holding, index| %>
               <div class='input-group'>
                 <% if f.object.item_limit.to_i == 1 %>
                   <span class='input-group-addon barcode-checkbox'>
@@ -51,7 +51,7 @@
                     <%= label_for_item_selector_holding(holding) %>
                   <% end %>
                 <% end %>
-
+                <span class='index'><%= index %></span>
                 <% if (note = CurrentLocationNote.new(holding)).present? %>
                   <div data-behavior='current-location-note' class='current-location-note'>
                     <%= note %>

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe 'Paging Schedule' do
     [
       double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                      pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
+                     enumeration: 'V12 2020', callnumber_no_enumeration: 'ABC 123',
                      status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
                      permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil)),
       double('item', callnumber: 'ABC 321', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                      pageable?: true, mediateable?: false, barcode: '9928812', checked_out?: false, status_class: 'active',
+                     enumeration: 'V12 2021', callnumber_no_enumeration: 'ABC 321',
                      status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
                      permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil))
     ]
@@ -77,6 +79,7 @@ RSpec.describe 'Paging Schedule' do
         double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                        pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
                        status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:page_en_location),
+                       enumeration: 'V12 2020', callnumber_no_enumeration: 'ABC 123',
                        requestable?: true, permanent_location: build(:page_en_location), material_type: build(:book_material_type),
                        loan_type: double(id: nil))
       ]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -59,6 +59,69 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#sort_holdings_records' do
+    let(:all_items) do
+      [
+        double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
+                       pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
+                       enumeration: rec_one_enumeration, callnumber_no_enumeration: 'ABC 123',
+                       status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
+                       permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil)),
+        double('item', callnumber: 'ABC 123', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
+                       pageable?: true, mediateable?: false, barcode: '9928812', checked_out?: false, status_class: 'active',
+                       enumeration: rec_two_enumeration, callnumber_no_enumeration: 'ABC 123',
+                       status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
+                       permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil))
+      ]
+    end
+    let(:sorted_holdings) { sort_holdings(all_items) }
+
+    context 'when date with volume' do
+      let(:rec_one_enumeration) { 'V12 2020' }
+      let(:rec_two_enumeration) { 'V12 2021' }
+
+      it 'expects to sort desc by date' do
+        expect(sorted_holdings.first.barcode).to equal('9928812')
+      end
+    end
+
+    context 'when volume with letter' do
+      let(:rec_one_enumeration) { 'V12' }
+      let(:rec_two_enumeration) { 'V12A' }
+
+      it 'expects sort asc by volume and letter' do
+        expect(sorted_holdings.first.barcode).to equal('123123124')
+      end
+    end
+
+    context 'when one item has no enumeration' do
+      let(:rec_one_enumeration) { '' }
+      let(:rec_two_enumeration) { '12' }
+
+      it 'expects items with no enumeration first' do
+        expect(sorted_holdings.first.barcode).to equal('123123124')
+      end
+    end
+
+    context 'when there are months in barcode' do
+      let(:rec_one_enumeration) { 'JANUARY-MARCH 2021' }
+      let(:rec_two_enumeration) { 'Dec 2020:Apr 2021' }
+
+      it 'expects newest month/year combo to be first' do
+        expect(sorted_holdings.first.barcode).to equal('9928812')
+      end
+    end
+
+    context 'when there are months, years, and volumes in barcode' do
+      let(:rec_one_enumeration) { 'JANUARY-MARCH 2021 1' }
+      let(:rec_two_enumeration) { 'Feb-MARCH 2021 12' }
+
+      it 'expects to sort by volume due to same end month' do
+        expect(sorted_holdings.first.barcode).to equal('123123124')
+      end
+    end
+  end
+
   describe '#render_user_information' do
     before do
       helper.extend(Module.new do


### PR DESCRIPTION
Update sort order to sort desc if there is a date, sort asc if there is a volume number without date.

Assumptions I made that might not be right
1. There are no enumerations with 4 digits in a row that are not a year
2. We want the header sort to match what is on sw.

Problem records/not exact matches
1. https://searchworks.stanford.edu/view/3439715: SAL3 sorting is slightly off due to the call number `AP4 .N65 V.149:NO.5540-5550 2020:OCT-202` missing a date and only including it in the notes. We might be able to fix this but I wasn't sure if it was possible due to the fact that the note indicating this wasn't in the results I was getting from dev. It might also be somewhat dangerous if the note is in a weird format. Not all are about missing dates.

**Weirdness**
I used an index value to keep sort matching what is in searchworks. Unfortunately in order to allow sort on that number you also have to allow filtering. That means if you search for example 6 on this record: http://localhost:3000/pages/new?item_id=72765&origin=SAL3&origin_location=SAL3-STACKS you will get two results.

Tested pages
-----
http://localhost:3000/pages/new?item_id=6273253&origin=SAL&origin_location=SAL-ND-PAGE-EA (same on both)

http://localhost:3000/pages/new?item_id=9273087&origin=SAL3&origin_location=SAL3-STACKS (same on both)

http://localhost:3000/pages/new?item_id=5490833&origin=MUSIC&origin_location=MUS-STACKS
Prod
<img width="1684" alt="5490833 - current" src="https://github.com/sul-dlss/sul-requests/assets/19173991/d2a3e2be-6c0b-4bc1-80ee-1885fc2e015a">
This branch
<img width="1695" alt="5490833 - local" src="https://github.com/sul-dlss/sul-requests/assets/19173991/f37f0e45-3612-424e-b60a-bc1631ea817f">

http://localhost:3000/pages/new?item_id=72770&origin=SAL3&origin_location=SAL3-STACKS (this one should be no change. Looks exactly the same on prod and this branch).

http://localhost:3000/pages/new?item_id=72765&origin=SAL3&origin_location=SAL3-STACKS (this one should be no change. Looks exactly the same on prod and this branch).
<img width="1677" alt="72765 - local" src="https://github.com/sul-dlss/sul-requests/assets/19173991/6bbd2f3c-6fc1-4677-a0e4-aa1e544deaf6">


http://localhost:3000/pages/new?item_id=3439715&origin=SAL&origin_location=SAL-PAGE
Prod
<img width="1720" alt="3439715 - current" src="https://github.com/sul-dlss/sul-requests/assets/19173991/77b1d570-d3b4-467d-b9d4-966e54c698da">
This branch
<img width="1721" alt="3439715 - locally" src="https://github.com/sul-dlss/sul-requests/assets/19173991/c4a603c6-9670-4131-981d-821ed1316719">

http://localhost:3000/pages/new?item_id=2403853&origin=SAL3&origin_location=SAL3-STACKS

Prod
<img width="1227" alt="2403853 - current" src="https://github.com/sul-dlss/sul-requests/assets/19173991/a5aca7e1-4836-44e0-9e7f-f9b36a8bbb26">

This branch
<img width="1233" alt="2403853 - local" src="https://github.com/sul-dlss/sul-requests/assets/19173991/0867b273-9c75-4c71-b18c-f2fffbd54f25">

http://localhost:3000/pages/new?item_id=372380&origin=SAL3&origin_location=SAL3-STACKS
prod
<img width="1243" alt="372380 - current" src="https://github.com/sul-dlss/sul-requests/assets/19173991/97ad5279-800e-407c-a5a6-4ab4d77cc0d7">

this branch
<img width="1241" alt="372380 - local" src="https://github.com/sul-dlss/sul-requests/assets/19173991/f466bee2-00a2-472e-b07c-f852f6dfbe43">




closes #2002
