### PR TITLE
Handle open redirect problems with exceptions

### DIFF
--- a/app/controllers/interstitial_controller.rb
+++ b/app/controllers/interstitial_controller.rb
@@ -9,7 +9,7 @@ class InterstitialController < ApplicationController
   layout false
 
   before_action do
-    render(file: 'public/500.html', status: :internal_server_error) unless redirect_param_same_as_host?
+    raise ActionController::Redirecting::UnsafeRedirectError unless redirect_param_same_as_host?
   end
 
   def show

--- a/spec/controllers/interstitial_controller_spec.rb
+++ b/spec/controllers/interstitial_controller_spec.rb
@@ -5,15 +5,15 @@ require 'rails_helper'
 RSpec.describe InterstitialController do
   describe 'show' do
     it 'renders a 500 error if there is no redirect_to parameter' do
-      get :show
-      expect(response).not_to be_successful
-      expect(response).to have_http_status :internal_server_error
+      expect do
+        get :show
+      end.to raise_error(ActionController::Redirecting::UnsafeRedirectError)
     end
 
     it 'renders a 500 error if the redirect_to parameter does not include the original request host' do
-      get :show, params: { redirect_to: 'http://google.com?p=http://test.host' }
-      expect(response).not_to be_successful
-      expect(response).to have_http_status :internal_server_error
+      expect do
+        get :show, params: { redirect_to: 'http://google.com?p=http://test.host' }
+      end.to raise_error(ActionController::Redirecting::UnsafeRedirectError)
     end
 
     it 'successfully responds when the redirect_to parameter is the same host' do


### PR DESCRIPTION
It's possible this logic is basically the same as `Rails.application.config.action_controller.raise_on_open_redirects = true`, but that'd need more investigation.