### PR TITLE
update call unclassified call number to display shelved by title

### DIFF
--- a/spec/models/folio/item_spec.rb
+++ b/spec/models/folio/item_spec.rb
@@ -506,6 +506,26 @@ RSpec.describe Folio::Item do
       end
     end
 
+    context 'an item with a shelved by title call number' do
+      let(:data) do
+        <<~JSON
+          {
+            "effectiveCallNumberComponents": { "callNumber": "UNCLASSIFIED" },
+            "effectiveLocation": { "id": "82d77fc4-6d63-4de9-a6b9-5056570ce060",
+                                   "code": "MAR-SHELBYTITLE",
+                                   "temporaryLoanTypeId": null,
+                                   "permanentLoanTypeId": null },
+            "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+            "notes": []
+          }
+        JSON
+      end
+
+      it 'is shelved by title' do
+        expect(item.callnumber).to eq('Shelved by title')
+      end
+    end
+
     context 'with an item that is checked out' do
       let(:data) do
         <<~JSON


### PR DESCRIPTION
closes #1852 

Couple of things that I assumed wouldn't be an issue but we might want to keep in mind.

1. If the call number is unclassified and there is a volume or enumeration associated with the item they will display together. 
i.e. Shelved by title vol.2. This is an easy fix if we don't want that information to display but I was working under the assumption we would still want to display this information if it exists.

2. We want to only display `shelved by title`. The location name for MAR-SHELBYTITLE is Marine Bio Shelve by tit
le. I am assuming we don't want to include the marine bio information in the call number.

<img width="671" alt="Screenshot 2024-03-11 at 4 08 55 PM" src="https://github.com/sul-dlss/sul-requests/assets/19173991/eb7e41f6-4124-463c-8d42-5102e426e909">
