### PR TITLE
Update to GitHub actions v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,21 +13,21 @@ jobs:
       matrix:
         ruby: ['3.2']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-202103-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-202103
-    - name: Use Node.js 18.17
-      uses: actions/setup-node@v3
+    - name: Use Node.js LTS v18
+      uses: actions/setup-node@v4
       with:
-        node-version: '18.17'
+        node-version: 'lts/hydrogen'
     - name: Bundle install
       run: bundle config path vendor/bundle
     - name: Install dependencies


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Tried to bump node as well, but we have failing tests on v20. Settled for pinning to the hydrogen LTS release (18.19) rather than 18.17.
