### PR TITLE
Add bound-with information to multiple item selector

### DIFF
--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -73,6 +73,11 @@ hr {
   white-space: nowrap;
 }
 
+.single-item-callnumber {
+  margin: -1em 0 0.5em;
+  color: $color-cardinal-red;
+}
+
 .go-back-link {
   line-height: 3;
 }

--- a/app/assets/stylesheets/modules/item-selector.scss
+++ b/app/assets/stylesheets/modules/item-selector.scss
@@ -91,3 +91,28 @@
 .index {
   display: none;
 }
+
+.bound-withs {
+  max-height: 14em;
+  background-color: $fog-light;
+  overflow: scroll;
+  padding: 8px;
+  margin-bottom: 15px;
+  border-radius: 4px;
+
+  ul {
+    margin: 0px;
+  }
+
+  .bound-with-item {
+    padding: 4px 0px;
+  }
+
+  .heading {
+    padding: 8px 0px;
+  }
+
+  li:not(:only-child) {
+    border-top: 1px solid $grayish-yellow;
+  }
+}

--- a/app/assets/stylesheets/modules/item-selector.scss
+++ b/app/assets/stylesheets/modules/item-selector.scss
@@ -42,7 +42,7 @@
 .item-selector {
   border: 1px solid $item-selector-border-color;
   margin-bottom: 1rem;
-  max-height: 200px;
+  max-height: 400px;
   overflow: auto;
 
   .current-location-note {
@@ -54,6 +54,10 @@
     border-color: $item-selector-border-color;
     border-radius: 0;
     border-top: 0;
+
+    .bound-with {
+      border-bottom: none;
+    }
   }
 
   .input-group.active .form-control {
@@ -114,5 +118,39 @@
 
   li:not(:only-child) {
     border-top: 1px solid $grayish-yellow;
+  }
+}
+
+.bound-with-content {
+  background-color: $accent-fog-light;
+  border: 1px solid $gray-ccc;
+  padding: 10px;
+
+  .bound-with-type {
+    display: block;
+    color: $alert-red;
+    padding-top: 8px;
+  }
+
+  .bound-with-item span {
+    display: block;
+  }
+
+  ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    &:not(:only-child) {
+      border-top: 1px solid $primary-black-20;
+      padding-top: 4px;
+      padding-bottom: 4px;
+
+      &:first-child {
+        margin-top: 8px;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -1,5 +1,6 @@
 // Colors
 $alert-red: #a94442;
+$accent-fog-light: #f4f4f4;
 $gray-ccc: #ccc;
 $gray-41-percent: #696969;
 $grayish-yellow: #d5d5d3;
@@ -12,6 +13,7 @@ $white: #fff;
 $dark-cyan: #007c5d;
 $dark-gray:#737373;
 $fog-light: #f4f4f4;
+$primary-black-20: #D5D5D4;
 
 // Mappings
 $sul-admin-h3-color: $gray-41-percent;

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -11,6 +11,7 @@ $pure-yellow: #ff0;
 $white: #fff;
 $dark-cyan: #007c5d;
 $dark-gray:#737373;
+$fog-light: #f4f4f4;
 
 // Mappings
 $sul-admin-h3-color: $gray-41-percent;

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -45,6 +45,22 @@ module RequestsHelper
     end
   end
 
+  def label_for_boundwith_holding(holding)
+    holding.bound_with_parent? ? 'Bound with:' : 'Bound and shelved with:'
+  end
+
+  def all_bound_with_holdings(holding)
+    requested_holdings = holding.bound_with_requested_instance_holdings || []
+    other_holdings = holding.bound_with_other_instance_holdings || []
+
+    if holding.bound_with_parent?
+      requested_holdings.sort_by(&:callnumber) + other_holdings.sort_by(&:callnumber)
+    else
+      remainder_of_requested_holdings = requested_holdings.drop(1)
+      [holding.bound_with_parent] + remainder_of_requested_holdings.sort_by(&:callnumber)
+    end
+  end
+
   def request_level_request_status(request = current_request)
     if request.ils_response.usererr_code
       t("symphony_response.failure.code_#{request.ils_response.usererr_code}.alert_html")

--- a/app/models/folio/boundwith_holding.rb
+++ b/app/models/folio/boundwith_holding.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Folio
+  # Represents holding information in a bound with item
+  class BoundwithHolding
+    attr_reader :callnumber, :title
+
+    def initialize(callnumber:, title:)
+      @callnumber = callnumber
+      @title = title
+    end
+  end
+end

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -28,6 +28,7 @@ module Folio
     end
 
     def self.update_item_fields(item, holdings_record)
+      item['originalEffectiveCallNumber'] = item['effectiveCallNumberComponents']['callNumber']
       item['effectiveCallNumberComponents']['callNumber'] = holdings_record['callNumber']
       item['volume'] = ''
       item['enumeration'] = ''
@@ -47,7 +48,14 @@ module Folio
         matching_bound_with = parent_bound_withs_all_holdings.find { |bound_with| bound_with['boundWithItem']['id'] == item['id'] }
 
         if matching_bound_with && matching_bound_with&.dig('boundWithItem', 'instance', 'hrid') != hrid
-          item['bound_with_parent'] = matching_bound_with&.dig('boundWithItem', 'instance')
+          parent = matching_bound_with&.dig('boundWithItem', 'instance')
+
+          # TODO: This is silly. Once https://github.com/sul-dlss/sul-requests/pull/2030 is in, resolve for real.
+          parent['items'].each do |item|
+            item['effectiveCallNumberComponents']['callNumber'] = item['originalEffectiveCallNumber']
+          end
+
+          item['bound_with_parent'] = parent
         end
 
         matching_bound_with_items = matching_bound_with&.dig('boundWithItem', 'instance', 'items')&.find do |bound_with_item|

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -14,6 +14,46 @@ module Folio
 
       Folio::Instance.from_dynamic(data)
     end
+
+    def self.filter_parent_bound_withs(parent_bound_withs, hrid)
+      return [] unless parent_bound_withs
+
+      parent_bound_withs.flatten.compact.each do |bound_with_record|
+        @filter_parent_bound_withs = bound_with_record.dig('instance', 'items').each.map do |item|
+          boundwithhrids = item['boundWithHoldingsPerItem'].filter { |bw| bw.dig('instance', 'hrid') == hrid }.flatten
+          update_item_fields(item, boundwithhrids.first) if boundwithhrids.present?
+        end
+      end
+      @filter_parent_bound_withs.compact
+    end
+
+    def self.update_item_fields(item, holdings_record)
+      item['effectiveCallNumberComponents']['callNumber'] = holdings_record['callNumber']
+      item['volume'] = ''
+      item['enumeration'] = ''
+      item
+    end
+
+    def self.items(json)
+      hrid = json.fetch('hrid', '')
+      parent_bound_withs = parent_bound_withs(json)
+      return json.fetch('items', []).map { |item| Folio::Item.from_hash(item) } unless parent_bound_withs.present? && hrid
+
+      parent_bound_withs = parent_bound_withs.pluck('boundWithItem')
+      items = filter_parent_bound_withs(parent_bound_withs, hrid)
+      items += json['items'] if json['items']
+      items.compact.map { |item| Folio::Item.from_hash(item) }
+    end
+
+    def self.parent_bound_withs(json)
+      json.fetch('holdingsRecords', []).filter { |holding| holding['boundWithItem'] }
+    end
+
+    def self.child_bound_withs(json)
+      return unless json['items']
+
+      json['items'].pluck('boundWithHoldingsPerItem').flatten.compact
+    end
     # rubocop:enable Style/OptionalBooleanParameter
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -35,14 +75,17 @@ module Folio
         end,
         electronic_access: json.fetch('electronicAccess', []),
         edition: json.fetch('editions', []),
-        items: json.fetch('items', []).map { |item| Folio::Item.from_hash(item) }
+        items: items(json),
+        parent_bound_withs: parent_bound_withs(json),
+        child_bound_withs: child_bound_withs(json)
       )
     end
+
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
     def initialize(id:, hrid: '', title: '', contributors: [], pub_date: nil, pub_place: nil, publisher: nil, format: nil,
-                   isbn: [], oclcn: [], electronic_access: [], edition: [], items: [])
+                   isbn: [], oclcn: [], electronic_access: [], edition: [], items: [], parent_bound_withs: [], child_bound_withs: [])
       @id = id
       @hrid = hrid
       @title = title
@@ -56,6 +99,8 @@ module Folio
       @electronic_access = electronic_access
       @edition = edition
       @items = items
+      @parent_bound_withs = parent_bound_withs
+      @child_bound_withs = child_bound_withs
     end
     # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
@@ -70,7 +115,7 @@ module Folio
       contributor&.fetch('name')
     end
 
-    attr_reader :pub_date, :pub_place, :publisher, :format
+    attr_reader :pub_date, :pub_place, :publisher, :format, :parent_bound_withs, :child_bound_withs
 
     def isbn
       @isbn.first

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -86,6 +86,18 @@ class Request < ActiveRecord::Base
     super || bib_data&.title
   end
 
+  def bound_with?
+    child_bound_withs.present? || parent_bound_withs.present?
+  end
+
+  def parent_bound_withs
+    bib_data&.parent_bound_withs
+  end
+
+  def child_bound_withs
+    bib_data&.child_bound_withs
+  end
+
   # This method gets called when saving the user assocation
   # and allows us to make sure we assign the user object if
   # there already is one associated with that email address

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -65,6 +65,115 @@ class FolioGraphqlClient
       })
   end
 
+  def item_values
+    'items {
+      id
+      barcode
+      discoverySuppress
+      volume
+      status {
+        name
+      }
+      dueDate
+      materialType {
+        id
+        name
+      }
+      chronology
+      enumeration
+      effectiveCallNumberComponents {
+        callNumber
+      }
+      boundWithHoldingsPerItem {
+        callNumber
+        instance {
+          title
+          hrid
+        }
+      }
+      notes {
+        note
+        itemNoteType {
+          name
+        }
+      }
+      effectiveLocation {
+        id
+        campusId
+        libraryId
+        institutionId
+        code
+        discoveryDisplayName
+        name
+        servicePoints {
+          id
+          code
+          pickupLocation
+        }
+        library {
+          id
+          code
+        }
+        campus {
+          id
+          code
+        }
+        details {
+          pageAeonSite
+          pageMediationGroupKey
+          pageServicePoints {
+            id
+            code
+            name
+          }
+          scanServicePointCode
+          availabilityClass
+          searchworksTreatTemporaryLocationAsPermanentLocation
+        }
+      }
+      permanentLocation {
+        id
+        code
+        details {
+          pageAeonSite
+          pageMediationGroupKey
+          pageServicePoints {
+            id
+            code
+            name
+          }
+          pagingSchedule
+          scanServicePointCode
+        }
+      }
+      temporaryLocation {
+        id
+        code
+        discoveryDisplayName
+      }
+      permanentLoanTypeId
+      temporaryLoanTypeId
+      holdingsRecord {
+        id
+        effectiveLocation {
+          id
+          code
+          details {
+            pageAeonSite
+            pageMediationGroupKey
+            pageServicePoints {
+              id
+              code
+              name
+            }
+            pagingSchedule
+            scanServicePointCode
+          }
+        }
+      }
+    }'
+  end
+
   def instance(hrid:)
     data = post_json('/', json:
     {
@@ -79,6 +188,22 @@ class FolioGraphqlClient
                 value
                 identifierTypeObject {
                   name
+                }
+              }
+              holdingsRecords {
+                callNumber
+                boundWithItem {
+                  hrid
+                  effectiveCallNumberComponents {
+                    callNumber
+                  }
+                  volume
+                  enumeration
+                  instance {
+                    hrid
+                    title
+                    #{item_values}
+                  }
                 }
               }
               instanceType {
@@ -98,105 +223,7 @@ class FolioGraphqlClient
                 materialsSpecification
                 uri
               }
-              items {
-                id
-                barcode
-                discoverySuppress
-                volume
-                status {
-                  name
-                }
-                dueDate
-                materialType {
-                  id
-                  name
-                }
-                chronology
-                enumeration
-                effectiveCallNumberComponents {
-                  callNumber
-                }
-                notes {
-                  note
-                  itemNoteType {
-                    name
-                  }
-                }
-                effectiveLocation {
-                  id
-                  campusId
-                  libraryId
-                  institutionId
-                  code
-                  discoveryDisplayName
-                  name
-                  servicePoints {
-                    id
-                    code
-                    pickupLocation
-                  }
-                  library {
-                    id
-                    code
-                  }
-                  campus {
-                    id
-                    code
-                  }
-                  details {
-                    pageAeonSite
-                    pageMediationGroupKey
-                    pageServicePoints {
-                      id
-                      code
-                      name
-                    }
-                    scanServicePointCode
-                    availabilityClass
-                    searchworksTreatTemporaryLocationAsPermanentLocation
-                  }
-                }
-                permanentLocation {
-                  id
-                  code
-                  details {
-                    pageAeonSite
-                    pageMediationGroupKey
-                    pageServicePoints {
-                      id
-                      code
-                      name
-                    }
-                    pagingSchedule
-                    scanServicePointCode
-                  }
-                }
-                temporaryLocation {
-                  id
-                  code
-                  discoveryDisplayName
-                }
-                permanentLoanTypeId
-                temporaryLoanTypeId
-                holdingsRecord {
-                  id
-                  effectiveLocation {
-                    id
-                    code
-                    details {
-                      pageAeonSite
-                      pageMediationGroupKey
-                      pageServicePoints {
-                        id
-                        code
-                        name
-                      }
-                      pagingSchedule
-                      scanServicePointCode
-                    }
-                  }
-                }
-              }
+              #{item_values}
             }
           }
         GQL

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -193,6 +193,7 @@ class FolioGraphqlClient
               holdingsRecords {
                 callNumber
                 boundWithItem {
+                  id
                   hrid
                   effectiveCallNumberComponents {
                     callNumber

--- a/app/views/application/_item_selector.html.erb
+++ b/app/views/application/_item_selector.html.erb
@@ -16,6 +16,19 @@
         </div>
       </div>
       <%= barcode.hidden_field single_item.barcode.present? ? single_item.barcode : 'NO_BARCODE', value: 1 %>
+      <% if f.object.bound_with? %>
+        <div class="bound-withs">
+            <% is_child = f.object.parent_bound_withs.present? %>
+            <% bound_withs = is_child ? f.object.parent_bound_withs : f.object.child_bound_withs %>
+            <strong class="heading">This item is bound<% if is_child %> and shelved<% end %> with</strong>
+            <%= render 'item_selector_bound_withs', bound_withs:, is_child: %>
+        </div>
+      <% end %>
+      <% if (note = CurrentLocationNote.new(single_item)).present? %>
+        <p class="single-item-current-location-note">
+          <%= note %>
+        </p>
+      <% end %>
     <% elsif f.object.all_holdings.many? %>
       <div id='selected-items-filter' data-behavior='item-selector' data-limit-reached-message="<%= t('sul_requests.limit_reached_message', limit: f.object.item_limit) %>">
         <% if f.object.all_holdings.count >= 10 %>

--- a/app/views/application/_item_selector.html.erb
+++ b/app/views/application/_item_selector.html.erb
@@ -6,7 +6,9 @@
         <span class='col-form-label <%= label_column_class %>'>Call number</span>
         <div class='<%= content_column_class %>'>
           <p class="form-control-static">
-            <%= single_item.callnumber %>
+            <div class="single-item-callnumber">
+              Call number: <%= single_item.callnumber %>
+            </div>
           </p>
           <% if (note = CurrentLocationNote.new(single_item)).present? %>
             <p class="single-item-current-location-note">
@@ -59,10 +61,13 @@
                   <span class='input-group-prepend barcode-checkbox'>
                     <%= render partial: 'item_selector_checkbox', locals: { f: f, barcode: barcode, holding: holding, index: index } %>
                   </span>
-                  <%= barcode.label holding.barcode, class: 'form-control' do %>
+                  <%= barcode.label holding.barcode, class: "form-control #{'bound-with' if holding.bound_with?}" do %>
                     <span class='callnumber'><%= holding.callnumber %></span>
                     <%= label_for_item_selector_holding(holding) %>
                   <% end %>
+                <% end %>
+                <% if holding.bound_with? %>
+                  <%= render partial: 'item_selector_bound_with_content', locals: { holding: holding } %>
                 <% end %>
                 <span class='index'><%= index %></span>
                 <% if (note = CurrentLocationNote.new(holding)).present? %>

--- a/app/views/application/_item_selector_bound_with_content.html.erb
+++ b/app/views/application/_item_selector_bound_with_content.html.erb
@@ -1,0 +1,11 @@
+<div class='bound-with-content'>
+  <span class='bound-with-type'><%= label_for_boundwith_holding(holding) %></span>
+  <ul>
+    <% all_bound_with_holdings(holding).each do |bound_with_holding| %>
+      <li class="bound-with-item <%= 'parent' if !holding.bound_with_parent? %>">
+        <span class='title'><%= bound_with_holding.title %></span>
+        <span class='callnumber'><%= bound_with_holding.callnumber %></span>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/application/_item_selector_bound_withs.html.erb
+++ b/app/views/application/_item_selector_bound_withs.html.erb
@@ -1,0 +1,12 @@
+<ul class="list-unstyled">
+    <% bound_withs.each do |bound_with| %>
+        <li class="bound-with-item">
+            <% item =  is_child ? bound_with['boundWithItem'] : bound_with %>
+            <% callNumber = is_child ? item['effectiveCallNumberComponents']['callNumber'] : item['callNumber'] %>
+            <div class="title"><%= item['instance']['title'] %></div>
+            <div class="callnumber">
+                <%= callNumber %> <%= item['volume'] %> <%= item['enumeration'] %>
+            </div>
+        </li>
+    <% end %>
+</ul>

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -124,6 +124,84 @@ FactoryBot.define do
     end
   end
 
+  factory :boundwith_holding, class: 'Folio::BoundwithHolding' do
+    title { 'Boundwith Title' }
+    callnumber { 'ABC 456' }
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
+
+  factory :multiple_holdings_with_a_child_boundwith, class: 'Folio::Instance' do
+    id { '1234' }
+    hrid { 'a1234' }
+    title { 'Cats' }
+    format { 'Book' }
+    items do
+      [
+        build(:item,
+              barcode: '3610512345678',
+              callnumber: 'XYZ 123',
+              bound_with_parent: build(:boundwith_holding, callnumber: 'XYZ 123', title: 'Dogs'),
+              bound_with_requested_instance_holdings: [
+                build(:boundwith_holding, callnumber: 'ABC 124', title: 'Cats'),
+                build(:boundwith_holding, callnumber: 'ABC 125', title: 'Cats')
+              ],
+              bound_with_other_instance_holdings: [
+                build(:boundwith_holding, callnumber: 'GGG 111', title: 'Birds')
+              ],
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              barcode: '3610587654321',
+              callnumber: 'ZZZ 321',
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              barcode: '12345679',
+              callnumber: 'ZZZ 456',
+              effective_location: build(:location, code: 'SAL3-STACKS'))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
+
+  factory :multiple_holdings_with_a_parent_boundwith, class: 'Folio::Instance' do
+    id { '1234' }
+    hrid { 'a1234' }
+    title { 'Cats' }
+    format { 'Book' }
+    items do
+      [
+        build(:item,
+              barcode: '3610512345678',
+              callnumber: 'XYZ 123',
+              bound_with_requested_instance_holdings: [
+                build(:boundwith_holding, callnumber: 'ABC 124', title: 'Cats')
+              ],
+              bound_with_other_instance_holdings: [
+                build(:boundwith_holding, callnumber: 'GGG 111', title: 'Birds'),
+                build(:boundwith_holding, callnumber: 'GGG 222', title: 'Lizards')
+              ],
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              barcode: '3610587654321',
+              callnumber: 'ZZZ 321',
+              effective_location: build(:location, code: 'SAL3-STACKS')),
+        build(:item,
+              barcode: '12345679',
+              callnumber: 'ZZZ 456',
+              effective_location: build(:location, code: 'SAL3-STACKS'))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
+
   factory :sal3_holding, class: 'Folio::Instance' do
     id { '12345' }
     hrid { 'a12345' }

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -231,6 +231,47 @@ RSpec.describe 'Item Selector' do
         expect(page).to have_css('dd', text: 'ABC 901')
       end
     end
+
+    describe 'when one item from an unrequested instance is bound-with that contains a requested holding (child)' do
+      let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS') }
+
+      before do
+        stub_bib_data_json(build(:multiple_holdings_with_a_child_boundwith))
+        visit request_path
+      end
+
+      it 'shows the first child in place of the unrequested item' do
+        expect(page).to have_css('.form-control.bound-with .callnumber', text: 'ABC 124')
+      end
+
+      it 'shows that the requested holding is bound with an unrequested item and other requested holdings' do
+        expect(page).to have_css('.bound-with-type', text: 'Bound and shelved with')
+        expect(page).to have_css('.bound-with-content .bound-with-item', text: 'Dogs')
+        expect(page).to have_css('.bound-with-item .callnumber', text: 'XYZ 123')
+        expect(page).to have_css('.bound-with-content .bound-with-item', text: 'Cats')
+        expect(page).to have_css('.bound-with-item .callnumber', text: 'ABC 125')
+      end
+    end
+
+    describe 'when one item from a requested instance is a bound-with (parent)' do
+      let(:request_path) { new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS') }
+
+      before do
+        stub_bib_data_json(build(:multiple_holdings_with_a_parent_boundwith))
+        visit request_path
+      end
+
+      it 'shows both requested and unrequested holdings bound with the item' do
+        expect(page).to have_css('.form-control.bound-with .callnumber', text: 'XYZ 123')
+        expect(page).to have_css('.bound-with-type', text: 'Bound with')
+        expect(page).to have_css('.bound-with-content .bound-with-item', text: 'Cats')
+        expect(page).to have_css('.bound-with-item .callnumber', text: 'ABC 124')
+        expect(page).to have_css('.bound-with-content .bound-with-item', text: 'Birds')
+        expect(page).to have_css('.bound-with-item .callnumber', text: 'GGG 111')
+        expect(page).to have_css('.bound-with-content .bound-with-item', text: 'Lizards')
+        expect(page).to have_css('.bound-with-item .callnumber', text: 'GGG 222')
+      end
+    end
   end
 
   describe 'when viewed under Back-Forward Cache', :js do

--- a/spec/features/library_instructions_spec.rb
+++ b/spec/features/library_instructions_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe 'Library Instructions' do
                    material_type: build(:book_material_type), loan_type: double(id: nil))]
   end
 
-  let(:instance) { instance_double(Folio::Instance, title: 'Test title', request_holdings: selected_items, items: []) }
+  let(:instance) do
+    instance_double(Folio::Instance, title: 'Test title', request_holdings: selected_items, items: [],
+                                     parent_bound_withs: [], child_bound_withs: [])
+  end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:fetch).and_return(instance)

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe 'Paging Schedule' do
     ]
   end
 
-  let(:instance) { instance_double(Folio::Instance, title: 'Test title', request_holdings: all_items, items: []) }
+  let(:instance) do
+    instance_double(Folio::Instance, title: 'Test title', request_holdings: all_items, items: [],
+                                     parent_bound_withs: [], child_bound_withs: [])
+  end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:fetch).and_return(instance)

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe 'Paging Schedule' do
                      pageable?: true, mediateable?: false, barcode: '123123124', checked_out?: false, status_class: 'active',
                      enumeration: 'V12 2020', callnumber_no_enumeration: 'ABC 123',
                      status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
-                     permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil)),
+                     permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil),
+                     bound_with?: false),
       double('item', callnumber: 'ABC 321', processing?: false, missing?: false, hold?: false, on_order?: false, hold_recallable?: false,
                      pageable?: true, mediateable?: false, barcode: '9928812', checked_out?: false, status_class: 'active',
                      enumeration: 'V12 2021', callnumber_no_enumeration: 'ABC 321',
                      status_text: 'Active', public_note: 'huh?', type: 'STKS', effective_location: build(:location), requestable?: true,
-                     permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil))
+                     permanent_location: build(:location), material_type: build(:book_material_type), loan_type: double(id: nil),
+                     bound_with?: false)
     ]
   end
 

--- a/spec/features/pickup_libraries_dropdown_spec.rb
+++ b/spec/features/pickup_libraries_dropdown_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe 'Pickup Libraries Dropdown' do
           effective_location: build(:location, code: 'SAL3-STACKS'))
   end
 
-  let(:instance) { instance_double(Folio::Instance, title: 'Test title', request_holdings: [item], items: []) }
+  let(:instance) do
+    instance_double(Folio::Instance, title: 'Test title', request_holdings: [item], items: [],
+                                     parent_bound_withs: [], child_bound_withs: [])
+  end
 
   before do
     allow(Settings.ils.bib_model.constantize).to receive(:fetch).and_return(instance)

--- a/spec/features/send_request_buttons_spec.rb
+++ b/spec/features/send_request_buttons_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe 'Send Request Buttons' do
   let(:mediateable) { false }
 
   let(:instance) do
-    instance_double(Folio::Instance, title: 'Test title', request_holdings: selected_items, items: [])
+    instance_double(Folio::Instance, title: 'Test title', request_holdings: selected_items, items: [],
+                                     parent_bound_withs: [], child_bound_withs: [])
   end
 
   before do

--- a/spec/views/application/_item_selector.html.erb_spec.rb
+++ b/spec/views/application/_item_selector.html.erb_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe 'application/_item_selector.html.erb' do
     context 'from the holdings' do
       let(:request) { create(:request_with_holdings) }
 
-      it 'displays the single barcoded item' do
-        expect(rendered).to have_css '.form-control-static', text: 'ABC 123'
+      it 'displays the single call number' do
+        expect(rendered).to have_css '.single-item-callnumber', text: 'ABC 123'
       end
     end
 
     context 'requested via barcode' do
       let(:request) { create(:request_with_multiple_holdings, barcode: '3610512345678') }
 
-      it 'displays the single barcoded item' do
-        expect(rendered).to have_css '.form-control-static', text: 'ABC 123'
+      it 'displays the single call number' do
+        expect(rendered).to have_css '.single-item-callnumber', text: 'ABC 123'
       end
     end
   end


### PR DESCRIPTION
Drafting this so it does not get lost. It is not ready.

This is for #1998. It is currently dependent on the work done in https://github.com/sul-dlss/sul-requests/pull/2030, which has not been merged yet. I've cherry picked what I need to create this branch.

Main is ahead, so there were merge conflicts and I didn't fully resolve them. There are some tests here that are failing for single items because of this. When this gets picked up again and conflicts need to be resolved, code related to single item selection should definitely not come from this branch.

Some examples of how it currently looks:
http://localhost:3000/pages/new?item_id=387559&origin=SAL3&origin_location=STACKS
![Screenshot 2024-03-15 at 4 24 53 PM](https://github.com/sul-dlss/sul-requests/assets/4421877/270c3014-6806-408c-ab28-d4f02bebc106)
![Screenshot 2024-03-15 at 6 03 12 PM](https://github.com/sul-dlss/sul-requests/assets/4421877/12fd59a8-a664-42a8-acba-34334a793a0e)

Note: In a design huddle we decided to try placing additional holdings of the requested item to the top of the bound-with list (e.g., in the first example `A 1.34:173` appears at the top of the list). Darcy hasn't gotten to see the result with live data yet though, might be a good idea to have a designer confirm they like this.
