### PR TITLE
Implement SUL header

### DIFF
--- a/app/assets/stylesheets/application_redesign.scss
+++ b/app/assets/stylesheets/application_redesign.scss
@@ -59,13 +59,28 @@ a {
   text-decoration: none;
 }
 
+// Footer and header links don't get underline until you hover
+#sul-header,
+#su-footer {
+  --bs-link-decoration: none;
+  --bs-link-hover-decoration: underline;
+}
+
+// Font smoothing for light text on dark background
+#app-header,
+#su-footer {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#sul-header {
+  --bs-link-color-rgb: $su-cardinal;
+  --bs-link-hover-color-rgb: $su-cardinal;
+}
+
 #su-footer {
   --bs-link-color-rgb: $white;
   --bs-link-hover-color-rgb: $white;
-  --bs-link-decoration: none;
-  --bs-link-hover-decoration: underline;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 
   ul {
     a {

--- a/app/views/layouts/application_new.html.erb
+++ b/app/views/layouts/application_new.html.erb
@@ -27,6 +27,9 @@
   </head>
 
   <body>
+    <header>
+      <%= render 'shared/sul_header' %>
+    </header>
     <main class="container">
       <%= yield %>
     </main>

--- a/app/views/shared/_sul_header.html.erb
+++ b/app/views/shared/_sul_header.html.erb
@@ -1,0 +1,34 @@
+<!-- SUL header -->
+<div id="sul-header" class="bg-white text-cardinal py-1 fs-7">
+  <div class="container d-flex flex-column flex-sm-row gap-1 gap-sm-0 justify-content-between align-items-center">
+    <%= link_to 'https://library.stanford.edu' do %>
+      <%= tag.span t('.sul'), class: "visually-hidden" %>
+      <%= image_tag "sul-logo.svg", class: "sul-logo d-none d-md-block", alt: "", height: 25 %>
+      <%= image_tag "sul-logo-stacked.svg", class: "sul-logo d-md-none", alt: "", height: 25 %>
+    <% end %>
+    <nav aria-label="header menu">
+      <ul class="list-unstyled d-flex gap-4 m-0">
+        <li>
+          <% if current_user.sso_user? %>
+            <%= link_to t('.logout', sunetid: current_user.sunetid), logout_path(referrer: root_path) %>
+          <% else %>
+            <%= link_to t('.login'), login_path(referrer: request.original_url) %>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to t('.my_account'), "https://mylibrary.stanford.edu/" %>
+        </li>
+        <li>
+          <%= link_to t('.feedback'), "https://searchworks.stanford.edu/feedback", target: '_blank'  %>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+
+<!-- Application header -->
+<div id="app-header" class="text-white bg-cardinal py-3 d-flex">
+  <div class="container">
+    <%= tag.span t('.application_name'), class: "fs-3" %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,3 +196,11 @@ en:
       help_text:
         one: 'Select an item from the list above.'
         other: 'Select one or more items from the list above.'
+  shared:
+    sul_header:
+      sul: Stanford University Libraries
+      login: Login
+      logout: "%{sunetid}: Logout"
+      mylibrary: My Account
+      feedback: Feedback
+      application_name: Requests

--- a/spec/views/shared/_sul_header.html.erb_spec.rb
+++ b/spec/views/shared/_sul_header.html.erb_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'shared/_sul_header.html.erb' do
+  before do
+    allow(view).to receive_messages(current_user: user)
+    render
+  end
+
+  describe 'login link' do
+    let(:user) { create(:anon_user) }
+
+    it 'has a login link if there is no user' do
+      expect(rendered).to have_css('a', text: 'Login')
+    end
+  end
+
+  describe 'logout link' do
+    let(:user) { create(:sso_user) }
+
+    it 'has a logout link if there is a user' do
+      expect(rendered).to have_css('a', text: 'some-sso-user: Logout')
+    end
+
+    it 'redirects users back to the home page of the app' do
+      expect(rendered).to have_link('Logout', href: '/sso/logout?referrer=%2F')
+    end
+  end
+end


### PR DESCRIPTION
Closes #2066

I didn't add the 'SearchWorks' text to the app header (it just says "Requests") since I don't think we were 100% on that yet?

The font size for the header links is also quite small in current production and in the designs (smaller than BS5's minimum font size). Should we make it that small? I left it as the default.

Most screens:

![Screenshot 2024-03-20 at 14 14 55](https://github.com/sul-dlss/sul-requests/assets/4924494/b726bba9-aa20-405f-abda-beb35c25d454)

Small screens:

![Screenshot 2024-03-20 at 14 15 09](https://github.com/sul-dlss/sul-requests/assets/4924494/983bc632-e5a8-4ec8-bc5a-1dbcd38f1890)
