### PR TITLE
create homepage for patron_requests

### DIFF
--- a/app/assets/stylesheets/application_redesign.scss
+++ b/app/assets/stylesheets/application_redesign.scss
@@ -12,6 +12,7 @@ $black: $su-process-black;
 
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
+@import "bootstrap-icons/font/bootstrap-icons";
 
 // Create your own map
 $custom-colors: (
@@ -83,4 +84,19 @@ a {
       font-size: 0.9375rem;
     }
   }
+}
+
+details[open] summary .bi-chevron-right::before {
+ transform: rotate(-90deg);
+}
+
+summary .bi-chevron-right::before {
+  transition: .25s transform ease;
+  font-weight: 900!important;
+}
+
+.required-label::after {
+    content: '*';
+    color: $su-cardinal;
+    margin-left: 5px;
 }

--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -5,15 +5,29 @@
 ###
 class PatronRequestsController < ApplicationController
   layout 'application_new'
-  load_and_authorize_resource
+  load_and_authorize_resource instance_name: :request
+  helper_method :current_request
 
   def show; end
 
-  def new; end
+  def new
+    current_request.assign_attributes(new_params)
+  end
 
   def create; end
 
   protected
+
+  def current_request
+    @request
+  end
+
+  def new_params
+    params.require(:instance_hrid)
+    params.require(:origin_location_code)
+
+    params.permit(:instance_hrid, :origin_location_code, :barcode)
+  end
 
   def patron_request_params
     params.require(:patron_request).permit(:patron_email, :instance_hrid, :needed_date, :service_point_code)

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -17,12 +17,11 @@ class RequestsController < ApplicationController
 
   helper_method :current_request, :delegated_request?
 
-  class_attribute :bib_model_class, default: Settings.ils.bib_model.constantize
-
-  rescue_from bib_model_class::NotFound, with: :item_not_found
-
   before_action only: :new, if: -> { Settings.features.requests_redesign } do
-    redirect_to(new_patron_request_path(current_request))
+    mapped_params = { 'instance_hrid' => new_params[:item_id],
+                      'origin_location_code' => params[:origin_location],
+                      'barcode' => new_params[:barcode] }
+    redirect_to(new_patron_request_path(mapped_params))
   end
 
   def new

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -17,6 +17,10 @@ class RequestsController < ApplicationController
 
   helper_method :current_request, :delegated_request?
 
+  class_attribute :bib_model_class, default: Settings.ils.bib_model.constantize
+
+  rescue_from bib_model_class::NotFound, with: :item_not_found
+
   before_action only: :new, if: -> { Settings.features.requests_redesign } do
     mapped_params = { 'instance_hrid' => new_params[:item_id],
                       'origin_location_code' => params[:origin_location],

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
 
+###
+#  Main Request class for Requests WC.
+###
 class PatronRequest < ApplicationRecord
+  class_attribute :bib_model_class, default: Settings.ils.bib_model.constantize
+
+  def bib_data
+    @bib_data ||= begin
+      # Append "a" to the item_id unless it already starts with a letter (e.g. "in00000063826")
+      hrid = instance_hrid.start_with?(/\d/) ? "a#{instance_hrid}" : instance_hrid
+      bib_model_class.fetch(hrid)
+    end
+  end
+
+  def item_title
+    bib_data&.title
+  end
 end

--- a/app/views/layouts/application_new.html.erb
+++ b/app/views/layouts/application_new.html.erb
@@ -27,7 +27,9 @@
   </head>
 
   <body>
-    <%= yield %>
+    <main class="container">
+      <%= yield %>
+    </main>
     <footer>
       <%= render 'shared/su_global_footer' %>
     </footer>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -1,1 +1,102 @@
-Hello world.
+<h1>Request</h1>
+<h2 class="text-cardinal">
+  <%= current_request.item_title %>
+</h2>
+<p>Stanford Libraries aims to improve convenience by offering various request services.
+    The availability of these services is contingent upon specific circumstances, including material type,
+    item status (whether it's available, checked out, or otherwise unavailable), the owning library of the item,
+    and your affiliation. Typically, SUNet ID access grants the highest level of privileges, while visitor access
+    offers fewer options.
+</p>
+<div class="row flex-column flex-sm-row landing-page">
+    <div class="col-sm-6">
+        <div class="card">
+            <h3 class="card-header bg-white">Stanford affiliation</h3>
+            <div class="card-body">
+                <button class="btn btn-md btn-primary btn-full btn-cardinal mb-2">Log in with SUNet ID</button>
+                <p>
+                    As a Stanford affiliated faculty member, student, post-doc, fellow, or visiting scholars,
+                    you’ve been assigned a SUNet ID, which gives you more request options,
+                    including scan and deliver to your email address, interlibrary loan, and paging
+                    - a service where a library staff member will retrieve an item from a shelf.
+                    <br>
+                    <strong>This is the recommended path if you have a SUNet ID.</strong>
+                <p>
+                <a href="https://library.stanford.edu/services/borrow-and-request" target="_blank">
+                    <i class="bi bi-box-arrow-up-right"></i> Review borrow and request policies
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6">
+        <div class="card border-0">
+            <div class="card-body">
+                <h3>Library card holder</h3>
+                <p>If you’ve purchased a library card or received courtesy access,
+                log in with your University ID and PIN.
+                </p>
+                <p>
+                    <a href="https://library.stanford.edu/visitor-access" target="_blank">
+                        <i class="bi bi-box-arrow-up-right"></i> Learn about library card holder access
+                    </a>
+                </p>
+                <details>
+                    <summary class="btn btn-link p-0">Login with University ID/PIN <i class="bi bi-chevron-right"></i></summary>
+                    <form class="form p-3">
+                        <div class="form-group mt-2">
+                            <label class="form-label required-label" for="university_id">Library ID</label>
+                            <input class="form-control" id="university_id" name="university_id" required />
+                            <div class="form-text">Last 10 digits above the barcode on your library card</div>
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="form-label required-label" for="pin">PIN</label>
+                            <input class="form-control" type="password" id="pin" name="pin" required/>
+                            <div class="form-text">
+                                <a href="https://mylibrary.stanford.edu/reset_pin">
+                                    Forgot your PIN? Don't have one yet?
+                                </a>
+                            </div>
+                        </div>
+                        <div class="d-flex justify-content-end">
+                            <button type="submit" class="btn btn-outline-cardinal float-right">
+                                Login
+                            </button>
+                        </div>
+                    </form>
+                </details>
+            </div>
+        </div>
+        <div class="card border-0">
+            <div class="card-body">
+                <h3>Visitor</h3>
+                <p>If you don’t have a SUNet ID or a library card, you might still be eligible for visitor access.
+                Visitor access is seven free days each year.
+                Please note that in order to borrow your requested item(s), you must first register for
+                visitor access at one of the following libraries: Green Library,
+                Art and Architecture Library (Bowes) or East Asia Library.
+                </p>
+                <p><a href="https://library.stanford.edu/visitor-access" target="_blank">
+                    <i class="bi bi-box-arrow-up-right"></i> Visitor access
+                </a></p>
+                <details>
+                    <summary class="btn btn-link p-0">Proceed as visitor <i class="bi bi-chevron-right"></i></summary>
+                    <form class="form p-3">
+                        <div class="form-group mt-2">
+                            <label class="form-label required-label" for="name">Name</label>
+                            <input class="form-control" id="name" name="name" required />
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="form-label required-label" for="patron_email">Email</label>
+                            <input class="form-control" id="patron_email" name="patron_email" required/>
+                        </div>
+                        <div class="d-flex justify-content-end mt-3">
+                            <button type="submit" class="btn btn-outline-cardinal float-right">
+                                Login
+                            </button>
+                        </div>
+                    </form>
+                </details>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
closes #2071 

PR does the following:

1. When going to a url like http://localhost:3000/requests/new?item_id=14029321&origin=SAL3&origin_location=SAL3-STACKS, it will redirect with new parameters to http://localhost:3000/patron_requests/new?instance_hrid=14029321&origin_location_code=SAL3-STACKS
2. Builds a homepage with login modules for everything. (all login including SUNet need to be setup)
3. Gets data from Folio

See screenshots for local view.
![Screenshot 2024-03-20 at 6 36 50 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/7d1a268a-b696-46ee-8a0b-35548aac4d1c)
![Screenshot 2024-03-20 at 6 36 35 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/22929d62-4c33-4fb7-b8ee-1180c8c5b2e5)
![Screenshot 2024-03-20 at 18-39-07 SUL Requests](https://github.com/sul-dlss/sul-requests/assets/19173991/165863b2-1b16-4c17-a4ff-7452128a188f)
