### PR TITLE
port over mylibrary feedback form to requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,3 +120,5 @@ gem "jsbundling-rails", "~> 1.1"
 gem "turbo-rails", "~> 1.4"
 
 gem "propshaft", "~> 0.7.0"
+
+gem 'recaptcha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    recaptcha (5.16.0)
     redcarpet (3.6.0)
     redis (4.8.1)
     redis-client (0.21.0)
@@ -519,6 +520,7 @@ DEPENDENCIES
   rack
   rails (~> 7.1.3)
   rails-controller-testing
+  recaptcha
   redcarpet
   redis (~> 4.8)
   rspec-rails (~> 6.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,12 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= CurrentUser.for(request)
   end
-  helper_method :current_user
+
+  def current_user?
+    current_user.sunetid.present?
+  end
+
+  helper_method :current_user, :current_user?
 
   private
 

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+###
+#  Controller to handle feedback from app
+###
+class FeedbackFormsController < ApplicationController
+  layout 'application_new'
+
+  def new; end
+
+  def create
+    FeedbackMailer.submit_feedback(params, request.remote_ip).deliver_now if valid?
+
+    respond_to do |format|
+      format.json { render json: feedback_flash_messages }
+      format.html { redirect_to params[:url], flash: feedback_flash_messages }
+    end
+  end
+
+  protected
+
+  def url_regex
+    %r/.*href=.*|.*url=.*|.*https?:\/{2}.*/i
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def errors
+    errors = []
+    errors << 'You must pass the reCAPTCHA challenge' if !current_user? && !verify_recaptcha
+    errors << 'A message is required' if params[:message].blank?
+    if params[:email_address].present?
+      errors << 'You have filled in a field that makes you appear as a spammer.' \
+                'Please follow the directions for the individual form fields.'
+    end
+    if params[:user_agent] =~ url_regex || params[:viewport] =~ url_regex
+      errors << 'Your message appears to be spam, and has not been sent.'
+    end
+    errors
+  end
+
+  # rubocop:enable Metrics/AbcSize
+  def valid?
+    errors.empty?
+  end
+
+  def feedback_flash_messages
+    feedback_messages = {}
+    if valid?
+      feedback_messages[:success] = t 'sul_requests.feedback_form.success'
+    else
+      feedback_messages[:warning] = errors.join('<br/>')
+    end
+    feedback_messages
+  end
+end

--- a/app/helpers/feedback_forms_helper.rb
+++ b/app/helpers/feedback_forms_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# FeedbackFormsHelper
+module FeedbackFormsHelper
+end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# FeedbackMailer
+class FeedbackMailer < ApplicationMailer
+  def submit_feedback(params, ip)
+    @name = params[:name].presence || 'No name given'
+    @email = params[:to].presence || 'No email given'
+    @message = params[:message]
+    @url = params[:url]
+    @ip = ip
+    @user_agent = params[:user_agent]
+    @viewport = params[:viewport]
+
+    mail(to: Settings.EMAIL_TO,
+         subject: t('sul_requests.feedback_mailer.subject').to_s,
+         from: 'feedback@requests.stanford.edu',
+         reply_to: Settings.EMAIL_TO)
+  end
+end

--- a/app/views/feedback_forms/new.html.erb
+++ b/app/views/feedback_forms/new.html.erb
@@ -1,0 +1,66 @@
+<% if current_page?(feedback_form_path) %>
+  <h1 class="text-center mt-2">Submit feedback</h1>
+<% end %>
+<%= form_tag feedback_form_path, method: :post, class:"feedback-form" do %>
+  <div class="row mt-4">
+    <div class="offset-md-2 col-md-8 mb-2">
+      <div class="alert alert-info" role="alert">
+        <div class="row">
+          <div class="col-sm-9">
+            Reporting from: <span class="reporting-from-field"><%= root_url %></span>
+            <%# TODO_SW_2024: update to url that is not request.fullpath and is root_url %>
+            <%= hidden_field_tag :url, request.fullpath, class:"reporting-from-field" %>
+          </div>
+          <div class="col-sm-3 text-right">
+            <%= link_to 'Check system status', 'http://library-status.stanford.edu' %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <span class="d-none">
+      <%= label_tag(:email_address, 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.') %><br/>
+      <%= email_field_tag :email_address %><br/>
+      <%= hidden_field_tag :user_agent %>
+      <%= hidden_field_tag :viewport %>
+    </span>
+    <div class="offset-md-2 col-md-7">
+      <div class="mb-3 row">
+        <%= label_tag(:message, 'Message', class:"col-md-3 col-form-label text-right") %>
+        <div class="col-md-9">
+          <%= text_area_tag :message, "", rows:"5", class:"form-control", required: true %>
+        </div>
+      </div>
+      <div class="mb-3 row">
+        <%= label_tag(:name, 'Your name', class:"col-md-3 col-form-label text-right") %>
+        <div class="col-md-9">
+          <%= text_field_tag :name, "", class:"form-control", required: true %>
+        </div>
+      </div>
+      <div class="mb-3 row">
+        <%= label_tag(:to, 'Your email', class:"col-md-3 col-form-label text-right") %>
+        <div class="col-md-9">
+          <%= email_field_tag :to, "", class:"form-control", required: true %>
+        </div>
+      </div>
+
+      <% unless current_user? %>
+        <div class="mb-3 row requests-captcha">
+        <div class="col-md-9 offset-md-3">
+            <%= recaptcha_tags %>
+
+            <p>(Stanford users can avoid this Captcha by logging in.)</p>
+        </div>
+        </div>
+      <% end %>
+
+      <div class="mb-3 row">
+        <div class="col-md-9 offset-md-3">
+          <button type="submit" class="btn btn-primary">Send</button>
+          <%= link_to "Cancel", :back, class:"btn", data: {toggle:"collapse", target:"#feedback-form"} %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/feedback_mailer/submit_feedback.text.erb
+++ b/app/views/feedback_mailer/submit_feedback.text.erb
@@ -1,0 +1,10 @@
+Name: <%= @name %>
+Email: <%= @email %>
+Comment:
+<%= @message.html_safe unless @message.nil? %>
+
+Message sent from: <%= @url %>
+Host: <%= Settings.HOSTNAME %>
+IP: <%= @ip %>
+User agent: <%= @user_agent %>
+Viewport: <%= @viewport %>

--- a/app/views/layouts/application_new.html.erb
+++ b/app/views/layouts/application_new.html.erb
@@ -31,6 +31,7 @@
       <%= render 'shared/sul_header' %>
     </header>
     <main class="flex-fill container">
+      <%= render 'shared/flashes' %>
       <%= yield %>
     </main>
     <footer>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <style>
+      /* Email styles need to be inline */
+    </style>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/shared/_sul_header.html.erb
+++ b/app/views/shared/_sul_header.html.erb
@@ -18,14 +18,20 @@
         <li>
           <%= link_to t('.my_account'), "https://mylibrary.stanford.edu/" %>
         </li>
-        <li>
-          <%= link_to t('.feedback'), "https://searchworks.stanford.edu/feedback", target: '_blank'  %>
-        </li>
+        <% unless current_page?(feedback_form_path) %>
+          <li>
+            <%= link_to "#feedback-form", role: 'button', data: {'bs-toggle':"collapse", 'bs-target':"#feedback-form"} do %>
+              Feedback
+            <% end %>
+          </li>
+        <% end %>
       </ul>
     </nav>
   </div>
 </div>
-
+<div id="feedback-form" class="feedback-form-container collapse">
+    <%= render template: 'feedback_forms/new' unless current_page?(feedback_form_path) %>
+</div>
 <!-- Application header -->
 <div id="app-header" class="text-white bg-cardinal py-3 d-flex">
   <div class="container">

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Recaptcha.configure do |config|
+  config.site_key = Settings.RECAPTCHA.SITE_KEY
+  config.secret_key = Settings.RECAPTCHA.SECRET_KEY
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,6 +182,10 @@ en:
     unlisted: Approved for manual processing
   sul_requests:
     limit_reached_message: "<p>You've reached the maximum of %{limit} items per day.</p><p>Contact the library if you need help prioritizing your selections.</p>"
+    feedback_form:
+      success: Thank you! Your feedback has been sent.
+    feedback_mailer:
+      subject: Feedback from Requests
   symphony_response:
     failure:
       code_U003:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,4 +61,6 @@ Rails.application.routes.draw do
       get :approve_item, as: :approve_item
     end
   end
+  resource :feedback_form, path: 'feedback', only: %I[new, create]
+  get 'feedback' => 'feedback_forms#new'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -364,3 +364,8 @@ scan_destinations:
 
 # Aeon external request endpoint (ERE)
 aeon_ere_url: https://stanford.aeon.atlas-sys.com/logon?Action=11&Type=200
+RECAPTCHA:
+  SITE_KEY: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
+  SECRET_KEY: 6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx
+EMAIL_TO: yolo@example.com
+HOSTNAME: foo.example.com

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe 'Accessibility testing', :js do
     expect(page).to be_accessible
   end
 
+  it 'validates the feedback form page' do
+    visit feedback_form_path
+    expect(page).to be_accessible
+  end
+
   def be_accessible
     be_axe_clean
   end

--- a/spec/helpers/feedback_forms_helper_spec.rb
+++ b/spec/helpers/feedback_forms_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FeedbackFormsHelper. For example:
+#
+# describe FeedbackFormsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FeedbackFormsHelper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeedbackMailer do
+  describe 'submit_feedback' do
+    describe 'with all fields' do
+      let(:ip) { '123.43.54.123' }
+      let(:params) do
+        {
+          name: 'Mildred Turner ',
+          to: 'test@test.com',
+          user_agent: 'agent #1',
+          viewport: 'width:100 height:50'
+        }
+      end
+      let(:mail) { described_class.submit_feedback(params, ip) }
+
+      it 'has the correct to field' do
+        expect(mail.to).to eq ['yolo@example.com']
+      end
+
+      it 'has the correct subject' do
+        expect(mail.subject).to eq 'Feedback from Requests'
+      end
+
+      it 'has the correct from field' do
+        expect(mail.from).to eq ['feedback@requests.stanford.edu']
+      end
+
+      it 'has the correct reply to field' do
+        expect(mail.reply_to).to eq ['yolo@example.com']
+      end
+
+      it 'has the right email' do
+        expect(mail.body).to have_content 'Name: Mildred Turner'
+      end
+
+      it 'has the right name' do
+        expect(mail.body).to have_content 'Email: test@test.com'
+      end
+
+      it 'has the right host' do
+        expect(mail.body).to have_content 'Host: foo.example.com'
+      end
+
+      it 'has the right IP' do
+        expect(mail.body).to have_content '123.43.54.123'
+      end
+
+      it 'has the user_agent' do
+        expect(mail.body).to have_content 'agent #1'
+      end
+    end
+
+    describe 'without name and email' do
+      let(:ip) { '123.43.54.123' }
+      let(:params) { {} }
+      let(:mail) { described_class.submit_feedback(params, ip) }
+
+      it 'has the right email' do
+        expect(mail.body).to have_content 'Name: No name given'
+      end
+
+      it 'has the right name' do
+        expect(mail.body).to have_content 'Email: No email given'
+      end
+    end
+  end
+end

--- a/spec/requests/feedback_forms_spec.rb
+++ b/spec/requests/feedback_forms_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'FeedbackForm', type: :feature do
+  let(:current_user?) { false }
+  let(:user) { create(:sso_user) }
+
+  context 'when not logged in' do
+    it 'reCAPTCHA challenge is present' do
+      visit feedback_path
+      expect(page).to have_css '.requests-captcha'
+    end
+  end
+
+  context 'without js' do
+    before do
+      stub_current_user(user)
+    end
+
+    it 'reCAPTCHA challenge is NOT present' do
+      visit feedback_path
+      expect(page).to have_no_css '.requests-captcha'
+    end
+
+    # TODO_SW_2024: Wait for page after homepage to be created to add
+    # it 'feedback form should be shown filled out and submitted' do
+    #   visit new_patron_request_path({'instance_hrid' => '1234', 'origin_location_code' => 'SAL3'})
+    #   click_on 'Feedback'
+    #   expect(page).to have_css('#feedback-form', visible: :visible)
+    #   expect(page).to have_link 'Cancel'
+    #   within 'form.feedback-form' do
+    #     fill_in('message', with: 'This is only a test')
+    #     fill_in('name', with: 'Ronald McDonald')
+    #     fill_in('to', with: 'test@kittenz.eu')
+    #     click_on 'Send'
+    #   end
+    #   puts page.inspect
+    #   expect(page).to have_css('div.alert-success', text: 'Thank you! Your feedback has been sent.')
+    # end
+  end
+end

--- a/spec/views/shared/_sul_header.html.erb_spec.rb
+++ b/spec/views/shared/_sul_header.html.erb_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'shared/_sul_header.html.erb' do
   before do
     allow(view).to receive_messages(current_user: user)
+    allow(view).to receive_messages(current_user?: user.sunetid.present?)
     render
   end
 


### PR DESCRIPTION
closes #2069 

Difference from mylibrary
- show_feedback_form? Replaced with current_page?(feedback_form_path)
- Doesn’t show feedback link in menu if it is on the feedback form page
- Updates the validate method to not mark an email as spam if there email has an url in it
- Uses the feedback_form/new template for all feedback form views instead of a shared/feedback_forms/form 
- Does not separate the reporting from html into a partial
- Uses root_url for mailer 
- Checks for sunset id for current_user?

Feedback page
![Screenshot 2024-03-21 at 5 22 29 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/717ebed9-c6fc-43af-b1c2-28a185ec80f1)

Feedback page at home
![Screenshot 2024-03-21 at 5 22 43 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/f0d7c066-7aeb-41e1-877a-f5cab3cc80ed)

