### PR TITLE
Add handling for when the origin location is SAL3-PAGE-AS

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -99,8 +99,8 @@ module RequestsHelper
   # For the reading room information, we need to check if 'ARS' is in the location details
   # for the library. An example is SAL3, which should show the ARS reading room information
   # and so should return ARS as the library code for the reading room text block.
+  # This logic will be extended in the future to cover any location that has a pageAeonSite value.
   def aeon_reading_room_code
-
     details = Folio::Types.locations.find_by(code: current_request.origin_location).details
     details.key?('pageAeonSite') && details['pageAeonSite'] == 'ARS' ? 'ARS' : current_request.origin_library_code
   end

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -95,4 +95,13 @@ module RequestsHelper
       user.library_id
     end
   end
+
+  # For the reading room information, we need to check if 'ARS' is in the location details
+  # for the library. An example is SAL3, which should show the ARS reading room information
+  # and so should return ARS as the library code for the reading room text block.
+  def aeon_reading_room_code
+
+    details = Folio::Types.locations.find_by(code: current_request.origin_location).details
+    details.key?('pageAeonSite') && details['pageAeonSite'] == 'ARS' ? 'ARS' : current_request.origin_library_code
+  end
 end

--- a/app/views/aeon_pages/_info_modal.html.erb
+++ b/app/views/aeon_pages/_info_modal.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     </ol>
     <p class="dialog-more-info">
-      <%= t('.more_details_html', library: LibraryLocation.library_name_by_code(current_request.origin_library_code), reading_room_url: Settings.libraries[current_request.origin_library_code].reading_room_url) %>
+      <%= t('.more_details_html', library: LibraryLocation.library_name_by_code(aeon_reading_room_code), reading_room_url: Settings.libraries[aeon_reading_room_code].reading_room_url) %>
     </p>
     <div class="dialog-buttons">
       <% if current_request.finding_aid? %>

--- a/app/views/aeon_pages/_info_modal.html.erb
+++ b/app/views/aeon_pages/_info_modal.html.erb
@@ -1,6 +1,6 @@
 <div id="aeon-info-overlay" class="aeon-overlay">
   <div class="modal-body">
-    <h1 class="dialog-title" id='dialogTitle'><%= t('.header', library: LibraryLocation.library_name_by_code(current_request.origin_library_code)) %></h1>
+    <h1 class="dialog-title" id='dialogTitle'><%= t('.header', library: LibraryLocation.library_name_by_code(aeon_reading_room_code)) %></h1>
     <p><%= t('.reading_room_info') %></p>
     <h2 class="dialog-how-to"><%= t('.how_to.header') %></h2>
     <p><%= t('.how_to.body') %></p>

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -35,6 +35,11 @@ FactoryBot.define do
     details { { 'pageServicePoints' => [{ 'code' => 'ENG' }] } }
   end
 
+  factory :page_as_location, parent: :location do
+    code { 'SAL3-PAGE-AS' }
+    details { { 'pageAeonSite' => 'ARS' } }
+  end
+
   factory :scannable_location, parent: :location do
     code { 'SAL3-STACKS' }
     details { { 'scanServicePointCode' => 'SAL3' } }
@@ -135,6 +140,25 @@ FactoryBot.define do
               barcode: '87654321',
               callnumber: 'ABC 87654321',
               effective_location: build(:location, code: 'SAL3-STACKS'))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
+
+  factory :sal3_as_holding, class: 'Folio::Instance' do
+    id { '12345' }
+    hrid { 'a12345' }
+    title { 'Item Title' }
+    format { 'Book' }
+    items do
+      [
+        build(:item,
+              barcode: '87654321',
+              callnumber: 'ABC 87654321',
+              effective_location: build(:page_as_location))
       ]
     end
 

--- a/spec/features/create_aeon_page_request_spec.rb
+++ b/spec/features/create_aeon_page_request_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe 'Creating an Aeon request', :js do
   before do
     stub_current_user(user)
     stub_bib_data_json(build(bib_data))
-    visit new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'SPEC-STACKS')
   end
 
   describe 'info modal' do
+    before do
+      visit new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'SPEC-STACKS')
+    end
+
     it 'identifies the library of the item' do
       expect(page).to have_content 'Special Collections access'
     end
@@ -22,7 +25,20 @@ RSpec.describe 'Creating an Aeon request', :js do
     end
   end
 
+  context 'handles info modal display for locations like SAL3-PAGE-AS' do
+    let(:bib_data) { :sal3_as_holding }
+
+    it 'provides a link to the ARS reading room if the origin location is SAL3' do
+      visit new_aeon_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-PAGE-AS')
+      expect(page).to have_link 'Archive of Recorded Sound Reading Room service page', href: 'https://library.stanford.edu/libraries/archive-recorded-sound'
+    end
+  end
+
   context 'with an item without a finding aid' do
+    before do
+      visit new_aeon_page_path(item_id: '1234', origin: 'SPEC-COLL', origin_location: 'SPEC-STACKS')
+    end
+
     context 'with a single holding' do
       describe 'info modal' do
         it 'provides instructions for the user to complete the request' do


### PR DESCRIPTION
Background:
As described in the issue, when the origin location is SAL3-PAGE-AS, the interstitial page for Aeon uses the URL for the same request as the link for the reading room.

Desired behavior:
In this situation, the page should display the information for 'ARS' which is included under 'pageAeonSite' in the details for the location in Folio. 

What this pull request does:

For both the page heading and the more info description and link, this code uses a method that checks if the location details has "ARS" as the value for "pageAeonSite".  If that condition is true, we return "ARS" as the origin library code.  Otherwise we return the actual origin library code. 


Closes #2059 