### PR TITLE
2097 recalls based on user group

### DIFF
--- a/app/jobs/submit_folio_request_job.rb
+++ b/app/jobs/submit_folio_request_job.rb
@@ -89,7 +89,7 @@ class SubmitFolioRequestJob < ApplicationJob
 
       request_data = FolioClient::CirculationRequestData.new(
         request_level: 'Item',
-        request_type: item.best_request_type,
+        request_type: item.best_request_type(patron),
         instance_id: request.bib_data.instance_id,
         item_id: item.id,
         holdings_record_id: item.holdings_record_id,

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -95,6 +95,14 @@ module Folio
       end
     end
 
+    def current_location_id
+      if effective_location && permanent_location.code == effective_location.code
+        effective_location.id
+      else
+        permanent_location.id
+      end
+    end
+
     def suppressed_from_discovery?
       @suppressed_from_discovery
     end
@@ -175,8 +183,10 @@ module Folio
       hold_recallable? || mediateable? || pageable?
     end
 
-    def best_request_type
-      return 'Recall' if recallable?
+    def best_request_type(patron = nil)
+      patron_recallable = true
+      patron_recallable = patron.request_type?('Recall', current_location_id) if patron
+      return 'Recall' if recallable? && patron_recallable
       return 'Hold' if holdable?
 
       'Page' if pageable?

--- a/app/services/folio/types.rb
+++ b/app/services/folio/types.rb
@@ -35,7 +35,7 @@ module Folio
       circulation_rules = folio_client.circulation_rules
       File.write(cache_dir.join('circulation_rules.txt'), circulation_rules)
       File.write(cache_dir.join('circulation_rules.csv'),
-                 Folio::CirculationRules::PolicyService.rules(circulation_rules).map(&:to_csv).join)
+                 Folio::CirculationRules::PolicyService.rules(nil, circulation_rules).map(&:to_csv).join)
     end
     # rubocop:enable Metrics/AbcSize
 


### PR DESCRIPTION
closes #2097 

I think a lot of this code is going to be able to be reused for our rewrite.

What it does:
Allows the patron model to check the rules for specific locations. The item model will then check if the logged in patron has recall permissions.

I used the Fee Borrower user and http://localhost:3000/hold_recalls/new?barcode=36105232863154&item_id=14720993&origin=GREEN&origin_location=GRE-STACKS for testing.