### PR TITLE
fix needs_shib_logout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,11 +32,11 @@ class SessionsController < ApplicationController
   #
   # GET /logout
   def destroy
-    needs_shibboleth_logout = request.env['warden']&.user&.dig('shibboleth').present?
+    needs_shib_logout = needs_shibboleth_logout
     request.env['warden'].logout
     flash[:notice] = t('.notice')
 
-    if needs_shibboleth_logout
+    if needs_shib_logout
       redirect_to '/Shibboleth.sso/Logout'
     else
       redirect_to root_url
@@ -44,6 +44,10 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def needs_shibboleth_logout
+    request.env['warden']&.user&.data&.dig('shibboleth').present?
+  end
 
   def redirect_after_login
     if params[:referrer]

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe SessionsController do
 
   describe 'logout' do
     it 'redirects to the Shibboleth logout page' do
-      warden.set_user({ 'shibboleth' => true })
+      warden.set_user(CurrentUser.new({ 'shibboleth' => true }))
       get :destroy
       expect(response).to redirect_to('/Shibboleth.sso/Logout')
     end
 
     it 'has a flash notice message informing the user they logged out' do
-      warden.set_user({})
+      warden.set_user(CurrentUser.new({}))
       get :destroy
       expect(flash[:notice]).to eq 'You have been successfully logged out.'
     end


### PR DESCRIPTION
closes #2118

I am pretty sure about this. I tested it locally with a library id and it worked. I am not sure about with a shib login.

For context the bold is what got added
request.env['warden']&.user**&.data**&.dig('shibboleth').present? 