### PR TITLE
Support university ID login; rename methods for clarity

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,14 +2,14 @@
 
 # :nodoc:
 class SessionsController < ApplicationController
-  before_action :logout_user, only: [:login_by_library_id, :login_by_sunetid]
+  before_action :logout_user, only: [:login_by_university_id, :login_by_sunetid]
 
-  # Handle login for Barcode + PIN users by authenticating them with the
+  # Handle login for University ID + PIN users by authenticating them with the
   # ILS using the Warden configuration.
   #
-  # GET /sessions/login_by_library_id
-  def login_by_library_id
-    if request.env['warden'].authenticate(:library_id)
+  # GET /sessions/login_by_university_id
+  def login_by_university_id
+    if request.env['warden'].authenticate(:university_id)
       redirect_after_login
     else
       redirect_to post_auth_redirect_url, flash: { error: t('.alert') }

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -3,24 +3,15 @@
 module Folio
   # Model for working with FOLIO Patron information
   class Patron
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     def self.find_by(sunetid: nil, library_id: nil, patron_key: nil, **_kwargs)
-      # if no sunet or library_id they are probably a general public (name/email) user.
-      return unless sunetid || library_id.present? || patron_key.present?
-
-      response = folio_client.user_info(patron_key) if patron_key.present?
-      response ||= folio_client.login_by_sunetid(sunetid) if sunetid.present?
-      response ||= folio_client.login_by_library_id(library_id) if library_id.present?
-
-      return new(response) if response.present?
-
-      Honeybadger.notify("Unable to find patron (looked up by sunetid: #{sunetid} / barcode: #{library_id}")
+      return folio_client.find_patron_by_id(patron_key) if patron_key.present?
+      return folio_client.find_patron_by_barcode_or_university_id(library_id) if library_id.present?
+      return folio_client.find_patron_by_sunetid(sunetid) if sunetid.present?
 
       nil
     rescue HTTP::Error
       nil
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
 
     def self.folio_client
       FolioClient.new

--- a/app/views/patron_requests/login.html.erb
+++ b/app/views/patron_requests/login.html.erb
@@ -44,12 +44,12 @@
                 </p>
                 <details>
                     <summary class="btn btn-link p-0">Login with Library ID/PIN <i class="bi bi-chevron-right"></i></summary>
-                    <%= form_tag login_by_library_id_url, method: 'POST', class: 'form p-3', data: { turbo: false } do %>
+                    <%= form_tag login_by_university_id_url, method: 'POST', class: 'form p-3', data: { turbo: false } do %>
                         <%= hidden_field_tag :referrer, new_patron_request_path(new_params.merge(step: 'select')) %>
                         <div class="form-group mt-2">
-                            <label class="form-label required-label" for="library_id">Library ID</label>
-                            <input class="form-control" id="library_id" name="library_id" required />
-                            <div class="form-text">Last 10 digits above the barcode on your library card</div>
+                            <label class="form-label required-label" for="university_id"><%= t('sessions.university_id.label') %></label>
+                            <input class="form-control" id="university_id" name="university_id" aria-describedby="university-id-help" required />
+                            <div class="form-text" id="university-id-help"><%= t('sessions.university_id.help_text') %></div>
                         </div>
                         <div class="form-group mt-2">
                             <label class="form-label required-label" for="pin">PIN</label>

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -75,16 +75,17 @@ Warden::Strategies.add(:development_shibboleth_stub) do
   end
 end
 
-Warden::Strategies.add(:library_id) do
+Warden::Strategies.add(:university_id) do
   def valid?
-    params['library_id'].present? && params['pin'].present?
+    params['university_id'].present? && params['pin'].present?
   end
 
   def authenticate!
-    response = FolioClient.new.login_by_library_id_and_pin(params['library_id'], params['pin'])
+    # TODO: change to login_by_university_id when we stop accepting barcodes
+    user = FolioClient.new.login_by_barcode_or_university_id(params['university_id'], params['pin'])
 
-    if response&.key?('patronKey') || response&.key?('id')
-      u = { username: params['library_id'], patron_key: response['patronKey'] || response['id'] }
+    if user&.key?('patronKey') || user&.key?('id')
+      u = { username: params['university_id'], patron_key: user['patronKey'] || user['id'] }
       success!(CurrentUser.new(u))
     else
       fail!('Could not log in')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,6 @@ en:
       failure:
         code_U003: 'Your request could not be processed because your user privileges are blocked.'
         code_U004: 'Your request could not be processed because your user privileges have expired.'
-
   confirmation_email:
     request:
       subject: 'New request needs mediation'
@@ -214,7 +213,10 @@ en:
       feedback: Feedback
       application_name: Requests
   sessions:
-    login_by_library_id:
+    university_id:
+      label: 'Library ID'
+      help_text: 'Last 10 digits above the barcode on your library card'
+    login_by_university_id:
       alert: Unable to authenticate.
     login_by_sunetid:
       alert: Unable to authenticate.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   # Authorization routes
   get 'sso/login', to: 'sessions#login_by_sunetid', as: :login_by_sunetid
   get 'sso/logout', to: 'sessions#destroy', as: :logout
-  post '/sessions/login_by_library_id', to: 'sessions#login_by_library_id', as: :login_by_library_id
+  post '/sessions/login_by_university_id', to: 'sessions#login_by_university_id', as: :login_by_university_id
 
   resources :paging_schedule, only: :index
   get 'paging_schedule/:origin(/:destination)' => 'paging_schedule#show', as: :paging_schedule

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Creating a page request' do
     before do
       allow(FolioClient).to receive(:new).and_return(stub_client)
 
-      allow(stub_client).to receive(:login_by_library_id_and_pin).with('12345', '54321').and_return({ 'patronKey' => 'some-lib-id-uuid' })
+      allow(stub_client).to receive(:login_by_barcode).with('12345', '54321').and_return({ 'patronKey' => 'some-lib-id-uuid' })
       allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(patron_key: 'some-lib-id-uuid').and_return(patron)
     end
 


### PR DESCRIPTION
This mostly ports work from mylibrary to rename/rearrange some folio client methods for clarity, and support combo university ID/barcode logins as prep for implementing PIN resets.