### PR TITLE
add in request preferences

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -15,6 +15,7 @@ class PatronRequestsController < ApplicationController
   end
 
   def new
+    @request.patron_id = current_user.patron&.id
     current_request.assign_attributes(new_params)
   end
 
@@ -43,6 +44,6 @@ class PatronRequestsController < ApplicationController
 
   def patron_request_params
     params.require(:patron_request).permit(:patron_email, :instance_hrid, :origin_location_code, :needed_date, :service_point_code,
-                                           :barcode)
+                                           :barcode, :fulfillment_type)
   end
 end

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -109,6 +109,14 @@ class PatronRequest < ApplicationRecord
     self.barcodes = [barcode]
   end
 
+  def holdable_recallable_items
+    @holdable_recallable_items ||= items_in_location.filter { |item| item.recallable?(patron) && item.holdable?(patron) }
+  end
+
+  def patron
+    @patron ||= Folio::Patron.find_by(patron_key: patron_id)
+  end
+
   private
 
   # Returns default service point codes

--- a/app/views/patron_requests/_request_preferences.html.erb
+++ b/app/views/patron_requests/_request_preferences.html.erb
@@ -1,0 +1,23 @@
+<% if f.object.holdable_recallable_items.any? %>
+<p class="text-cardinal">
+  This item is currently checked out by another patron or otherwise unavailable. 
+</p>
+<fieldset class="mb-4">
+  <legend class="fs-6">Choose your preferred request method:</legend>
+  <div class="mt-2 form-check">
+    <%= f.radio_button :fulfillment_type, 'recall', class: 'form-check-input' %>
+    <%= f.label :fulfillment_type_recall, class: 'form-check-label' do %>
+      Expedite a copy from a partner library
+      <a href="https://library.stanford.edu/services/borrow-and-request#request"><i class="bi bi-box-arrow-up-right"></i> Learn more</a>
+    <% end %>
+  </div>
+  <div class="mt-2 form-check">
+    <%= f.radio_button :fulfillment_type, 'hold', class: 'form-check-input' %>
+    <%= f.label :fulfillment_type_hold, 'Wait for a Stanford copy to become available', class: 'form-check-label' %>
+  </div>
+</fieldset>
+<div class="mb-4">
+  <%= f.label :needed_date, 'Not needed after:', class: 'required-label' %>
+  <%= f.date_field :needed_date, required: true, min: Date.today, class: 'd-block' %>
+</div>
+<% end %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -61,6 +61,8 @@
     <% end %>
   <% end %>
 
+  <%= render 'request_preferences', f: %>
+
   <div class="form-group d-flex justify-content-end gap-1">
     <%= link_to 'Cancel', new_patron_request_path(instance_hrid: @request.instance_hrid, origin_location_code: @request.origin_location_code), class: 'btn btn-outline-primary' %>
     <%= f.submit t('.submit'), class: 'btn btn-primary' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
         item_comment: 'Item(s) requested'
         user: 'Requested by'
       patron_request:
-        service_point_code: 'Pickup from'
+        service_point_code: 'Preferred pickup location'
       hold_recall:
         <<: *request_anchor
         needed_date: 'Not needed after'

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'Accessibility testing', :js do
     let(:patron) do
       instance_double(Folio::Patron, id: user.patron_key, display_name: 'A User', exists?: true, email: nil,
                                      patron_group: { desc: 'faculty' },
+                                     allowed_request_types: ['Hold', 'Recall'],
                                      ilb_eligible?: true, blocks: ['there is a block'])
     end
 

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Creating a page request' do
   let(:patron) do
     instance_double(Folio::Patron, id: user.patron_key, display_name: 'A User', exists?: true, email: nil,
                                    patron_group: { desc: 'faculty' },
+                                   allowed_request_types: ['Hold', 'Recall'],
                                    ilb_eligible?: true, blocks: ['there is a block'])
   end
 
@@ -43,7 +44,7 @@ RSpec.describe 'Creating a page request' do
       visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
       click_on 'Log in with SUNet ID'
 
-      select 'Marine Biology Library', from: 'Pickup from'
+      select 'Marine Biology Library', from: 'Preferred pickup location'
 
       expect { click_on 'Submit' }.to change(PatronRequest, :count).by(1)
 
@@ -95,7 +96,7 @@ RSpec.describe 'Creating a page request' do
           expect(page).to have_content('Wednesday, Apr 3 2024, after 10am')
         end
 
-        select 'Marine Biology Library', from: 'Pickup from'
+        select 'Marine Biology Library', from: 'Preferred pickup location'
         within '#earliestAvailableContainer' do
           expect(page).to have_content('Friday, Apr 5 2024, after 4pm')
         end
@@ -107,6 +108,7 @@ RSpec.describe 'Creating a page request' do
     let(:stub_client) { FolioClient.new }
     let(:patron) do
       instance_double(Folio::Patron, id: 'some-lib-id-uuid', display_name: 'A User', exists?: true, email: nil,
+                                     allowed_request_types: ['Hold'],
                                      patron_group: { desc: 'courtesy' }, ilb_eligible?: true, blocks: [])
     end
 


### PR DESCRIPTION
closes #2105 

Add form for request/hold. Make form build based on patron rights (in screenshots, Finely Fee doesn't have recall access so they don't get the option to get as soon as possible)

![Screenshot 2024-04-04 at 11 07 27 AM](https://github.com/sul-dlss/sul-requests/assets/19173991/d185935a-cb55-416c-b0fc-1a5a38cdf455)

![Screenshot 2024-04-04 at 11 07 45 AM](https://github.com/sul-dlss/sul-requests/assets/19173991/07c815c4-af85-439b-9e0b-fe511458ec94)
