### PR TITLE
adding path, test, and handling for visitor registration

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,6 @@
 
 # :nodoc:
 class SessionsController < ApplicationController
-
   before_action :logout_user, only: [:login_by_university_id, :login_by_sunetid, :register_visitor]
 
   # Handle login for University ID + PIN users by authenticating them with the

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 # :nodoc:
 class SessionsController < ApplicationController
-  before_action :logout_user, only: [:login_by_library_id, :login_by_sunetid]
+  before_action :logout_user, only: [:login_by_library_id, :login_by_sunetid, :register_visitor]
 
   # Handle login for Barcode + PIN users by authenticating them with the
   # ILS using the Warden configuration.
@@ -23,6 +23,17 @@ class SessionsController < ApplicationController
   # GET /sessions/login_by_sunetid
   def login_by_sunetid
     if request.env['warden'].authenticate(:shibboleth, :development_shibboleth_stub)
+      redirect_after_login
+    else
+      redirect_to post_auth_redirect_url, flash: { error: t('.alert') }
+    end
+  end
+
+  # Handle visitor name and email registration
+  #
+  # GET /sessions/register_visitor
+  def register_visitor
+    if request.env['warden'].authenticate(:register_visitor)
       redirect_after_login
     else
       redirect_to post_auth_redirect_url, flash: { error: t('.alert') }

--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -18,6 +18,8 @@ class CurrentUser
         sso_user
       elsif library_id?
         library_id_user
+      elsif name_email_user?
+        name_email_user
       else
         anonymous_user
       end
@@ -36,6 +38,10 @@ class CurrentUser
     data['patron_key']
   end
 
+  def name_email_user?
+    data['name'].present? && data['email'].present?
+  end
+
   def sso_user
     User.find_or_create_by(sunetid: user_id).tap do |user|
       update_ldap_attributes(user)
@@ -47,6 +53,10 @@ class CurrentUser
     User.find_or_create_by(library_id: user_id).tap do |user|
       update_folio_attributes(user)
     end
+  end
+
+  def name_email_user
+    User.new(name: data['name'], email: data['email'])
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/views/patron_requests/login.html.erb
+++ b/app/views/patron_requests/login.html.erb
@@ -83,7 +83,8 @@
                 </a></p>
                 <details>
                     <summary class="btn btn-link p-0">Proceed as visitor <i class="bi bi-chevron-right"></i></summary>
-                    <%= form_tag new_patron_request_path(new_params.merge(step: 'select')), method: 'POST', class: 'form p-3', data: { turbo: false } do %>
+                    <%= form_tag register_visitor_url, method: 'POST', class: 'form p-3', data: { turbo: false } do %>
+                        <%= hidden_field_tag :referrer, new_patron_request_path(new_params.merge(step: 'select')) %>
                         <div class="form-group mt-2">
                             <label class="form-label required-label" for="name">Name</label>
                             <input class="form-control" id="name" name="name" required />

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -91,3 +91,21 @@ Warden::Strategies.add(:library_id) do
     end
   end
 end
+
+# For visitor registration, information does not go through Shibboleth.
+# The only authentication is ensuring the name and email fields are both present.
+Warden::Strategies.add(:register_visitor) do
+  def valid?
+    params['name'].present? || params['patron_email'].present?
+  end
+
+  def authenticate!
+    if params['name'].present? && params['patron_email'].present?
+      u = { name: params['name'], email: params['patron_email'], shibboleth: false }
+      success!(CurrentUser.new(u))
+    else
+      # TODO: Should there be specific wording to this error message?
+      fail!('Please supply both name and email')
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,5 +223,7 @@ en:
                     <li>A library account is created for patrons who are eligible to check out library materials.</li>
                     <li>If you believe you should have an account, contact <a href="mailto:%{mailto}">Circulation &amp; Privileges</a> for assistance.</li>
                   </ul>
+    register_visitor:
+      alert: Unable to register visitor.  Both name and email are required.
     destroy:
       notice: You have been successfully logged out.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get 'sso/login', to: 'sessions#login_by_sunetid', as: :login_by_sunetid
   get 'sso/logout', to: 'sessions#destroy', as: :logout
   post '/sessions/login_by_library_id', to: 'sessions#login_by_library_id', as: :login_by_library_id
+  post '/sessions/register_visitor', to: 'sessions#register_visitor', as: :register_visitor
 
   resources :paging_schedule, only: :index
   get 'paging_schedule/:origin(/:destination)' => 'paging_schedule#show', as: :paging_schedule

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe SessionsController do
       expect(response).to redirect_to('/')
     end
 
+    it 'redirects back to the provided referrer for registered visitor' do
+      allow(request.env['warden']).to receive(:authenticate).and_return(true)
+      get :register_visitor, params: { referrer: '/' }
+      expect(response).to redirect_to('/')
+    end
+
+    it 'displays error flash message if the registered visitor does not authenticate' do
+      allow(request.env['warden']).to receive(:authenticate).and_return(false)
+      get :register_visitor, params: { referrer: '/' }
+      expect(flash[:error]).to eq 'Unable to register visitor.  Both name and email are required.'
+    end
+
     it 'redirects back when there is no provided referrer' do
       allow(request.env['warden']).to receive(:authenticate).and_return(true)
       get :login_by_sunetid

--- a/spec/models/current_user_spec.rb
+++ b/spec/models/current_user_spec.rb
@@ -66,5 +66,21 @@ RSpec.describe CurrentUser do
         end
       end
     end
+
+    context 'with a registered visitor user' do
+      let(:user) do
+        {
+          name: 'some-user',
+          email: 'some-user@stanford.edu',
+          shibboleth: false
+        }
+      end
+
+      it 'returns a user with the name and email information' do
+        expect(subject).to be_a User
+        expect(subject.name).to eq 'some-user'
+        expect(subject.email).to eq 'some-user@stanford.edu'
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #2072 .

What this pull request does:

- Extend Warden with a "register_visitor" strategy.  Valid? checks for either the name or email field.  Authenticate checks that both are present.  
- Add a "register_visitor" method to sessions controller and add path to the routes.rb.  The method checks if the Warden strategy for register_visitor authenticates. If so, it will redirect to the next page.  If not, an error message will be shown.
- Update the login form so that the form action now goes to the sessions controller register_visitor action.  Add the new patron request with step parameter as the referrer parameter. 
- Update en.yml to include the error alert message if the visitor registration form does not pass. 
- Update current user to handle name and email user initialization
- Add tests for both session controller and current user

Although the fields on the form don't allow empty values for name and email, it is possible to enter just a space each.  If that happens, the authenticate method will capture that and show an error. 

![Screenshot 2024-04-05 at 9 41 26 AM](https://github.com/sul-dlss/sul-requests/assets/2677207/63c84798-2946-4fda-b36c-4c0db87a59b4)
