### PR TITLE
render html page when there is no schedule

### DIFF
--- a/app/controllers/paging_schedule_controller.rb
+++ b/app/controllers/paging_schedule_controller.rb
@@ -5,7 +5,9 @@
 ###
 class PagingScheduleController < ApplicationController
   rescue_from PagingSchedule::ScheduleNotFound do
-    render plain: 'Schedule not found', status: :not_found
+    turbo_frame = helpers.content_tag('turbo-frame', style: 'display:none', id: 'earliestAvailable') { 'No delievery estimate' }
+    turbo_frame += helpers.content_tag('body') { 'Schedule not found' }
+    render html: turbo_frame, layout: false, status: :not_found
   end
 
   before_action only: [:show, :open] do


### PR DESCRIPTION
close #2132 

This fixes that is there is no schedule for the item it will not staying `Loading....`

It does change the error page a little bit for paging scheduler

![Screenshot 2024-04-05 at 3 57 40 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/20a5e6e9-95fd-4880-b1f9-f74eea04f923)

Main
![Screenshot 2024-04-05 at 3 58 37 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/4f6b4c3f-b09e-42b9-972b-66be0465b727)

This branch


![Screenshot 2024-04-05 at 3 58 24 PM](https://github.com/sul-dlss/sul-requests/assets/19173991/81f18c8f-b97e-4fbb-9eed-ceee1f5c867f)
