### PR TITLE
add in handling for user choice

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -659,3 +659,8 @@ paging_schedule:
     after: '9:00am'
     will_arrive_after: '3:00pm'
     business_days_later: 2
+
+hold_instead_of_recall:
+  - 'In process'
+  - 'On order'
+  - 'In transit'


### PR DESCRIPTION
Since patron is now part of PatronRequest we feed in PatronRequest to the best_request_type field. This will allow more tricky things in the future for fulfillment type if we need it. We are going to have to do more complicated things for in transit but I think that needs to be part of another ticket to determines how many holds there are on an item.


closes #2144 