### PR TITLE
Adding placeholder patron for registered visitor

### DIFF
--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -154,6 +154,10 @@ module Folio
       @policy_service ||= Folio::CirculationRules::PolicyService.new(patron_groups: [patron_group_id])
     end
 
+    def visitor_patron?
+      id == Settings.folio.visitor_placeholder_id
+    end
+
     private
 
     def patron_summary
@@ -170,10 +174,6 @@ module Folio
 
     def proxy_group_info
       @proxy_group_info ||= self.class.folio_client.proxy_group_info(id)
-    end
-
-    def visitor_patron?
-      id == Settings.folio.visitor_placeholder_id
     end
   end
 end

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -111,6 +111,9 @@ module Folio
     end
 
     def blocks
+      # If this is a registered visitor, do not make any calls to FOLIO client and return empty array
+      return [] if visitor_patron?
+
       blocks = patron_blocks.fetch('automatedPatronBlocks')
       blocks.map { |block| construct_message(block['message']) }
     end
@@ -167,6 +170,10 @@ module Folio
 
     def proxy_group_info
       @proxy_group_info ||= self.class.folio_client.proxy_group_info(id)
+    end
+
+    def visitor_patron?
+      id == Settings.folio.visitor_placeholder_id
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,8 +113,18 @@ class User < ActiveRecord::Base
         patron_model_class.find_by(sunetid:)
       elsif library_id_user?
         patron_model_class.find_by(library_id:)
+      elsif name_email_user?
+        placeholder_patron
       end
     end
+  end
+
+  def placeholder_patron
+    patron_model_class.new({
+                             'id' => Settings.folio.visitor_placeholder_id,
+                             'personal' => { 'email' => email, 'lastName' => name },
+                             'patronGroup' => sul_purchased_patron_group_id
+                           })
   end
 
   def policy_service

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,6 +79,7 @@ folio:
     - staff-casual
     - undergrad
     - visiting-scholar
+  visitor_placeholder_id: 'visitor'
 
 mailer_host: <%= `echo $HOSTNAME` %>
 hours_api: 'https://library-hours.stanford.edu/'

--- a/spec/models/folio/patron_spec.rb
+++ b/spec/models/folio/patron_spec.rb
@@ -95,5 +95,28 @@ RSpec.describe Folio::Patron do
         it { is_expected.to be_ilb_eligible }
       end
     end
+
+    context 'when the patron is a registered visitor' do
+      let(:patron_group_id) { '985acbb9-f7a7-4f44-9b34-458c02a78fbc' } # sul-purchased
+      let(:fields) do
+        {
+          'id' => Settings.folio.visitor_placeholder_id,
+          'personal' => { 'email' => 'test@test.com', 'lastName' => 'test' },
+          'patronGroup' => patron_group_id
+        }
+      end
+
+      describe '#blocks' do
+        it 'returns empty blocks array for registered visitor' do
+          expect(subject.blocks).to be_empty
+        end
+      end
+
+      describe '#visitor_patron?' do
+        it 'returns true for the method checking if the user is a registered visitor' do
+          expect(subject.visitor_patron?).to be true
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -188,4 +188,21 @@ RSpec.describe User do
       expect(subject).to be_site_admin
     end
   end
+
+  describe '#patron' do
+    let(:fields) do
+      {
+        'id' => Settings.folio.visitor_placeholder_id,
+        'personal' => { 'email' => subject.email, 'lastName' => subject.name },
+        'patronGroup' => '985acbb9-f7a7-4f44-9b34-458c02a78fbc'
+      }
+    end
+
+    it 'returns placeholder patron for name email user' do
+      subject.name = 'jstanford'
+      subject.email = 'jstanford@stanford.edu'
+
+      expect(subject.patron.user_info).to eq(fields)
+    end
+  end
 end


### PR DESCRIPTION
Closes #2149 .

Background: At various points, the new requests workflow requires the existing of a patron object with specific fields (or would use the information, like name, for display).  We need to create a placeholder patron object to support the workflow for a registered visitor. 

What this pull request does:

- In the user class, the patron method returns a Patron object depending on various conditions.  This pull requests adds a condition for a name and email user i.e. registered visitor, where a placeholder Patron object is returned.  The object uses the patron group id for the sul-purchased patron group.  In addition, the id is set to a value that is added to Settings to indicate a registered visitor user.  The id is necessary b/c the page throws an error without the id.  Also, the name the user adds is set to "last name" for the patron.  The name field doesn't distinguish between first and last name, and there is no general "name" field in patron.  Using "last name" allows the resulting user header message to display the name the registered visitor entered on the request landing page.
- In the patron class, the blocks method checks if the user is a registered visitor by looking at the id.  If the user is a registered visitor, the method returns an empty array instead of trying to check the id with Folio client (which would throw an error).
- Adds tests for patron and user  