### PR TITLE
PIN reset fixes

### DIFF
--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -160,7 +160,7 @@ module Folio
 
     # Generate a PIN reset token for the patron
     def pin_reset_token
-      crypt.encrypt_and_sign(key, expires_in: 20.minutes)
+      crypt.encrypt_and_sign(id, expires_in: 20.minutes)
     end
 
     private

--- a/app/views/reset_pins/change_form.html.erb
+++ b/app/views/reset_pins/change_form.html.erb
@@ -16,7 +16,7 @@
     <div class="input-group" data-controller="password-visibility">
       <%= password_field_tag :pin, nil, class: 'form-control', 'aria-describedby':
       'pin-help', autofocus: true, autocomplete: 'off', data: {
-      'password-visibility-target': 'input', } %>
+      'password-visibility-target': 'input' }, pattern: '[a-zA-Z0-9]{6,25}' %>
       <div class="input-group-append">
         <button
           class="btn btn-link"

--- a/app/views/reset_pins_mailer/reset_pin.html.erb
+++ b/app/views/reset_pins_mailer/reset_pin.html.erb
@@ -9,7 +9,7 @@
       change the PIN for account <b><%= @patron.barcode %></b>.
     </p>
     <p style="font-size: 18pt">
-      <a href="<%= @url %>">Change my PIN</a>
+      <%= link_to 'Change my PIN', @url.html_safe %>
     </p>
     <p>
       If you did not ask to change your PIN, ignore this email. This link will

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,5 +240,4 @@ en:
     success_html: <span class="fw-bold">Success!</span><br/> A set/reset link and instructions were sent to the email address associated with Library ID %{university_id}.
     request_failed_html: <span class="fw-bold">Sorry!</span><br/> Something went wrong, possibly due to a connection failure. Try again or contact us for help.
   reset_pins_mailer:
-    reset_pin:
-      subject: Stanford Libraries PIN reset
+    subject: Stanford Libraries PIN reset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,7 +237,7 @@ en:
   reset_pin:
     title: Request set/reset PIN
     instructions: Enter your Library ID below and we’ll send you an email with instructions on how to set or reset your PIN.
-    success_html: <span class="fw-bold">Check your email!</span><br/> A PIN reset link has been sent to the address associated with library ID %{university_id}
+    success_html: <span class="fw-bold">Success!</span><br/> A set/reset link and instructions were sent to the email address associated with Library ID %{university_id}.
     request_failed_html: <span class="fw-bold">Sorry!</span><br/> Something went wrong, possibly due to a connection failure. Try again or contact us for help.
   reset_pins_mailer:
     reset_pin:

--- a/spec/features/reset_pin_spec.rb
+++ b/spec/features/reset_pin_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Reset PIN workflow' do
     end
 
     it 'shows a success message' do
-      expect(page).to have_css '.flash_messages', text: 'Check your email!'
+      expect(page).to have_css '.flash_messages', text: 'Success!'
     end
   end
 


### PR DESCRIPTION
- Update PIN reset message text
- Use the right name for the PIN reset identifier
- Use the correct subject for PIN reset emails
- Ensure the reset PIN link in emails is encoded correctly
- Enforce our requirements for PIN resets via validation
