### PR TITLE
Extract a `NullPatron` object for visitors without a FOLIO account

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -85,7 +85,7 @@ class Ability
     can :read, [PatronRequest], patron_id: user.patron.id if user.patron
 
     can :request, Folio::Item do |item|
-      allowed_request_types = user.policy_service.item_request_policy(item)&.dig('requestTypes')
+      allowed_request_types = user.patron&.allowed_request_types(item) || []
       item.requestable?(request_types: allowed_request_types)
     end
 

--- a/app/models/folio/null_patron.rb
+++ b/app/models/folio/null_patron.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Folio
+  # Model for working with FOLIO Patron information
+  class NullPatron
+    attr_reader :user
+
+    delegate :email, to: :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def display_name
+      user.name
+    end
+
+    def patron_description
+      'Visitor'
+    end
+
+    # this returns the full patronGroup object
+    def patron_group
+      Folio::Types.patron_groups[sul_purchased_patron_group_id]
+    end
+
+    def patron_group_id
+      @patron_group_id ||= Folio::Types.patron_groups.select { |_k, v| v['group'] == 'sul-purchased' }.keys.first
+    end
+
+    def patron_group_name
+      patron_group&.dig('group')
+    end
+
+    def patron_comments
+      "#{display_name} <#{email}>"
+    end
+
+    def allowed_request_types(item)
+      (policy_service.item_request_policy(item)&.dig('requestTypes') || []) & ['Page']
+    end
+
+    def policy_service
+      @policy_service ||= Folio::CirculationRules::PolicyService.new(patron_groups: [patron_group_id])
+    end
+
+    def blocks
+      []
+    end
+
+    # define the remaining methods of Folio::Patron
+    (Folio::Patron.instance_methods(false) - instance_methods(false)).each do |method|
+      define_method(method) do |*, **|
+        nil
+      end
+    end
+  end
+end

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -48,7 +48,7 @@ class PatronRequest < ApplicationRecord
     destinations = (default_pickup_service_points + additional_pickup_service_points).uniq if location_restricted_service_point_codes.empty?
     destinations ||= location_restricted_service_point_codes
 
-    return destinations.select { |destination| Settings.allowed_visitor_pickups.include?(destination) } if patron.visitor_patron?
+    return destinations.select { |destination| Settings.allowed_visitor_pickups.include?(destination) } unless patron
 
     destinations
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,24 +119,10 @@ class User < ActiveRecord::Base
     end
   end
 
-  def placeholder_patron
-    patron_model_class.new({
-                             'id' => Settings.folio.visitor_placeholder_id,
-                             'personal' => { 'email' => email, 'lastName' => name },
-                             'patronGroup' => sul_purchased_patron_group_id
-                           })
-  end
-
-  def policy_service
-    @policy_service ||= Folio::CirculationRules::PolicyService.new(patron_groups: [
-                                                                     patron&.patron_group_id || sul_purchased_patron_group_id
-                                                                   ])
-  end
-
   private
 
-  def sul_purchased_patron_group_id
-    @sul_purchased_patron_group_id ||= Folio::Types.patron_groups.select { |_k, v| v['group'] == 'sul-purchased' }.keys.first
+  def placeholder_patron
+    @placeholder_patron ||= Folio::NullPatron.new(self)
   end
 
   def notify_honeybadger_of_missing_sso_email!

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,6 @@ folio:
     - staff-casual
     - undergrad
     - visiting-scholar
-  visitor_placeholder_id: 'visitor'
 
 mailer_host: <%= `echo $HOSTNAME` %>
 hours_api: 'https://library-hours.stanford.edu/'

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe 'Accessibility testing', :js do
       instance_double(Folio::Patron, id: user_object.patron_key, display_name: 'A User', exists?: true, email: nil,
                                      patron_group_id: '503a81cd-6c26-400f-b620-14c08943697c',
                                      patron_description: 'faculty',
-                                     visitor_patron?: false,
                                      allowed_request_types: ['Hold', 'Recall'],
                                      ilb_eligible?: true, blocks: [])
     end
@@ -50,7 +49,6 @@ RSpec.describe 'Accessibility testing', :js do
         instance_double(Folio::Patron, id: user_object.patron_key, display_name: 'A User', exists?: true, email: nil,
                                        patron_group_id: nil,
                                        patron_description: 'faculty',
-                                       visitor_patron?: false,
                                        allowed_request_types: ['Hold', 'Recall'],
                                        ilb_eligible?: true, blocks: ['there is a block'])
       end

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'Creating a page request' do
   let(:bib_data) { build(:single_holding) }
   let(:patron) do
     instance_double(Folio::Patron, id: user.patron_key, display_name: 'A User', exists?: true, email: nil,
-                                   patron_description: 'faculty', visitor_patron?: false,
+                                   patron_description: 'faculty',
                                    patron_group_id: '503a81cd-6c26-400f-b620-14c08943697c',
-                                   allowed_request_types: ['Hold', 'Recall'],
+                                   allowed_request_types: ['Hold', 'Recall', 'Page'],
                                    ilb_eligible?: true, blocks: ['there is a block'])
   end
 
@@ -105,7 +105,7 @@ RSpec.describe 'Creating a page request' do
     let(:stub_client) { FolioClient.new }
     let(:patron) do
       instance_double(Folio::Patron, id: 'some-lib-id-uuid', display_name: 'A User', exists?: true, email: nil,
-                                     allowed_request_types: ['Hold'], visitor_patron?: false,
+                                     allowed_request_types: ['Hold', 'Page'],
                                      patron_group_id: '985acbb9-f7a7-4f44-9b34-458c02a78fbc',
                                      patron_description: 'courtesy', ilb_eligible?: true, blocks: [])
     end
@@ -137,6 +137,13 @@ RSpec.describe 'Creating a page request' do
     end
 
     context 'when circ rules prevent any request on the item for the patron' do
+      let(:patron) do
+        instance_double(Folio::Patron, id: 'some-lib-id-uuid', display_name: 'A User', exists?: true, email: nil,
+                                       allowed_request_types: [],
+                                       patron_group_id: '985acbb9-f7a7-4f44-9b34-458c02a78fbc',
+                                       patron_description: 'courtesy', ilb_eligible?: true, blocks: [])
+      end
+
       let(:bib_data) { build(:single_holding, items: [build(:item, effective_location: build(:law_location))]) }
 
       it 'goes to a dead-end page' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -160,7 +160,9 @@ RSpec.describe Ability do
 
     context 'with a request for an item that is not requestable by non-affiliates' do
       let(:request) { PatronRequest.new(instance_hrid: 'a1234', origin_location_code: 'LAW-STACKS1') }
-      let(:patron) { instance_double(Folio::Patron, id: '', patron_group_id: '3684a786-6671-4268-8ed0-9db82ebca60b') }
+      let(:patron) do
+        instance_double(Folio::Patron, id: '', patron_group_id: '3684a786-6671-4268-8ed0-9db82ebca60b', allowed_request_types: ['Page'])
+      end
 
       before do
         allow(user).to receive(:patron).and_return(patron)

--- a/spec/models/folio/patron_spec.rb
+++ b/spec/models/folio/patron_spec.rb
@@ -95,28 +95,5 @@ RSpec.describe Folio::Patron do
         it { is_expected.to be_ilb_eligible }
       end
     end
-
-    context 'when the patron is a registered visitor' do
-      let(:patron_group_id) { '985acbb9-f7a7-4f44-9b34-458c02a78fbc' } # sul-purchased
-      let(:fields) do
-        {
-          'id' => Settings.folio.visitor_placeholder_id,
-          'personal' => { 'email' => 'test@test.com', 'lastName' => 'test' },
-          'patronGroup' => patron_group_id
-        }
-      end
-
-      describe '#blocks' do
-        it 'returns empty blocks array for registered visitor' do
-          expect(subject.blocks).to be_empty
-        end
-      end
-
-      describe '#visitor_patron?' do
-        it 'returns true for the method checking if the user is a registered visitor' do
-          expect(subject.visitor_patron?).to be true
-        end
-      end
-    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -190,19 +190,13 @@ RSpec.describe User do
   end
 
   describe '#patron' do
-    let(:fields) do
-      {
-        'id' => Settings.folio.visitor_placeholder_id,
-        'personal' => { 'email' => subject.email, 'lastName' => subject.name },
-        'patronGroup' => '985acbb9-f7a7-4f44-9b34-458c02a78fbc'
-      }
+    before do
+      subject.name = 'jstanford'
+      subject.email = 'jstanford@stanford.edu'
     end
 
     it 'returns placeholder patron for name email user' do
-      subject.name = 'jstanford'
-      subject.email = 'jstanford@stanford.edu'
-
-      expect(subject.patron.user_info).to eq(fields)
+      expect(subject.patron).to have_attributes(id: nil, display_name: 'jstanford', email: 'jstanford@stanford.edu', blocks: [])
     end
   end
 end


### PR DESCRIPTION
The not-really-a-FOLIO-patron bugged me. I think pulling it out with a null-object pattern will help clarify when we have a real patron and when we don't