### PR TITLE
Update accordion steps to use bootstrap accordion behaviors to toggle other sections closed

### DIFF
--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -36,17 +36,17 @@ export default class extends Controller {
   }
 
   nextStep(event) {
-    const step = 'patron_request[' + event.target.id + ']';
+    const step = 'patron_request[' + event.params.step + ']';
     const formdata = new FormData(this.element);
     const nextstepid = formdata.get(step.replace('-', '_'));
     if (!nextstepid) { return }
 
-    const accordionbutton = document.querySelector(`[data-bs-target='#${event.target.id}']`);
+    const accordionbutton = document.querySelector(`[data-bs-target='#${event.params.step}']`);
     accordionbutton.parentElement.classList.add('completed');
     accordionbutton.click();
     accordionbutton.setAttribute('disabled', '');
     const accordions = Array.from(document.querySelectorAll('.accordion-item:not([id*="placeholder"])'));
-    const current = accordions.findIndex( x => x.id.indexOf(event.target.id) > -1  );
+    const current = accordions.findIndex( x => x.id.indexOf(event.params.step) > -1  );
     var nextitem = accordions.at(current+1).id.split('-accordion')[0];
     nextitem = (nextitem == 'pickup' || nextitem == 'scan') && formdata.get('patron_request[request_type]') ? formdata.get('patron_request[request_type]') : nextitem;
     var nextstep = document.querySelector(`[data-bs-target='#${nextitem}']`);

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -7,23 +7,32 @@ export default class extends Controller {
     const form = this.element;
     const accordionbuttons = this.accordionButtonTargets;
 
-    if (accordionbuttons.length == 1){
-      form.classList.remove('accordion');
-      const accordion = document.querySelector(`${accordionbuttons[0].dataset.bsTarget}-accordion`);
-      accordion.classList.remove('d-none');
-      accordion.classList.remove('shadow-sm');
-      accordion.querySelector('.accordion-header').remove();
-      const formitem = document.querySelector(`${accordionbuttons[0].dataset.bsTarget}`);
-      formitem.classList.remove('collapse')
+    if (accordionbuttons.length == 1) {
+      this.removeAccordionStyling();
     } else {
-      accordionbuttons.forEach((accordionbutton, index) => {
-        accordionbutton.getElementsByClassName('step-number')[0].innerHTML = index + 1;
-        if (index == 0) {
-          accordionbutton.removeAttribute('disabled');
-          accordionbutton.click();
-        }
-      });
+      this.renumberSteps();
+      this.accordionButtonTargets[0].removeAttribute('disabled');
+      this.accordionButtonTargets[0].click();
     }
+  }
+
+  removeAccordionStyling() {
+    this.element.classList.remove('accordion');
+
+    const accordionbutton = this.accordionButtonTargets[0];
+    const accordion = document.querySelector(`${accordionbutton.dataset.bsTarget}-accordion`);
+    accordion.classList.remove('d-none');
+    accordion.classList.remove('shadow-sm');
+    accordion.querySelector('.accordion-header').remove();
+
+    const formitem = document.querySelector(`${accordionbutton.dataset.bsTarget}`);
+    formitem.classList.remove('collapse')
+  }
+
+  renumberSteps() {
+    this.accordionButtonTargets.forEach((accordionbutton, index) => {
+      accordionbutton.getElementsByClassName('step-number')[0].innerHTML = index + 1;
+    });
   }
 
   nextStep(event) {

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -1,91 +1,87 @@
 import { Controller } from "@hotwired/stimulus"
+import { Collapse } from "bootstrap"
 
 export default class extends Controller {
-  static targets = ['earliestAvailable', 'accordionButton']
+  static targets = ['earliestAvailable', 'accordion']
 
   connect() {
-    const form = this.element;
-    const accordionbuttons = this.accordionButtonTargets;
-
-    if (accordionbuttons.length == 1) {
+    if (this.accordionTargets.length == 1) {
       this.removeAccordionStyling();
     } else {
-      this.renumberSteps();
-      this.accordionButtonTargets[0].removeAttribute('disabled');
-      this.accordionButtonTargets[0].click();
+      this.renumberVisibleSteps();
+      Collapse.getOrCreateInstance(this.accordionTargets[0].querySelector('.accordion-collapse')).show();
     }
   }
 
   removeAccordionStyling() {
     this.element.classList.remove('accordion');
 
-    const accordionbutton = this.accordionButtonTargets[0];
-    const accordion = document.querySelector(`${accordionbutton.dataset.bsTarget}-accordion`);
+    const accordion = this.accordionTargets[0];
     accordion.classList.remove('d-none');
     accordion.classList.remove('shadow-sm');
     accordion.querySelector('.accordion-header').remove();
 
-    const formitem = document.querySelector(`${accordionbutton.dataset.bsTarget}`);
-    formitem.classList.remove('collapse')
+    Collapse.getOrCreateInstance(this.accordionTargets[0].querySelector('.accordion-collapse')).show();
   }
 
-  renumberSteps() {
-    this.accordionButtonTargets.forEach((accordionbutton, index) => {
-      accordionbutton.getElementsByClassName('step-number')[0].innerHTML = index + 1;
+  renumberVisibleSteps() {
+    this.accordionTargets.filter(element => (!element.classList.contains('d-none'))).forEach((accordion, index) => {
+      accordion.getElementsByClassName('step-number')[0].innerHTML = index + 1;
     });
   }
 
   nextStep(event) {
-    const step = 'patron_request[' + event.params.step + ']';
-    const formdata = new FormData(this.element);
-    const nextstepid = formdata.get(step.replace('-', '_'));
-    if (!nextstepid) { return }
+    const accordion = event.target.closest('.accordion-item');
 
-    const accordionbutton = document.querySelector(`[data-bs-target='#${event.params.step}']`);
+    // mark the current step as completed
+    const accordionbutton = accordion.querySelector('.accordion-header');
     accordionbutton.parentElement.classList.add('completed');
-    accordionbutton.click();
-    accordionbutton.setAttribute('disabled', '');
-    const accordions = Array.from(document.querySelectorAll('.accordion-item:not([id*="placeholder"])'));
-    const current = accordions.findIndex( x => x.id.indexOf(event.params.step) > -1  );
-    var nextitem = accordions.at(current+1).id.split('-accordion')[0];
-    nextitem = (nextitem == 'pickup' || nextitem == 'scan') && formdata.get('patron_request[request_type]') ? formdata.get('patron_request[request_type]') : nextitem;
-    var nextstep = document.querySelector(`[data-bs-target='#${nextitem}']`);
 
-    this.clickNext(nextstep, accordionbutton);
+    // figure out what the next step is:
+    const accordions = this.accordionTargets.filter(e => !e.classList.contains('step-placeholder'));
+    const current = accordions.findIndex( x => x == accordion);
+    var nextitem = accordions.at(current+1).id.split('-accordion')[0];
+
+    // ... but the pickup or scan step varies based on data in the form:
+    const formdata = new FormData(this.element);
+    nextitem = (nextitem == 'pickup' || nextitem == 'scan') && formdata.get('patron_request[request_type]') ? formdata.get('patron_request[request_type]') : nextitem;
+    var nextstep = document.querySelector(`#${nextitem}`);
+
+    this.showStep(nextstep);
     event.preventDefault();
   }
 
   editForm(event) {
     event.target.parentElement.classList.remove('completed');
-    document.querySelectorAll('.accordion-item').forEach(accordion => {
-      accordion.querySelector('.accordion-button').setAttribute('disabled', '');
-    })
-    document.querySelector('.show').classList.remove('show');
-    this.clickNext(event.target.parentElement.querySelector('.accordion-button'));
+    this.showStep(event.target.closest('.accordion-item').querySelector('.accordion-collapse'));
+
     event.preventDefault();
   }
 
-  clickNext(element, accordionbutton=false) {
-    element.removeAttribute('disabled');
-    const accordionid = element.dataset.bsTarget.replace('#', '') + '-accordion'
-    document.querySelector(`#${accordionid}`).classList.remove('d-none')
-    element.click();
-    if (accordionbutton) {
-      var previoustepnumber = parseInt(accordionbutton.querySelector('.step-number').innerHTML);
-      element.querySelector('.step-number').innerHTML = previoustepnumber + 1;
-      const placeholder = document.querySelector(`#placeholder${previoustepnumber + 1}-accordion`);
-      if (placeholder){ placeholder.classList.add('d-none'); }
-    } else {
-      const accordions = Array.from(document.querySelectorAll('.accordion-item'));
-      const currentelement = accordions.findIndex( x => x.id === accordionid  );
-      accordions.slice(currentelement+1).forEach(accordion => {
-        if (accordion.id.indexOf('placeholder') > -1) {
-          accordion.classList.remove('d-none');
-        } else {
-          accordion.classList.add('d-none');
-        }
-      })
+  // show the next step in the request form. Bootstrap will toggle the other steps closed,
+  // and we have to do some bookkeeping with the placeholder elements to hide them (if the non-placeholder step is visible)
+  // or show them (if we've stepped back)
+  showStep(accordionCollapseElement) {
+    const accordionitem = accordionCollapseElement.closest('.accordion-item');
+    accordionitem.classList.remove('d-none');
+
+    Collapse.getOrCreateInstance(accordionCollapseElement).show();
+
+    if (accordionitem.dataset.patronrequestPlaceholder) {
+      this.element.querySelector(accordionitem.dataset.patronrequestPlaceholder).classList.add('d-none');
+      this.element.querySelectorAll(`[data-patronRequest-placeholder="${accordionitem.dataset.patronrequestPlaceholder}"]`).forEach(el => { el != accordionitem && el.classList.add('d-none') });
     }
+
+    this.accordionTargets.slice(this.accordionTargets.indexOf(accordionitem) + 1).forEach(el => {
+      if (el.dataset.patronrequestPlaceholder && !el.classList.contains('d-none')) {
+        el.classList.add('d-none');
+        this.element.querySelector(el.dataset.patronrequestPlaceholder).classList.remove('d-none');
+      }
+
+      el.classList.remove('completed');
+    });
+
+    this.renumberVisibleSteps();
   }
 
   async updateEarliestAvailable(event) {

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -10,6 +10,18 @@ export default class extends Controller {
     }
   }
 
+  updateType(event) {
+    const requestType = event.target.value;
+
+    this.accordionTargets.filter(e => e.dataset.patronrequestForrequesttype).forEach(el => {
+      if (el.dataset.patronrequestForrequesttype == requestType) {
+        el.classList.remove('d-none');
+      } else {
+        el.classList.add('d-none');
+      }
+    });
+  }
+
   removeAccordionStyling() {
     this.element.classList.remove('accordion');
 
@@ -27,16 +39,11 @@ export default class extends Controller {
     accordionbutton.parentElement.classList.add('completed');
 
     // figure out what the next step is:
-    const accordions = this.accordionTargets.filter(e => !e.classList.contains('step-placeholder'));
+    const accordions = this.accordionTargets.filter(e => !e.classList.contains('step-placeholder') && !e.classList.contains('d-none'));
     const current = accordions.findIndex( x => x == accordion);
-    var nextitem = accordions.at(current+1).id.split('-accordion')[0];
+    var nextitem = accordions.at(current+1);
 
-    // ... but the pickup or scan step varies based on data in the form:
-    const formdata = new FormData(this.element);
-    nextitem = (nextitem == 'pickup' || nextitem == 'scan') && formdata.get('patron_request[request_type]') ? formdata.get('patron_request[request_type]') : nextitem;
-    var nextstep = document.querySelector(`#${nextitem}`);
-
-    this.showStep(nextstep);
+    this.showStep(nextitem.querySelector('.accordion-collapse'));
     event.preventDefault();
   }
 
@@ -56,17 +63,7 @@ export default class extends Controller {
 
     Collapse.getOrCreateInstance(accordionCollapseElement).show();
 
-    if (accordionitem.dataset.patronrequestPlaceholder) {
-      this.element.querySelector(accordionitem.dataset.patronrequestPlaceholder).classList.add('d-none');
-      this.element.querySelectorAll(`[data-patronRequest-placeholder="${accordionitem.dataset.patronrequestPlaceholder}"]`).forEach(el => { el != accordionitem && el.classList.add('d-none') });
-    }
-
-    this.accordionTargets.slice(this.accordionTargets.indexOf(accordionitem) + 1).forEach(el => {
-      if (el.dataset.patronrequestPlaceholder && !el.classList.contains('d-none')) {
-        el.classList.add('d-none');
-        this.element.querySelector(el.dataset.patronrequestPlaceholder).classList.remove('d-none');
-      }
-
+    this.accordionTargets.slice(this.accordionTargets.indexOf(accordionitem)).forEach(el => {
       el.classList.remove('completed');
     });
   }

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -7,9 +7,6 @@ export default class extends Controller {
   connect() {
     if (this.accordionTargets.length == 1) {
       this.removeAccordionStyling();
-    } else {
-      this.renumberVisibleSteps();
-      Collapse.getOrCreateInstance(this.accordionTargets[0].querySelector('.accordion-collapse')).show();
     }
   }
 
@@ -20,14 +17,6 @@ export default class extends Controller {
     accordion.classList.remove('d-none');
     accordion.classList.remove('shadow-sm');
     accordion.querySelector('.accordion-header').remove();
-
-    Collapse.getOrCreateInstance(this.accordionTargets[0].querySelector('.accordion-collapse')).show();
-  }
-
-  renumberVisibleSteps() {
-    this.accordionTargets.filter(element => (!element.classList.contains('d-none'))).forEach((accordion, index) => {
-      accordion.getElementsByClassName('step-number')[0].innerHTML = index + 1;
-    });
   }
 
   nextStep(event) {
@@ -80,8 +69,6 @@ export default class extends Controller {
 
       el.classList.remove('completed');
     });
-
-    this.renumberVisibleSteps();
   }
 
   async updateEarliestAvailable(event) {

--- a/app/views/patron_requests/_accordion_continue.html.erb
+++ b/app/views/patron_requests/_accordion_continue.html.erb
@@ -1,3 +1,3 @@
 <div class="d-flex justify-content-end gap-1">
-  <button class="btn btn-primary" data-action="click->patronRequest#nextStep" id="<%= target %>">Continue</button>
+  <button class="btn btn-primary" data-action="click->patronRequest#nextStep" data-patronRequest-step-param="<%= target %>">Continue</button>
 </div>

--- a/app/views/patron_requests/_accordion_continue.html.erb
+++ b/app/views/patron_requests/_accordion_continue.html.erb
@@ -1,3 +1,3 @@
 <div class="d-flex justify-content-end gap-1">
-  <button class="btn btn-primary" data-action="click->patronRequest#nextStep" data-patronRequest-step-param="<%= target %>">Continue</button>
+  <button class="btn btn-primary" data-action="click->patronRequest#nextStep">Continue</button>
 </div>

--- a/app/views/patron_requests/_accordion_header.html.erb
+++ b/app/views/patron_requests/_accordion_header.html.erb
@@ -1,10 +1,10 @@
 <div class="accordion-header d-flex">
-  <button class="accordion-button" type="button" data-patronRequest-target="accordionButton" data-bs-toggle="collapse" data-bs-target="#<%= target %>" aria-controls="<%= target %>" disabled>
+  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#<%= target %>" aria-controls="<%= target %>" disabled>
     <div class="step-number d-flex justify-content-center align-items-center rounded-circle border border-secondary p-2 me-2 bg-secondary text-white"></div>
     <h2 class="accordion-title fw-semibold fs-5 mb-0">
       <%= title %>
     </h2>
-    <button class="btn btn-link d-none edit-button align-items-center" data-action='click->patronRequest#editForm'>
+    <button class="btn btn-link d-none edit-button align-items-center" data-action='click->patronRequest#editForm' aria-controls="<%= target %>">
       <i class="bi bi-pencil me-1"></i> Edit
     </button>
   </button>

--- a/app/views/patron_requests/_accordion_header.html.erb
+++ b/app/views/patron_requests/_accordion_header.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (target:, title:, step_number: nil, expanded: false) -%>
 <div class="accordion-header d-flex">
-  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#<%= target %>" aria-controls="<%= target %>" disabled>
-    <div class="step-number d-flex justify-content-center align-items-center rounded-circle border border-secondary p-2 me-2 bg-secondary text-white"></div>
+  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#<%= target %>" aria-expanded="<%= expanded ? 'true' : 'false' %>" aria-controls="<%= target %>" disabled>
+    <div class="step-number d-flex justify-content-center align-items-center rounded-circle border border-secondary p-2 me-2 bg-secondary text-white"><%= step_number %></div>
     <h2 class="accordion-title fw-semibold fs-5 mb-0">
       <%= title %>
     </h2>

--- a/app/views/patron_requests/_scan_or_pickup.html.erb
+++ b/app/views/patron_requests/_scan_or_pickup.html.erb
@@ -2,7 +2,7 @@
 <fieldset class="mb-4">
   <legend class="fs-6"></legend>
   <div>
-    <%= f.radio_button :request_type, 'scan', :class => 'form-check-input', :required => true %>
+    <%= f.radio_button :request_type, 'scan', :class => 'form-check-input', :required => true, data: { action: 'patronRequest#updateType' } %>
     <%= f.label :request_type_scan, :class => 'form-check-label ms-1' do %>
       Email digital scan
     <% end %>
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="mt-4">
-    <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input' %>
+    <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input', data: { action: 'patronRequest#updateType' } %>
     <%= f.label :request_type_pickup, :class => 'form-check-label ms-1' do %>
       Pickup physical item
     <% end %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -33,8 +33,8 @@
     </div>
 
     <% if f.object.items_in_location.one? %>
-      <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
-        <%= render 'accordion_header', title: 'Scan or pickup request', target: 'multioption-placeholder', step_number: current_step %>
+      <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-or-pickup-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
+        <%= render 'accordion_header', title: 'Scan or pickup request', target: 'scan-or-pickup-placeholder', step_number: current_step %>
       </div>
     <% end %>
 
@@ -77,8 +77,8 @@
       </div>
     </div>
 
-    <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
-      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'multioption-placeholder', step_number: current_step %>
+    <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-or-pickup-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
+      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'scan-or-pickup-placeholder', step_number: current_step %>
     </div>
 
     <!-- pickup request (multiple items) -->

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -8,6 +8,9 @@
 <% end %>
 
 <%= form_for(@request, data: { controller: 'patronRequest' }, html: { class: 'col-lg-8 accordion' }) do |f| %>
+  <% step_enum = Enumerator.new { |y| n = 0; loop { y << (n += 1) } } %>
+  <% current_step = nil %>
+  <% scan_or_pickup_step = nil %>
   <%= f.hidden_field :instance_hrid %>
   <%= f.hidden_field :origin_location_code %>
   <% if @request.items_in_location.one? || f.object.barcodes&.one? %>
@@ -19,9 +22,9 @@
   <!-- request type -->
   <% scan_pickup = can?(:request_scan, f.object) && can?(:prepare, f.object) %>
   <% if scan_pickup  %>
-    <div class="accordion-item my-4 shadow-sm" id="request-type-accordion" data-patronRequest-target="accordion">
-      <%= render 'accordion_header', title: 'Request type', target: 'request-type' %>
-      <div id="request-type" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>" data-bs-parent="#<%= f.id %>">
+    <div class="accordion-item my-4 shadow-sm accordion-step-<%= current_step = step_enum.next %>" id="request-type-accordion" data-patronRequest-target="accordion">
+      <%= render 'accordion_header', title: 'Request type', target: 'request-type', step_number: current_step, expanded: current_step == 1 %>
+      <div id="request-type" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <%= render 'scan_or_pickup', f: %>
           <%= render 'accordion_continue', target: 'request-type' %>
@@ -30,8 +33,8 @@
     </div>
 
     <% if f.object.items_in_location.one? %>
-      <div class="accordion-item my-4 shadow-sm step-placeholder" id="multioption-placeholder" data-patronRequest-target="accordion">
-        <%= render 'accordion_header', title: 'Scan or pickup request', target: 'multioption-placeholder' %>
+      <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= scurrent_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-target="accordion">
+        <%= render 'accordion_header', title: 'Scan or pickup request', target: 'multioption-placeholder', step_number: current_step %>
       </div>
     <% end %>
 
@@ -40,9 +43,9 @@
   <div data-controller="itemselector">
   <% if f.object.items_in_location.many? && (can?(:request_scan, f.object) || can?(:prepare, f.object)) %>
     <!-- item selector -->
-    <div class="accordion-item my-4 shadow-sm" id="barcodes-accordion" data-patronRequest-target="accordion">
-      <%= render 'accordion_header', title: 'Select item(s)', target: 'barcodes' %>
-      <div id="barcodes" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
+    <div class="accordion-item my-4 shadow-sm accordion-step-<%= current_step = step_enum.next %>" id="barcodes-accordion" data-patronRequest-target="accordion">
+      <%= render 'accordion_header', title: 'Select item(s)', target: 'barcodes', step_number: current_step %>
+      <div id="barcodes" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <div class="item-table border m-4">
             <table class="table w-75">
@@ -74,15 +77,15 @@
       </div>
     </div>
 
-    <div class="accordion-item my-4 shadow-sm step-placeholder" id="multioption-placeholder" data-patronRequest-target="accordion">
-      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'multioption-placeholder' %>
+    <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-target="accordion">
+      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'multioption-placeholder', step_number: current_step %>
     </div>
 
     <!-- pickup request (multiple items) -->
     <% if can? :prepare, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
-      <%= render 'accordion_header', title: 'Pickup request', target: 'pickup' %>
-      <div id="pickup" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
+    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
+      <%= render 'accordion_header', title: 'Pickup request', target: 'pickup', step_number: current_step %>
+      <div id="pickup" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <div class="selected-items-group">
             <%= render 'pickup_destination', f: %>
@@ -133,9 +136,9 @@
 
   <!-- pickup request (single item )-->
   <% if f.object.items_in_location.one? && can?(:prepare, f.object) %>
-    <div class="accordion-item my-4 shadow-sm d-none" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
-      <%= render 'accordion_header', title: 'Pickup request', target: 'pickup' %>
-      <div id="pickup" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
+    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
+      <%= render 'accordion_header', title: 'Pickup request', target: 'pickup', step_number: current_step %>
+      <div id="pickup" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <div id="earliestAvailableContainer" class="text-cardinal mt-4" aria-live="polite">
             Earliest available:
@@ -169,9 +172,9 @@
 
   <!-- scan request (single or multiitem) -->
   <% if can? :request_scan, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none" id="scan-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
-      <%= render 'accordion_header', title: 'Scan request', target: 'scan' %>
-      <div id="scan" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
+    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
+      <%= render 'accordion_header', title: 'Scan request', target: 'scan', step_number: current_step %>
+      <div id="scan" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <%= render 'scan_options', f: %>
           <div class="form-group d-flex justify-content-end gap-1">

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -76,14 +76,15 @@
         </div>
       </div>
     </div>
-
-    <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-or-pickup-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
-      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'scan-or-pickup-placeholder', step_number: current_step %>
-    </div>
+    <% if scan_pickup %>
+      <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-or-pickup-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
+        <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'scan-or-pickup-placeholder', step_number: current_step %>
+      </div>
+    <% end %>
 
     <!-- pickup request (multiple items) -->
     <% if can? :prepare, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-forRequestType="pickup" data-patronRequest-target="accordion">
+    <div class="accordion-item my-4 shadow-sm <%= scan_pickup ? 'd-none' : '' %> accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-forRequestType="pickup" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Pickup request', target: 'pickup', step_number: current_step %>
       <div id="pickup" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
@@ -136,7 +137,7 @@
 
   <!-- pickup request (single item )-->
   <% if f.object.items_in_location.one? && can?(:prepare, f.object) %>
-    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-forRequestType="pickup" data-patronRequest-target="accordion">
+    <div class="accordion-item my-4 shadow-sm <%= scan_pickup ? 'd-none' : '' %> accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-forRequestType="pickup" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Pickup request', target: 'pickup', step_number: current_step %>
       <div id="pickup" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
@@ -172,7 +173,7 @@
 
   <!-- scan request (single or multiitem) -->
   <% if can? :request_scan, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-accordion" data-patronRequest-forRequestType="scan" data-patronRequest-target="accordion">
+    <div class="accordion-item my-4 shadow-sm <%= scan_pickup ? 'd-none' : '' %> accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-accordion" data-patronRequest-forRequestType="scan" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Scan request', target: 'scan', step_number: current_step %>
       <div id="scan" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -33,7 +33,7 @@
     </div>
 
     <% if f.object.items_in_location.one? %>
-      <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= scurrent_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-target="accordion">
+      <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
         <%= render 'accordion_header', title: 'Scan or pickup request', target: 'multioption-placeholder', step_number: current_step %>
       </div>
     <% end %>
@@ -77,13 +77,13 @@
       </div>
     </div>
 
-    <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-target="accordion">
+    <div class="accordion-item my-4 shadow-sm step-placeholder accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="multioption-placeholder" data-patronRequest-forRequestType="none" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'multioption-placeholder', step_number: current_step %>
     </div>
 
     <!-- pickup request (multiple items) -->
     <% if can? :prepare, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
+    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-forRequestType="pickup" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Pickup request', target: 'pickup', step_number: current_step %>
       <div id="pickup" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
@@ -136,7 +136,7 @@
 
   <!-- pickup request (single item )-->
   <% if f.object.items_in_location.one? && can?(:prepare, f.object) %>
-    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
+    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="pickup-accordion" data-patronRequest-forRequestType="pickup" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Pickup request', target: 'pickup', step_number: current_step %>
       <div id="pickup" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
@@ -172,7 +172,7 @@
 
   <!-- scan request (single or multiitem) -->
   <% if can? :request_scan, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
+    <div class="accordion-item my-4 shadow-sm d-none accordion-step-<%= current_step = (scan_or_pickup_step ||= step_enum.next) %>" id="scan-accordion" data-patronRequest-forRequestType="scan" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Scan request', target: 'scan', step_number: current_step %>
       <div id="scan" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -19,9 +19,9 @@
   <!-- request type -->
   <% scan_pickup = can?(:request_scan, f.object) && can?(:prepare, f.object) %>
   <% if scan_pickup  %>
-    <div class="accordion-item my-4 shadow-sm" id="request-type-accordion">
+    <div class="accordion-item my-4 shadow-sm" id="request-type-accordion" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Request type', target: 'request-type' %>
-      <div id="request-type" class="accordion-collapse collapse">
+      <div id="request-type" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <%= render 'scan_or_pickup', f: %>
           <%= render 'accordion_continue', target: 'request-type' %>
@@ -30,8 +30,8 @@
     </div>
 
     <% if f.object.items_in_location.one? %>
-      <div class="accordion-item my-4 shadow-sm" id="placeholder2-accordion">
-        <%= render 'accordion_header', title: 'Scan or pickup request', target: 'placeholder2' %>
+      <div class="accordion-item my-4 shadow-sm step-placeholder" id="multioption-placeholder" data-patronRequest-target="accordion">
+        <%= render 'accordion_header', title: 'Scan or pickup request', target: 'multioption-placeholder' %>
       </div>
     <% end %>
 
@@ -40,9 +40,9 @@
   <div data-controller="itemselector">
   <% if f.object.items_in_location.many? && (can?(:request_scan, f.object) || can?(:prepare, f.object)) %>
     <!-- item selector -->
-    <div class="accordion-item my-4 shadow-sm" id="barcodes-accordion">
+    <div class="accordion-item my-4 shadow-sm" id="barcodes-accordion" data-patronRequest-target="accordion">
       <%= render 'accordion_header', title: 'Select item(s)', target: 'barcodes' %>
-      <div id="barcodes" class="accordion-collapse collapse">
+      <div id="barcodes" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <div class="item-table border m-4">
             <table class="table w-75">
@@ -74,16 +74,15 @@
       </div>
     </div>
 
-    <% placeholdername = scan_pickup ? 'placeholder3' : 'placeholder2' %>
-    <div class="accordion-item my-4 shadow-sm" id="<%= placeholdername %>-accordion">
-      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: placeholdername %>
+    <div class="accordion-item my-4 shadow-sm step-placeholder" id="multioption-placeholder" data-patronRequest-target="accordion">
+      <%= render 'accordion_header', title: scan_pickup ? 'Scan or pickup request' : 'Pickup request', target: 'multioption-placeholder' %>
     </div>
 
     <!-- pickup request (multiple items) -->
     <% if can? :prepare, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none" id="pickup-accordion">
+    <div class="accordion-item my-4 shadow-sm d-none" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
       <%= render 'accordion_header', title: 'Pickup request', target: 'pickup' %>
-      <div id="pickup" class="accordion-collapse collapse">
+      <div id="pickup" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <div class="selected-items-group">
             <%= render 'pickup_destination', f: %>
@@ -134,9 +133,9 @@
 
   <!-- pickup request (single item )-->
   <% if f.object.items_in_location.one? && can?(:prepare, f.object) %>
-    <div class="accordion-item my-4 shadow-sm d-none" id="pickup-accordion">
+    <div class="accordion-item my-4 shadow-sm d-none" id="pickup-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
       <%= render 'accordion_header', title: 'Pickup request', target: 'pickup' %>
-      <div id="pickup" class="accordion-collapse collapse">
+      <div id="pickup" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <div id="earliestAvailableContainer" class="text-cardinal mt-4" aria-live="polite">
             Earliest available:
@@ -168,11 +167,11 @@
     </div>
   <% end %>
 
-  <!-- scan request -->
+  <!-- scan request (single or multiitem) -->
   <% if can? :request_scan, f.object %>
-    <div class="accordion-item my-4 shadow-sm d-none" id="scan-accordion">
+    <div class="accordion-item my-4 shadow-sm d-none" id="scan-accordion" data-patronRequest-target="accordion" data-patronrequest-placeholder="#multioption-placeholder">
       <%= render 'accordion_header', title: 'Scan request', target: 'scan' %>
-      <div id="scan" class="accordion-collapse collapse">
+      <div id="scan" class="accordion-collapse collapse" data-bs-parent="#<%= f.id %>">
         <div class="accordion-body">
           <%= render 'scan_options', f: %>
           <div class="form-group d-flex justify-content-end gap-1">


### PR DESCRIPTION
- by adding `data-bs-parent` and Bootstrap's `Collapse` (instead of simulating a click), bootstrap can handle hiding + showing the different sections for us
- clarify (and make explicit) the placeholder sections
- pull step renumbering up to a shared method (fixing an off-by-one error with the multi-item case)