### PR TITLE
Unify date formats across the app

### DIFF
--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -140,7 +140,7 @@ module Folio
     end
 
     def due_date
-      Time.zone.parse(@due_date).strftime('%m/%d/%Y') if @due_date
+      I18n.l(Time.zone.parse(@due_date).to_date, format: :short) if @due_date
     end
 
     def hold?

--- a/app/models/paging_schedule.rb
+++ b/app/models/paging_schedule.rb
@@ -132,7 +132,7 @@ module PagingSchedule
       end
 
       def to_s
-        "#{I18n.l(estimated_delivery_day_to_destination, format: :long)}, #{time}"
+        "#{I18n.l(estimated_delivery_day_to_destination, format: :long)} #{time}"
       end
 
       def estimated_delivery_day_to_destination

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,9 +95,9 @@ en:
       mediator_subject: "New request needs mediation"
   date:
     formats:
-      quick: "%a %b %-d"
-      short: "%b %-d %Y"
-      long: "%A, %b %-d %Y"
+      quick: '%a %b %-d'
+      short: '%b %-d, %Y'
+      long: '%A, %b %-d, %Y'
   time:
     am: a
     pm: p

--- a/spec/features/circ_check_spec.rb
+++ b/spec/features/circ_check_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Circ Check app', :js do
       click_on 'Check'
 
       expect(page).to have_content('✅ 1234567890')
-      expect(page).to have_content('Due: Jan 1 2020')
+      expect(page).to have_content('Due: Jan 1, 2020')
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe 'Circ Check app', :js do
       click_on 'Check'
 
       expect(page).to have_content('✅ 1234567890')
-      expect(page).to have_content('Due: Jan 1 2020')
+      expect(page).to have_content('Due: Jan 1, 2020')
     end
   end
 

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe 'Creating a page request' do
         visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
 
         within '#earliestAvailableContainer' do
-          expect(page).to have_content('Wednesday, Apr 3 2024, after 10am')
+          expect(page).to have_content('Wednesday, Apr 3, 2024 after 10am')
         end
 
         select 'Marine Biology Library', from: 'Preferred pickup location'
         within '#earliestAvailableContainer' do
-          expect(page).to have_content('Friday, Apr 5 2024, after 4pm')
+          expect(page).to have_content('Friday, Apr 5, 2024 after 4pm')
         end
       end
     end

--- a/spec/features/item_selector_spec.rb
+++ b/spec/features/item_selector_spec.rb
@@ -316,14 +316,14 @@ RSpec.describe 'Item Selector' do
 
     it 'has the due date' do
       within('#item-selector') do
-        expect(page).to have_css('.unavailable', text: 'Due 01/01/2015')
+        expect(page).to have_css('.unavailable', text: 'Due Jan 1, 2015')
       end
     end
 
     it 'toggles the checked out note' do
       within('#item-selector') do
         expect(page).to have_no_css('.current-location-note')
-        find('.unavailable', text: 'Due 01/01/2015').click
+        find('.unavailable', text: 'Due Jan 1, 2015').click
         expect(page).to have_css('.current-location-note')
       end
     end

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Viewing all requests' do
 
         within '.library-page-SAL3' do
           expect(page).to have_content 'This is an important message'
-          expect(page).to have_content 'Active Jan 1 2000 through Jan 1 2100'
+          expect(page).to have_content 'Active Jan 1, 2000 through Jan 1, 2100'
         end
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe 'Viewing all requests' do
 
         within '.library-page-SAL3' do
           expect(page).to have_content 'This is an important message'
-          expect(page).to have_content 'Active Jan 1 2000 through Jan 1 2100'
+          expect(page).to have_content 'Active Jan 1, 2000 through Jan 1, 2100'
         end
       end
     end

--- a/spec/features/paging_schedule_spec.rb
+++ b/spec/features/paging_schedule_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Paging Schedule' do
 
       expect(page).to have_select('request_destination', selected: 'Green Library')
 
-      expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
+      expect(page).to have_css('[data-scheduler-text]', text: /(before|after)/, visible: :visible)
       before_text = find('[data-scheduler-text]').text
 
       select 'Engineering Library (Terman)', from: 'request_destination'
@@ -59,7 +59,7 @@ RSpec.describe 'Paging Schedule' do
     it 'is persisted' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
-      expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
+      expect(page).to have_css('[data-scheduler-text]', text: /(before|after)/, visible: :visible)
       schedule_text = find('[data-scheduler-text]').text
 
       within('#item-selector') do
@@ -89,7 +89,7 @@ RSpec.describe 'Paging Schedule' do
       visit new_page_path(item_id: '1234', origin: 'SAL3', origin_location: 'SAL3-PAGE-EN')
 
       expect(page).to have_no_select('request_destination')
-      expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
+      expect(page).to have_css('[data-scheduler-text]', text: /(before|after)/, visible: :visible)
     end
   end
 
@@ -102,7 +102,7 @@ RSpec.describe 'Paging Schedule' do
       visit new_request_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
       within('#deliveryDescription') do
-        expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
+        expect(page).to have_css('[data-scheduler-text]', text: /(before|after)/, visible: :visible)
       end
     end
   end
@@ -115,7 +115,7 @@ RSpec.describe 'Paging Schedule' do
     it 'shows the estimated delivery for the Scanning service' do
       visit new_scan_path(item_id: '12345', origin: 'SAL3', origin_location: 'SAL3-STACKS')
 
-      expect(page).to have_css('[data-scheduler-text]', text: /, (before|after)/, visible: :visible)
+      expect(page).to have_css('[data-scheduler-text]', text: /(before|after)/, visible: :visible)
     end
   end
 end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe RequestsHelper do
       end
 
       it 'includes the due date' do
-        expect(subject).to have_content('Due 08/30/2023')
+        expect(subject).to have_content('Due Aug 30, 2023')
       end
     end
 


### PR DESCRIPTION
Closes #2194

- Everything is now "[weekday] mmm dd, yyyy [after TIME]" except the date picker, which can't be changed.
- Some commas got moved around.

![Screenshot 2024-04-19 at 9 19 20 AM](https://github.com/sul-dlss/sul-requests/assets/4924494/17248571-7858-4a20-a802-7464f50a9d9d)

![Screenshot 2024-04-19 at 9 19 31 AM](https://github.com/sul-dlss/sul-requests/assets/4924494/a604c465-540e-4eb3-a66e-4a518885ae67)
