### PR TITLE
Incorporate proxy step into request form: Ask if user ok allowing proxy users to pick up requested items

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -55,6 +55,6 @@ class PatronRequestsController < ApplicationController
 
   def patron_request_params
     params.require(:patron_request).permit(:patron_email, :instance_hrid, :origin_location_code, :needed_date, :service_point_code,
-                                           :barcode, :fulfillment_type)
+                                           :barcode, :fulfillment_type, :proxy)
   end
 end

--- a/app/jobs/submit_folio_patron_request_job.rb
+++ b/app/jobs/submit_folio_patron_request_job.rb
@@ -47,12 +47,16 @@ class SubmitFolioPatronRequestJob < ApplicationJob
     end
   end
 
+  def request_comments(patron, request)
+    [("(PROXY PICKUP OK; request placed by #{patron.display_name} <#{patron.email}>)" if request.proxy?)].compact.join("\n")
+  end
+
   def folio_request_data_for_item(patron, request, item)
     FolioClient::CirculationRequestData.new(
       request_level: 'Item', request_type: best_request_type(request, item),
       instance_id: request.instance_id, item_id: item.id, holdings_record_id: item.holdings_record_id,
       requester_id: patron&.id, fulfillment_preference: 'Hold Shelf', pickup_service_point_id: request.pickup_service_point.id,
-      patron_comments: '', request_expiration_date: (Time.zone.today + 3.years).to_time.utc.iso8601
+      patron_comments: request_comments(patron, request), request_expiration_date: (Time.zone.today + 3.years).to_time.utc.iso8601
     )
   end
 

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -136,6 +136,11 @@ module Folio
       crypt.encrypt_and_sign(id, expires_in: 20.minutes)
     end
 
+    # Get all the proxies for this id, and not just the first one
+    def all_proxy_group_info
+      @all_proxy_group_info ||= self.class.folio_client.all_proxy_group_info(id)
+    end
+
     private
 
     def standing

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -190,6 +190,8 @@ class PatronRequest < ApplicationRecord
   # Check if the user has selected "yes" on the form with respect to proxy permission
   def proxy?
     proxy == 'share'
+  end
+
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def illiad_request_params(item)
     default_values = {

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -7,7 +7,8 @@ class PatronRequest < ApplicationRecord
   class_attribute :bib_model_class, default: Settings.ils.bib_model.constantize
   store :data, accessors: [
     :barcodes, :folio_responses, :illiad_response_data, :scan_page_range, :scan_authors, :scan_title, :request_type,
-    :proxy], coder: JSON
+    :proxy
+  ], coder: JSON
 
   delegate :instance_id, to: :bib_data
 

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -172,7 +172,6 @@ class PatronRequest < ApplicationRecord
     earliest_delivery_estimate(scan: true)
   end
 
-<<<<<<< HEAD
   # Return list of names of individuals who are proxies for this id
   def proxy_group_names
     return [] unless patron.sponsor?
@@ -191,7 +190,6 @@ class PatronRequest < ApplicationRecord
   # Check if the user has selected "yes" on the form with respect to proxy permission
   def proxy?
     proxy == 'share'
-=======
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def illiad_request_params(item)
     default_values = {
@@ -238,7 +236,6 @@ class PatronRequest < ApplicationRecord
 
   def notify_ilb!
     # TODO?
->>>>>>> main
   end
 
   private

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -138,12 +138,19 @@ class FolioClient
     check_response(response, title: 'Assign pin', context: { user_id: })
   end
 
-  def proxy_group_info(user_id)
+  # We sometimes want the full list of proxies and not just the first one
+  def all_proxy_group_info(user_id)
     response = get_json('/proxiesfor', params: { query: CqlQuery.new(userId: user_id).to_query })
 
-    response.dig('proxiesFor', 0)
+    response['proxiesFor']
   end
 
+  # Get proxies for this user id and return the first one
+  def proxy_group_info(user_id)
+    all_proxy_group_info(user_id)[0]
+  end
+
+  # For whom is this user id a proxy?
   def proxy_info(user_id)
     response = get_json('/proxiesfor', params: { query: CqlQuery.new(proxyUserId: user_id).to_query })
 

--- a/app/views/patron_requests/_proxy.html.erb
+++ b/app/views/patron_requests/_proxy.html.erb
@@ -1,0 +1,34 @@
+<div class="row p-3 gap-3 flex-column flex-md-row">
+  <div class="col alert alert-info">
+    We noticed your library account has designated proxies, individuals authorized to place requests and borrow 
+    materals on your behalf.  Sharing this request enables them to track its status.  Your library proxies are: 
+    <div class="mt-2">
+        <ul>
+        <%
+            current_request.proxy_group_names.sort.each do |proxy_group_name|
+        %>
+            <li><%=proxy_group_name %></li>
+        <%
+            end
+        %>
+        </ul>
+    </div>
+  </div>
+  <div class="col pe-0">
+    <div class="mt-2">
+      Do you want to share this request with your proxies?
+    </div>
+     <div class="mt-2">
+        <%= f.radio_button :proxy, 'share', :class => 'form-check-input' %>
+        <%= f.label :proxy_share, :class => 'form-check-label ms-1' do %>
+        Yes, share this request with my proxies.
+        <% end %>
+    </div>
+    <div class="mt-2">
+        <%= f.radio_button :proxy, 'noshare', :class => 'form-check-input' %>
+        <%= f.label :proxy_noshare, :class => 'form-check-label ms-1' do %>
+        No, this request is just for me.
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -18,6 +18,18 @@
   <% end %>
 
   <!-- proxy -->
+  <% if current_request.proxy_group_names.present? %>
+    <div class="accordion-item my-4 shadow-sm accordion-step-<%= current_step = step_enum.next %>" id="proxy-accordion" data-patronRequest-target="accordion">
+      <%= render 'accordion_header', title: 'Proxy/Sponsor', target: 'proxy', step_number: current_step, expanded: current_step == 1 %>
+
+      <div id="proxy" class="accordion-collapse collapse <%= 'show' if current_step == 1 %>" data-bs-parent="#<%= f.id %>" data-bs-parent="#<%= f.id %>">
+        <div class="accordion-body">
+          <%= render 'proxy', f: %>
+          <%= render 'accordion_continue', target: 'proxy' %>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
   <!-- request type -->
   <% scan_pickup = can?(:request_scan, f.object) && can?(:prepare, f.object) %>

--- a/spec/models/patron_request_spec.rb
+++ b/spec/models/patron_request_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe PatronRequest do
       expect(request.barcodes).to eq(['1234567890'])
     end
   end
+
+  describe '#proxy_group_names' do
+    let(:patron_one) { instance_double(Folio::Patron, id: 'proxy1', display_name: 'Proxy One') }
+    let(:patron_two) { instance_double(Folio::Patron, id: 'proxy2', display_name: 'Proxy Two') }
+
+    it 'retrieves the names of the proxy user ids correctly' do
+      request.patron = instance_double(Folio::Patron, id: 'sponsor')
+      stub_client = FolioClient.new
+      allow(FolioClient).to receive(:new).and_return(stub_client)
+      allow(stub_client).to receive(:find_patron_by_id).with('proxy1').and_return(patron_one)
+      allow(stub_client).to receive(:find_patron_by_id).with('proxy2').and_return(patron_two)
+      allow(request.patron).to receive_messages(
+        sponsor?: true,
+        all_proxy_group_info: [{ 'proxyUserId' => 'proxy1', 'requestForSponsor' => 'Yes' },
+                               { 'proxyUserId' => 'proxy2', 'requestForSponsor' => 'Yes' }]
+      )
+      expect(request.proxy_group_names.length).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
Closes #2156 .

What this pull request does:

- Adds a method to Folio client allowing a retrieval for the full list of people who can act as a proxy for the patron for the current request.   The method that already existed only returned the first proxy result back.
- Adds a method to patron to use this call the above new Folio client method to get all the proxy ids back associated with the patron. 
- Adds a method to patron request which returns the names of the people who can act as proxies for the patron.  Here, we also check specifically if the proxy ids also have a "requestForSponsor" value set to yes, since that field can also be set to "no" in which case that proxy is not considered someone who can pick up a request on behalf of the sponsor. 
- Adds a method to patron request which checks if the above method returns any values i.e. that the patron has an allowable list of proxies. 
- Adds the "proxy" property to the data accessors for the Patron class, so we can attach the form value (explained below) to it.
- Adds a partial for the proxy view, and renders the partial within the new page if there are any proxies possible for the request.  The form asks if the user is ok with the listed proxies acting on their behalf.  The value of the form is passed along to the patron request object. 
- Adds a method to the submit folio patron job class to process the proxy information ("share" or "noshare") passed along through the patron request class, which generates the appropriate patron comment field value.
- Adds a test for the patron request class. 