### PR TITLE
Add d-inline to the proxy labels so they wrap better at -md or -lg breakpoints

### DIFF
--- a/app/views/patron_requests/_proxy.html.erb
+++ b/app/views/patron_requests/_proxy.html.erb
@@ -20,13 +20,13 @@
     </div>
      <div class="mt-2">
         <%= f.radio_button :proxy, 'share', :class => 'form-check-input' %>
-        <%= f.label :proxy_share, :class => 'form-check-label ms-1' do %>
+        <%= f.label :proxy_share, :class => 'form-check-label ms-1 d-inline' do %>
         Yes, share this request with my proxies.
         <% end %>
     </div>
     <div class="mt-2">
         <%= f.radio_button :proxy, 'noshare', :class => 'form-check-input' %>
-        <%= f.label :proxy_noshare, :class => 'form-check-label ms-1' do %>
+        <%= f.label :proxy_noshare, :class => 'form-check-label ms-1  d-inline' do %>
         No, this request is just for me.
         <% end %>
     </div>


### PR DESCRIPTION
After:
<img width="308" alt="Screenshot 2024-04-23 at 07 20 19" src="https://github.com/sul-dlss/sul-requests/assets/111218/dd74de24-4da4-40b1-8af5-adde53d2b1f9">

Before:
<img width="262" alt="Screenshot 2024-04-23 at 07 20 58" src="https://github.com/sul-dlss/sul-requests/assets/111218/2cadd84b-5f5d-43c0-95fe-aaf1b0205d06">
