### PR TITLE
Update language on login page for library cardholders

### DIFF
--- a/app/views/patron_requests/login.html.erb
+++ b/app/views/patron_requests/login.html.erb
@@ -25,8 +25,7 @@
         <div class="card border-0">
             <h2 class="card-header bg-white border-0 h3">Library cardholder</h2>
             <div class="card-body pt-0">
-                <p>If you’ve purchased a library card or received courtesy access,
-                log in with your Library ID and PIN.
+                <p>If you have an alumni library account, purchased or received courtesy access, or are a staff member at Stanford Hospital or Lucile Packard Children’s Hospital Stanford, please log in using your Library ID and PIN.
                 </p>
                 <p class="mb-2">
                     <a href="https://library.stanford.edu/visitor-access" target="_blank">

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe 'Creating a page request' do
 
       it 'redirects to the login page' do
         visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
-        expect(page).to have_text 'log in with your Library ID and PIN'
+        expect(page).to have_text 'Login with Library ID/PIN'
       end
 
       it 'shows an error message' do
@@ -315,7 +315,7 @@ RSpec.describe 'Creating a page request' do
 
       it 'goes back to login page' do
         visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
-        expect(page).to have_text 'log in with your Library ID and PIN'
+        expect(page).to have_text 'Login with Library ID/PIN'
       end
     end
   end


### PR DESCRIPTION
This language change was requested in slack:
https://stanfordlib.slack.com/archives/G018TJ20XGE/p1714075283350929
