### PR TITLE
Adjust language in login error messages

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     if request.env['warden'].authenticate(:university_id)
       redirect_after_action
     else
-      redirect_to post_action_redirect_url, flash: { error: t('.alert') }
+      redirect_to post_action_redirect_url, flash: { error: t('.alert_html') }
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,12 +218,12 @@ en:
       label: "Library ID"
       help_text: "Last 10 digits above the barcode on your library card"
     login_by_university_id:
-      alert: Unable to authenticate.
+      alert_html: <span class="fw-bold">Login error!</span><br />Please verify your credentials and try again. If you continue to experience problems, contact the Privileges desk at <a href="mailto:sul-privileges@stanford.edu" class="alert-link">sul-privileges@stanford.edu</a> or call (650) 723-1492 for assistance.
     login_by_sunetid:
       alert: Unable to authenticate.
-      error_html: <span class="fw-bold">Your SUNet ID is not linked to a library account.</span><br/> A library account is created for patrons who are eligible to check out library materials. If you believe you should have an account, contact the Privileges desk at <a href="mailto:sul-privileges@stanford.edu" class="alert-link">sul-privileges@stanford.edu</a> or (650) 723-1492 for assistance.
+      error_html: <span class="fw-bold">Your SUNet ID is not linked to a library account.</span><br/> A library account is created for patrons who are eligible to check out library materials. If you believe you should have an account, contact the Privileges desk at <a href="mailto:sul-privileges@stanford.edu" class="alert-link">sul-privileges@stanford.edu</a> or call (650) 723-1492 for assistance.
     register_visitor:
-      alert: Unable to register visitor.  Both name and email are required.
+      alert: Unable to register visitor. Both name and email are required.
     destroy:
       notice: You have been successfully logged out.
   change_pin:

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SessionsController do
     it 'displays error flash message if the registered visitor does not authenticate' do
       allow(request.env['warden']).to receive(:authenticate).and_return(false)
       get :register_visitor, params: { referrer: '/' }
-      expect(flash[:error]).to eq 'Unable to register visitor.  Both name and email are required.'
+      expect(flash[:error]).to eq 'Unable to register visitor. Both name and email are required.'
     end
 
     it 'redirects back when there is no provided referrer' do


### PR DESCRIPTION
Language change requested in slack to match new designs:
https://stanfordlib.slack.com/archives/G018TJ20XGE/p1714076725160799
