### PR TITLE
Force visitors to re-authenticate each request via a hook

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -7,6 +7,8 @@ class PatronRequestsController < ApplicationController
   layout 'application_new'
   load_and_authorize_resource instance_name: :request, new: :login
   before_action :associate_request_with_patron, only: [:new, :create, :login]
+  # force visitors to re-authenticate on each request
+  before_action :logout_user, only: [:new], if: -> { current_user.name_email_user? }
   helper_method :current_request, :new_params
 
   def show
@@ -38,6 +40,10 @@ class PatronRequestsController < ApplicationController
 
   def current_request
     @request
+  end
+
+  def logout_user
+    request.env['warden'].logout
   end
 
   def associate_request_with_patron

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -187,6 +187,8 @@ class PatronRequest < ApplicationRecord
 
   # Return list of names of individuals who are proxies for this id
   def proxy_group_names
+    return nil if patron.is_a?(Folio::NullPatron)
+
     # Return display name for any proxies where 'requestForSponser' is yes.
     patron.all_proxy_group_info.filter_map do |info|
       return nil unless info['requestForSponsor'].downcase == 'yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
     resources :admin_comments
   end
 
-  constraints ->(request) { request.env['warden'].user.blank? || request.env['warden'].user.name_email_user? } do
+  constraints ->(request) { request.env['warden'].user.blank? } do
     get '/patron_requests/new', to: 'patron_requests#login'
   end
 

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -308,17 +308,15 @@ RSpec.describe 'Creating a page request' do
       end
     end
 
-    context 'when the user already made a request (logged in)' do
-      let(:current_user) { CurrentUser.new(name: 'A User', email: 'me@example.com') }
-
-      before do
-        login_as(current_user)
-      end
-
-      it 'goes back to login page' do
-        visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
-        expect(page).to have_text 'Login with Library ID/PIN'
-      end
+    it 'logs the user out before creating a request', :js do
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
+      find('summary', text: 'Proceed as visitor').click
+      fill_in 'Name', with: 'My Name'
+      fill_in 'Email', with: 'me@example.com'
+      click_on 'Continue'
+      click_on 'Submit'
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
+      expect(page).to have_text 'Login with Library ID/PIN'
     end
   end
 end


### PR DESCRIPTION
Making visitors re-authenticate via a route resulted in a loop
where they would just get redirected to the login page, even
after a successful authentication.

This moves the logic to the request controller, so we can force
them to re-auth each request but avoid the loop.

Fixes #2265
