### PR TITLE
Adjust the display of the visit date selector for mediated pages

### DIFF
--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -188,8 +188,8 @@
             After submitting your request, you will receive an email confirmation. Additionally, you will be notified by email once the item is ready for your visit.
             </p>
             <% if f.object.requires_needed_date? %>
-                <%= f.label :needed_date, 'I plan to visit on:', :class => 'required-label' %>
-                <%= f.date_field :needed_date, :required => true, value:  f.object.earliest_delivery_estimate['date'], min: f.object.earliest_delivery_estimate['date'] %>
+                <%= f.label :needed_date, 'I plan to visit on:', :class => 'required-label py-2' %>
+                <%= f.date_field :needed_date, :required => true, value:  f.object.earliest_delivery_estimate['date'], min: f.object.earliest_delivery_estimate['date'], class: 'd-block rounded border' %>
             <% end %>
         <% end %>
         <%= render 'request_preferences', f: %>


### PR DESCRIPTION
This makes the visit date selector match the UI of the other
date selector used for recalls.

mediated page (after this PR):

<img width="501" alt="Screenshot 2024-04-25 at 3 40 06 PM" src="https://github.com/sul-dlss/sul-requests/assets/4924494/35925ae0-0292-4333-a5b4-740b591d474d">

recall:

<img width="459" alt="Screenshot 2024-04-25 at 3 40 10 PM" src="https://github.com/sul-dlss/sul-requests/assets/4924494/8435011f-4127-4d36-82f6-6820608641d0">


