### PR TITLE
have item status and delivery underneath pill for scan

### DIFF
--- a/app/javascript/controllers/item_selector_controller.js
+++ b/app/javascript/controllers/item_selector_controller.js
@@ -65,12 +65,19 @@ export default class extends Controller {
     this.unavailableItemsTarget.innerHTML = this.renderItems(unavailableItems);
 
     if (availableItems.length && this.targets.find('scanItem')) {
-      this.scanItemTarget.innerHTML = this.renderItems(availableItems);
+      this.scanItemTarget.innerHTML = this.renderItems(availableItems, true);
       this.unavailableScanItemEstimateTarget.classList.add('d-none');
       this.availableScanItemEstimateTarget.classList.remove('d-none');
-    } else if (this.targets.find('scanItem')) {
-      this.scanItemTarget.innerHTML = this.renderItems(unavailableItems);
+    } else if (unavailableItems.length && this.targets.find('scanItem')) {
+      this.scanItemTarget.innerHTML = this.renderItems(unavailableItems, true);
       this.unavailableScanItemEstimateTarget.classList.remove('d-none');
+      const itemstatus = this.unavailableScanItemEstimateTarget.querySelector('#item-status');
+      if (unavailableItems[0].duequeueinfo) {
+        itemstatus.innerHTML = `Item status: ${unavailableItems[0].duequeueinfo}`
+        itemstatus.classList.remove('d-none');
+      } else {
+        itemstatus.classList.add('d-none');
+      }
       this.availableScanItemEstimateTarget.classList.add('d-none');
     }
 
@@ -86,7 +93,7 @@ export default class extends Controller {
     }
   }
 
-  renderItems(items) {
+  renderItems(items, scan=false) {
     return items.map((item) => {
       return `
         <li class="d-flex gap-2 w-100">
@@ -97,7 +104,7 @@ export default class extends Controller {
             <span class="vr"></span>
             <button data-action="${this.identifier}#unchecked" data-${this.identifier}-id-param="${item.id}" type="button" class="btn-close py-1 pill-close" aria-label="Remove ${item.label}"></button>
           </span>
-          ${item.duequeueinfo ? `<span class="text-cardinal d-block align-self-center">${item.duequeueinfo}</span>` : ''}
+          ${item.duequeueinfo && !scan ? `<span class="text-cardinal d-block align-self-center">${item.duequeueinfo}</span>` : ''}
         </li>
       `;
     }).join('');

--- a/app/views/patron_requests/_scan_options.html.erb
+++ b/app/views/patron_requests/_scan_options.html.erb
@@ -16,11 +16,13 @@
   </div>
   <div class="col pe-0">
     <% if f.object.items_in_location.many? %>
-      <div class="text-cardinal pb-1">
-        <span class="d-none" data-itemselector-target="availableScanItemEstimate">Earliest expected delivery: <%= f.object.scan_earliest['display_date'] %></span>
-        <span class="d-none" data-itemselector-target="unavailableScanItemEstimate">Earliest expected delivery: No date/time estimate</span>
-      </div>
       <ul data-itemselector-target="scanItem" class="list-unstyled d-flex flex-wrap gap-2 bg-white m-0 me-3"></ul>
+      <div class="text-cardinal pb-1 mt-2">
+        <span class="d-none" data-itemselector-target="availableScanItemEstimate">Earliest expected delivery: <%= f.object.scan_earliest['display_date'] %></span>
+        <span class="d-none" data-itemselector-target="unavailableScanItemEstimate">Earliest expected delivery: No date/time estimate
+        <div id="item-status" class="mt-2 d-none"></div>
+        </span>
+      </div>
     <% else %>
       <div class="text-cardinal">
         Earliest expected delivery: <%= f.object.scan_earliest['display_date'] %> <%= queue_length_display(f.object.items_in_location.first, prefix: ' - ') %>

--- a/app/views/patron_requests/_scan_options.html.erb
+++ b/app/views/patron_requests/_scan_options.html.erb
@@ -18,7 +18,7 @@
     <% if f.object.items_in_location.many? %>
       <div class="text-cardinal pb-1">
         <span class="d-none" data-itemselector-target="availableScanItemEstimate">Earliest expected delivery: <%= f.object.scan_earliest['display_date'] %></span>
-        <span class="d-none" data-itemselector-target="unavailableScanItemEstimate">No date/time estimate</span>
+        <span class="d-none" data-itemselector-target="unavailableScanItemEstimate">Earliest expected delivery: No date/time estimate</span>
       </div>
       <ul data-itemselector-target="scanItem" class="list-unstyled d-flex flex-wrap gap-2 bg-white m-0 me-3"></ul>
     <% else %>


### PR DESCRIPTION
Below is view Darcy requested
<img width="636" alt="view requested" src="https://github.com/sul-dlss/sul-requests/assets/19173991/ba367c6e-59d3-4cd5-b918-57d8a8722d59">

This is how it appears on the branch
<img width="745" alt="Screenshot 2024-04-26 at 12 52 06 PM" src="https://github.com/sul-dlss/sul-requests/assets/19173991/dc822bc2-37da-4efc-be42-db38b6383095">

