### PR TITLE
Update the request UI for Aeon pages

### DIFF
--- a/app/components/accordion_step_component.html.erb
+++ b/app/components/accordion_step_component.html.erb
@@ -19,8 +19,10 @@
 
         <% if submit? %>
           <div class="mt-3 form-group d-flex justify-content-end gap-1">
-            <%= link_to 'Cancel', new_patron_request_path(instance_hrid: @request.instance_hrid, origin_location_code: @request.origin_location_code), class: 'btn btn-outline-primary' %>
-            <%= submit_tag t('patron_requests.new.submit'), class: 'btn btn-primary' %>
+            <% if cancel? %>
+              <%= link_to 'Cancel', new_patron_request_path(instance_hrid: @request.instance_hrid, origin_location_code: @request.origin_location_code), class: 'btn btn-outline-primary' %>
+            <% end %>
+            <%= submit_tag submit_text, class: 'btn btn-primary' %>
           </div>
         <% else %>
           <div class="mt-3 d-flex justify-content-end gap-1">

--- a/app/components/accordion_step_component.rb
+++ b/app/components/accordion_step_component.rb
@@ -7,15 +7,27 @@ class AccordionStepComponent < ViewComponent::Base
 
   attr_reader :step_index, :id, :classes, :data, :patron_request_data, :form_id, :request
 
-  def initialize(id:, step_index: -1, classes: [], data: {}, form_id: nil, request: nil, submit: false) # rubocop:disable Metrics/ParameterLists
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(id:,
+                 step_index: -1,
+                 classes: [],
+                 data: {},
+                 form_id: nil,
+                 request: nil,
+                 submit: false,
+                 cancel: true,
+                 submit_text: nil)
     @id = id
     @step_index = step_index
     @classes = classes
     @data = data
     @form_id = form_id
     @submit = submit
+    @cancel = cancel
     @request = request
+    @submit_text = submit_text
   end
+  # rubocop:enable Metrics/ParameterLists
 
   def expanded?
     step_index == 1
@@ -23,5 +35,13 @@ class AccordionStepComponent < ViewComponent::Base
 
   def submit?
     @submit
+  end
+
+  def submit_text
+    @submit_text || t('patron_requests.new.submit')
+  end
+
+  def cancel?
+    @cancel
   end
 end

--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -25,6 +25,8 @@ class PatronRequestsController < ApplicationController
   end
 
   def create
+    redirect_to current_request.finding_aid if current_request.aeon_page? && current_request.finding_aid?
+
     if @request.save && @request.submit_later
       redirect_to @request
     else

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -148,7 +148,9 @@ module RequestsHelper
   # and so should return ARS as the library code for the reading room text block.
   # This logic will be extended in the future to cover any location that has a pageAeonSite value.
   def aeon_reading_room_code
-    folio_types_location = Folio::Types.locations.find_by(code: current_request.origin_location)
+    # TODO: this supports PatronRequest and Request; refactor to remove support for Request
+    code = current_request.try(:origin_location_code) || current_request.try(:origin_location)
+    folio_types_location = Folio::Types.locations.find_by(code:) if code
     return current_request.origin_library_code unless folio_types_location
 
     details = folio_types_location.details

--- a/app/javascript/controllers/item_selector_controller.js
+++ b/app/javascript/controllers/item_selector_controller.js
@@ -18,6 +18,14 @@ export default class extends Controller {
       this.selectedItemsValue = this.selectedItemsValue.filter((item) => item.id !== event.params.id);
     }
 
+    // Enable/disable sending hidden params to Aeon
+    const aeonCallNumberInput = event.currentTarget.nextElementSibling;
+    const aeonBarcodeInput = aeonCallNumberInput.nextElementSibling;
+    const aeonRequestIndexInput = aeonBarcodeInput.nextElementSibling;
+    aeonCallNumberInput.toggleAttribute('disabled');
+    aeonBarcodeInput.toggleAttribute('disabled');
+    aeonRequestIndexInput.toggleAttribute('disabled');
+
     this.dispatch('change', { detail: { selectedItems: this.selectedItemsValue }});
   }
 

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -95,6 +95,7 @@ export default class extends Controller {
     accordionbutton.parentElement.classList.add('completed');
 
     var nextitem = this.findNextAccordion(accordion);
+    if (!nextitem) return;
 
     this.showStep(nextitem.querySelector('.accordion-collapse'));
     event.preventDefault();

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -10,7 +10,7 @@ class PatronRequest < ApplicationRecord
     :proxy, :estimated_delivery
   ], coder: JSON
 
-  delegate :instance_id, to: :bib_data
+  delegate :instance_id, :finding_aid, :finding_aid?, to: :bib_data
 
   before_create do
     self.estimated_delivery = earliest_delivery_estimate(scan: scan?)&.dig('display_date')
@@ -18,6 +18,20 @@ class PatronRequest < ApplicationRecord
 
   def scan?
     request_type == 'scan'
+  end
+
+  def aeon_page?
+    items_in_location.any?(&:aeon_pageable?)
+  end
+
+  def aeon_site
+    items_in_location.filter_map(&:aeon_site).first
+  end
+
+  def aeon_form_target
+    return unless aeon_page?
+
+    finding_aid? ? finding_aid : Settings.aeon_ere_url
   end
 
   def submit_later

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -13,14 +13,50 @@
   <% end %>
 <% end %>
 
-<%= form_for(@request, data: { controller: 'patronRequest' }, html: { class: 'col-lg-8 accordion' }) do |f| %>
+<%= form_for(@request,
+             data: { controller: 'patronRequest' },
+             html: { class: 'col-lg-8 accordion' },
+             url: current_request.aeon_page? ? current_request.aeon_form_target : patron_requests_path(request: current_request),
+             method: current_request.finding_aid? ? 'GET' : 'POST') do |f| %>
   <% step_enum = Enumerator.new { |y| n = 0; loop { y << (n += 1) } } %>
   <% current_step = nil %>
   <% scan_or_pickup_step = nil %>
   <%= f.hidden_field :instance_hrid %>
   <%= f.hidden_field :origin_location_code %>
+  <%= f.hidden_field :aeon_system_id, name: 'SystemID', value: 'sul-requests'  %>
+  <%= f.hidden_field :aeon_request_form, name: 'WebRequestForm', value: 'GenericRequestMonograph' %>
+  <%= f.hidden_field :aeon_document_type, name: 'DocumentType', value: 'Monograph' %>
+  <%= f.hidden_field :aeon_site, name: 'Site', value: f.object.aeon_site %>
+  <%= f.hidden_field :aeon_location, name: 'Location', value: f.object.origin_location_code %>
+  <%= f.hidden_field :aeon_title, name: 'ItemTitle', value: f.object.bib_data.title %>
+  <%= f.hidden_field :aeon_author, name: 'ItemAuthor', value: f.object.bib_data.author %>
+  <%= f.hidden_field :aeon_date, name: 'ItemDate', value: f.object.bib_data.pub_date %>
+  <%= f.hidden_field :aeon_link, name: 'ItemInfo1', value: f.object.bib_data.view_url %>
   <% if @request.items_in_location.one? || f.object.barcodes&.one? %>
-    <%= f.hidden_field :barcode, value: f.object.barcodes&.first || (@request.items_in_location.first&.barcode || @request.items_in_location.first&.id) %>
+    <% single_item = @request.items_in_location.first %>
+    <% single_barcode = f.object.barcodes&.first || (single_item&.barcode || single_item&.id) %>
+    <%= f.hidden_field :aeon_request_index, name: 'Request', value: 1 %>
+    <%= f.hidden_field :aeon_callnumber, name: 'CallNumber_1', value: single_item.callnumber %>
+    <%= f.hidden_field :aeon_barcode, name: 'ItemNumber_1', value: single_barcode %>
+    <%= f.hidden_field :barcode, value: single_barcode %>
+  <% end %>
+
+  <!-- aeon items usage note -->
+  <% if current_request.aeon_page? %>
+  <div class="alert alert-warning alert-dismissible shadow-sm d-flex gap-3 align-items-center mt-3">
+    <i class="bi bi-exclamation-triangle-fill fs-3"></i>
+    <div>
+      <span class="fw-bold">
+        <%= t('aeon_pages.info_modal.header', library: LibraryLocation.library_name_by_code(aeon_reading_room_code)) %>
+      </span>
+      <br/>
+      <span>
+        <%= t('aeon_pages.info_modal.reading_room_info') %>
+        <%= t('aeon_pages.info_modal.more_details_html', library: LibraryLocation.library_name_by_code(aeon_reading_room_code), reading_room_url: Settings.libraries[aeon_reading_room_code].reading_room_url) %>
+      </span>
+    </div>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
   <% end %>
 
   <!-- proxy -->
@@ -51,7 +87,7 @@
   <% end %>
 
   <!-- item selector -->
-  <% if f.object.items_in_location.many? && (can?(:request_scan, f.object) || can?(:prepare, f.object)) %>
+  <% if f.object.items_in_location.many? && (can?(:request_scan, f.object) || can?(:prepare, f.object)) && !current_request.finding_aid? %>
     <div data-controller="itemselector" data-action="itemselector:change->patronRequest#showItemSelector">
     <%= render AccordionStepComponent.new(id: 'barcodes', step_index: step_enum.next, form_id: f.id, data: { 'switch-selector': true }) do |c| %>
       <% c.with_title.with_content('Select item(s)') %>
@@ -69,12 +105,15 @@
               </tr>
             </thead>
             <tbody>
-              <% sort_holdings(f.object.items_in_location).each_with_index do |item, index| %>
+              <% sort_holdings(f.object.items_in_location).each.with_index(1) do |item, index| %>
                 <% not_requestable = cannot?(:request, item) %>
                 <tr id="row-<%= index %>" data-sortby-status="<%= item.status_text.downcase.gsub(' ', '_') %>" data-sortby-callnumber="<%= index %>" >
                   <td class="align-middle">
                     <label>
                       <%= f.check_box 'barcodes', { multiple: true, class: 'form-check-input', disabled: cannot?(:request, item), data: { required: true, 'itemselector-target': 'items', 'itemselector-id-param': item.id, 'itemselector-available-param': item.available?, 'itemselector-duequeueinfo-param': queue_length_display(item),  'itemselector-label-param': callnumber_label(item), action: 'itemselector#change' } }, item.barcode || item.id, "" %>
+                      <%= f.hidden_field "aeon_callnumber_#{item.callnumber}", disabled: true, name: "CallNumber_#{index}", value: item.callnumber %>
+                      <%= f.hidden_field "aeon_barcode_#{item.barcode}", disabled: true, name: "ItemNumber_#{index}", value: item.barcode %>
+                      <%= f.hidden_field "aeon_request_#{index}", disabled: true, name: 'Request', value: index %>
                       <span class="form-check-label ms-1"><%= callnumber_label(item) %></span>
                       <% if item.public_note %>
                         <span class="text-cardinal d-block ms-4 mt-1">
@@ -101,7 +140,7 @@
     <% end %>
 
     <!-- pickup request (multiple items) -->
-    <% if can? :prepare, f.object %>
+    <% if can?(:prepare, f.object) && !current_request.aeon_page? %>
       <%= render AccordionStepComponent.new(request: @request, id: 'pickup', classes: [('d-none' if scan_pickup)], form_id: f.id, step_index: (scan_or_pickup_step ||= step_enum.next), data: { 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
         <% c.with_title.with_content('Pickup request') %>
         <% c.with_body do %>
@@ -169,10 +208,65 @@
       <% end %>
     <% end %>
   <% end %>
+
+  <!-- aeon request -->
+  <% if current_request.aeon_page? %>
+    <%= render AccordionStepComponent.new(
+      request: @request,
+      id: 'aeon',
+      step_index: f.object.items_in_location.many? ? 2 : 1,
+      form_id: f.id,
+      data: { 'patronrequest-forRequestType': 'aeon' },
+      submit: true,
+      submit_text: t('aeon_pages.new.continue_button'),
+      cancel: f.object.items_in_location.many?) do |c| %>
+      <% c.with_title.with_content('Aeon request') %>
+      <% c.with_body do %>
+        <% if f.object.items_in_location.many? %>
+        <div class="selected-items-group">
+          <div class="card">
+            <div class="card-body bg-light rounded">
+              <div class="d-flex flex-column flex-xl-row align-items-start justify-content-xl-between align-items-xl-center mb-3 gap-2 gap-xl-0">
+                <div class="text-black fw-semibold">Selected items</div>
+                  <div class="text-cardinal">
+                    <span data-patronRequest-target="destination">
+                      <%= LibraryLocation.library_name_by_code(aeon_reading_room_code) %>
+                    </span>
+                  </div>
+              </div>
+              <ul data-itemselector-target="availableItems" class="list-unstyled d-flex flex-wrap gap-2 bg-white p-3 m-0"></ul>
+            </div>
+          </div>
+        </div>
+        <div class="card selected-items-group my-3">
+          <div class="card-body bg-light rounded">
+            <div class="d-flex flex-column flex-xl-row align-items-start justify-content-xl-between align-items-xl-center mb-3 gap-2 gap-xl-0">
+              <div class="text-black fw-semibold">Unavailable items</div>
+            </div>
+            <div class="bg-white">
+              <ul data-itemselector-target="unavailableItems" class="list-unstyled d-flex flex-wrap gap-2 p-3 m-0"></ul>
+            </div>
+          </div>
+        </div>
+        <% end %>
+        <div class="mt-3">
+          <p><%= t('aeon_pages.info_modal.how_to.body') %></p>
+          <p><%= t('aeon_pages.info_modal.steps.header') %></p>
+          <ol class="dialog-steps">
+            <% if current_request.finding_aid? %>
+              <%= t('aeon_pages.info_modal.steps.finding_aid_html') %>
+            <% else %>
+              <%= t('aeon_pages.info_modal.steps.single_vol_html') %>
+            <% end %>
+          </ol>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
   </div>
 
   <!-- pickup request (single item )-->
-  <% if f.object.items_in_location.one? && can?(:prepare, f.object) %>
+  <% if f.object.items_in_location.one? && can?(:prepare, f.object) && !current_request.aeon_page? %>
     <%= render AccordionStepComponent.new(request: @request, id: 'pickup', classes: [('d-none' if scan_pickup)], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
       <% c.with_title.with_content('Pickup request') %>
       <% c.with_body do %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -23,22 +23,26 @@
   <% scan_or_pickup_step = nil %>
   <%= f.hidden_field :instance_hrid %>
   <%= f.hidden_field :origin_location_code %>
-  <%= f.hidden_field :aeon_system_id, name: 'SystemID', value: 'sul-requests'  %>
-  <%= f.hidden_field :aeon_request_form, name: 'WebRequestForm', value: 'GenericRequestMonograph' %>
-  <%= f.hidden_field :aeon_document_type, name: 'DocumentType', value: 'Monograph' %>
-  <%= f.hidden_field :aeon_site, name: 'Site', value: f.object.aeon_site %>
-  <%= f.hidden_field :aeon_location, name: 'Location', value: f.object.origin_location_code %>
-  <%= f.hidden_field :aeon_title, name: 'ItemTitle', value: f.object.bib_data.title %>
-  <%= f.hidden_field :aeon_author, name: 'ItemAuthor', value: f.object.bib_data.author %>
-  <%= f.hidden_field :aeon_date, name: 'ItemDate', value: f.object.bib_data.pub_date %>
-  <%= f.hidden_field :aeon_link, name: 'ItemInfo1', value: f.object.bib_data.view_url %>
+  <% if current_request.aeon_page? %>
+    <%= f.hidden_field :aeon_system_id, name: 'SystemID', value: 'sul-requests'  %>
+    <%= f.hidden_field :aeon_request_form, name: 'WebRequestForm', value: 'GenericRequestMonograph' %>
+    <%= f.hidden_field :aeon_document_type, name: 'DocumentType', value: 'Monograph' %>
+    <%= f.hidden_field :aeon_site, name: 'Site', value: f.object.aeon_site %>
+    <%= f.hidden_field :aeon_location, name: 'Location', value: f.object.origin_location_code %>
+    <%= f.hidden_field :aeon_title, name: 'ItemTitle', value: f.object.bib_data.title %>
+    <%= f.hidden_field :aeon_author, name: 'ItemAuthor', value: f.object.bib_data.author %>
+    <%= f.hidden_field :aeon_date, name: 'ItemDate', value: f.object.bib_data.pub_date %>
+    <%= f.hidden_field :aeon_link, name: 'ItemInfo1', value: f.object.bib_data.view_url %>
+  <% end %>
   <% if @request.items_in_location.one? || f.object.barcodes&.one? %>
     <% single_item = @request.items_in_location.first %>
     <% single_barcode = f.object.barcodes&.first || (single_item&.barcode || single_item&.id) %>
-    <%= f.hidden_field :aeon_request_index, name: 'Request', value: 1 %>
-    <%= f.hidden_field :aeon_callnumber, name: 'CallNumber_1', value: single_item.callnumber %>
-    <%= f.hidden_field :aeon_barcode, name: 'ItemNumber_1', value: single_barcode %>
     <%= f.hidden_field :barcode, value: single_barcode %>
+    <% if current_request.aeon_page? %>
+      <%= f.hidden_field :aeon_request_index, name: 'Request', value: 1 %>
+      <%= f.hidden_field :aeon_callnumber, name: 'CallNumber_1', value: single_item.callnumber %>
+      <%= f.hidden_field :aeon_barcode, name: 'ItemNumber_1', value: single_barcode %>
+    <% end %>
   <% end %>
 
   <!-- aeon items usage note -->
@@ -111,9 +115,11 @@
                   <td class="align-middle">
                     <label>
                       <%= f.check_box 'barcodes', { multiple: true, class: 'form-check-input', disabled: cannot?(:request, item), data: { required: true, 'itemselector-target': 'items', 'itemselector-id-param': item.id, 'itemselector-available-param': item.available?, 'itemselector-duequeueinfo-param': queue_length_display(item),  'itemselector-label-param': callnumber_label(item), action: 'itemselector#change' } }, item.barcode || item.id, "" %>
-                      <%= f.hidden_field "aeon_callnumber_#{item.callnumber}", disabled: true, name: "CallNumber_#{index}", value: item.callnumber %>
-                      <%= f.hidden_field "aeon_barcode_#{item.barcode}", disabled: true, name: "ItemNumber_#{index}", value: item.barcode %>
-                      <%= f.hidden_field "aeon_request_#{index}", disabled: true, name: 'Request', value: index %>
+                      <% if current_request.aeon_page? %>
+                        <%= f.hidden_field "aeon_callnumber_#{item.callnumber}", disabled: true, name: "CallNumber_#{index}", value: item.callnumber %>
+                        <%= f.hidden_field "aeon_barcode_#{item.barcode}", disabled: true, name: "ItemNumber_#{index}", value: item.barcode %>
+                        <%= f.hidden_field "aeon_request_#{index}", disabled: true, name: 'Request', value: index %>
+                      <% end %>
                       <span class="form-check-label ms-1"><%= callnumber_label(item) %></span>
                       <% if item.public_note %>
                         <span class="text-cardinal d-block ms-4 mt-1">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,7 +158,7 @@ en:
           <li>Complete the request form</li>
           <li>For on-site requests, create an appointment so we know when you’re planning to arrive</li>
           <li>Submit your request</li>
-      more_details_html: 'For more details, visit the <a href="%{reading_room_url}">%{library} Reading Room service page <span class="bi bi-link-45deg" aria-hidden="true"></span></a>'
+      more_details_html: 'For more details, visit the <a href="%{reading_room_url}">%{library} Reading Room service page <span class="bi bi-box-arrow-up-right" aria-hidden="true"></span></a>.'
       continue_button: Continue
       cancel_button: Cancel
   multiple_holds_notification:

--- a/spec/features/create_aeon_patron_request_spec.rb
+++ b/spec/features/create_aeon_patron_request_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Creating an Aeon patron request', :js do
+  let(:user) { create(:sso_user) }
+  let(:current_user) { CurrentUser.new(username: user.sunetid, patron_key: user.patron_key, shibboleth: true) }
+  let(:bib_data) { :special_collections_single_holding }
+  let(:patron) do
+    instance_double(Folio::Patron, id: user.patron_key, username: 'auser', display_name: 'A User', exists?: true, email: nil,
+                                   patron_description: 'faculty',
+                                   patron_group_id: '503a81cd-6c26-400f-b620-14c08943697c',
+                                   blocked?: false, all_proxy_group_info: [],
+                                   allowed_request_types: ['Hold', 'Recall', 'Page'])
+  end
+
+  before do
+    allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(patron_key: user.patron_key).and_return(patron)
+    login_as(current_user)
+    stub_bib_data_json(build(bib_data))
+  end
+
+  describe 'reading room info' do
+    before do
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SPEC-STACKS')
+    end
+
+    it 'identifies the library of the item' do
+      expect(page).to have_content 'Special Collections access'
+    end
+
+    it 'provides a link to the reading room info for the library of the item' do
+      expect(page).to have_link 'Special Collections Reading Room service page', href: 'https://library.stanford.edu/spc/using-our-collections'
+    end
+  end
+
+  context 'handles reading room info display for locations like SAL3-PAGE-AS' do
+    let(:bib_data) { :sal3_as_holding }
+
+    it 'provides a link to the ARS reading room if the origin location is SAL3' do
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-PAGE-AS')
+      expect(page).to have_link 'Archive of Recorded Sound Reading Room service page', href: 'https://library.stanford.edu/libraries/archive-recorded-sound'
+    end
+  end
+
+  context 'with an item without a finding aid' do
+    before do
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SPEC-STACKS')
+    end
+
+    context 'with a single holding' do
+      it 'provides instructions for the user to complete the request' do
+        expect(page).to have_content 'Complete the request form'
+      end
+
+      it 'goes to aeon when submitted' do
+        click_on 'Continue'
+        expect(page.current_host).to eq 'https://stanford.aeon.atlas-sys.com'
+      end
+
+      describe 'request form' do
+        it 'includes an identifier for the system making the request' do
+          expect(page).to have_field(type: 'hidden', name: 'SystemID', with: 'sul-requests')
+        end
+
+        it 'uses the aeon form for a monograph' do
+          expect(page).to have_field(type: 'hidden', name: 'WebRequestForm', with: 'GenericRequestMonograph')
+          expect(page).to have_field(type: 'hidden', name: 'DocumentType', with: 'Monograph')
+        end
+
+        it 'preselects the correct reading room to fulfill the request' do
+          expect(page).to have_field(type: 'hidden', name: 'Site', with: 'SPECUA')
+        end
+
+        it 'includes a link to view the item in searchworks' do
+          expect(page).to have_field(type: 'hidden', name: 'ItemInfo1', with: 'https://searchworks.stanford.edu/view/1234')
+        end
+
+        it 'includes the origin location of the item' do
+          expect(page).to have_field(type: 'hidden', name: 'Location', with: 'SPEC-STACKS')
+        end
+
+        it 'includes the title of the item' do
+          expect(page).to have_field(type: 'hidden', name: 'ItemTitle', with: 'Special Collections Item Title')
+        end
+
+        it 'includes the author of the item' do
+          expect(page).to have_field(type: 'hidden', name: 'ItemAuthor', with: 'John Q. Public')
+        end
+
+        it 'includes the publication date of the item' do
+          expect(page).to have_field(type: 'hidden', name: 'ItemDate', with: '2018')
+        end
+
+        it 'includes the request index' do
+          expect(page).to have_field(type: 'hidden', name: 'Request', with: '1')
+        end
+
+        it 'includes the call number of the item' do
+          expect(page).to have_field(type: 'hidden', name: 'CallNumber_1', with: 'ABC 123')
+        end
+
+        it 'includes the barcode of the item' do
+          expect(page).to have_field(type: 'hidden', name: 'ItemNumber_1', with: '12345678')
+        end
+      end
+    end
+
+    describe 'with multiple holdings' do
+      let(:bib_data) { :special_collections_holdings }
+
+      describe 'item selector' do
+        before do
+          click_on 'Continue'
+        end
+
+        describe 'with no items selected' do
+          it 'disables request indices' do
+            expect(page).to have_field(type: 'hidden', name: 'Request', with: '1', disabled: true)
+            expect(page).to have_field(type: 'hidden', name: 'Request', with: '2', disabled: true)
+          end
+
+          it 'disables item barcodes' do
+            expect(page).to have_field(type: 'hidden', name: 'ItemNumber_1', with: '12345678', disabled: true)
+            expect(page).to have_field(type: 'hidden', name: 'ItemNumber_2', with: '87654321', disabled: true)
+          end
+        end
+
+        describe 'with items selected' do
+          before do
+            check 'patron_request_barcodes_12345678'
+            check 'patron_request_barcodes_87654321'
+          end
+
+          it 'includes the index of each item' do
+            expect(page).to have_field(type: 'hidden', name: 'Request', with: '1')
+            expect(page).to have_field(type: 'hidden', name: 'Request', with: '2')
+          end
+
+          it 'includes the barcode of each item' do
+            expect(page).to have_field(type: 'hidden', name: 'ItemNumber_1', with: '12345678')
+            expect(page).to have_field(type: 'hidden', name: 'ItemNumber_2', with: '87654321')
+          end
+
+          it 'includes the call number of each item' do
+            expect(page).to have_field(type: 'hidden', name: 'CallNumber_1', with: 'ABC 123')
+            expect(page).to have_field(type: 'hidden', name: 'CallNumber_2', with: 'ABC 321')
+          end
+        end
+      end
+    end
+
+    describe 'for an item with a finding aid' do
+      let(:bib_data) { :special_collections_finding_aid_holdings }
+
+      it 'provides instructions for the user to complete the request' do
+        expect(page).to have_content 'Review the Collection Guide in the Online Archive of California'
+      end
+
+      it 'visits the finding aid when dismissed' do
+        click_on 'Continue'
+        expect(page.current_host).to eq 'https://oac.cdlib.org'
+      end
+    end
+  end
+end

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Creating a page request' do
+RSpec.describe 'Creating a request' do
   include ActiveJob::TestHelper
 
   let(:user) { create(:sso_user) }
@@ -146,10 +146,9 @@ RSpec.describe 'Creating a page request' do
         click_on 'Continue'
         check 'ABC 123'
         click_on 'Continue'
-        expect do
-          click_on 'Submit'
-          expect(page).to have_content 'We received your pickup request'
-        end.to change(PatronRequest, :count).by(1)
+        expect(page).to have_content 'Pickup request'
+        click_on 'Submit'
+        expect(page).to have_content 'We received your pickup request'
       end
 
       it 'allows scanning' do
@@ -162,11 +161,8 @@ RSpec.describe 'Creating a page request' do
         expect(page).to have_content 'Copyright notice'
         fill_in 'Page range', with: '1-15'
         fill_in 'Title of article or chapter', with: 'Some title'
-
-        expect do
-          click_on 'Submit'
-          expect(page).to have_content 'We received your scan request'
-        end.to change(PatronRequest, :count).by(1)
+        click_on 'Submit'
+        expect(page).to have_content 'We received your scan request'
       end
     end
 


### PR DESCRIPTION
- Add hidden form fields for submission to Aeon
- Add hidden fields to the item selector for submission to Aeon
- Change the target of the form if the request goes to Aeon
- Submit requests for items with finding aids to OAC
- Port informational alerts and text from the old design

Closes #2257

# Single item

![aeon_single](https://github.com/sul-dlss/sul-requests/assets/4924494/04ddfeda-dd65-4d2d-a54f-4ce69655fa5a)

# Multiple items

![Screenshot 2024-04-26 at 11 52 27 AM](https://github.com/sul-dlss/sul-requests/assets/4924494/20f4fa3b-e9dc-41c3-9a95-59d8bc21c534)

![Screenshot 2024-04-26 at 11 52 35 AM](https://github.com/sul-dlss/sul-requests/assets/4924494/579d924d-f743-417d-985c-bc67d551eb72)

# Finding aid item

![Screenshot 2024-04-26 at 11 55 57 AM](https://github.com/sul-dlss/sul-requests/assets/4924494/5b81fdcb-ba68-48c8-bceb-2b8fb336242e)



