### PR TITLE
Hide the proxy accordion if the request is an Aeon page

### DIFF
--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -64,7 +64,7 @@
   <% end %>
 
   <!-- proxy -->
-  <% if current_request.proxy_group_names.present? %>
+  <% if current_request.proxy_group_names.present? && !current_request.aeon_page? %>
     <%= render AccordionStepComponent.new(id: 'proxy', step_index: step_enum.next, form_id: f.id) do |c| %>
       <% c.with_title.with_content('Proxy/Sponsor') %>
       <% c.with_body do %>


### PR DESCRIPTION
The request is tracked outside of FOLIO, so we can't notify
proxies for Aeon requests.
