### PR TITLE
Make the item selector check mark yellow for non-circulating items

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -75,8 +75,10 @@ module RequestsHelper
   # rubocop:disable Metrics/MethodLength
   def availability_bootstrap_icon(css_class)
     case css_class
-    when 'available', 'available noncirc'
+    when 'available'
       content_tag(:i, '', class: 'bi bi-check align-middle fs-5 text-success')
+    when 'available noncirc'
+      content_tag(:i, '', class: 'bi bi-check align-middle fs-5 text-warning')
     when 'unavailable'
       content_tag(:i, '', class: 'bi bi-x fs-4 align-middle text-danger')
     when 'deliver-from-offsite noncirc'


### PR DESCRIPTION
Via slack message: https://stanfordlib.slack.com/archives/G018TJ20XGE/p1714430082441799

This matches how the items appear in Searchworks.
