### PR TITLE
Prefer pickup_service_point over destination_service_point

### DIFF
--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 module Folio
-  Location = Data.define(:id, :campus, :library, :library_id, :institution, :code, :discovery_display_name,
+  Location = Data.define(:id, :campus, :campus_id, :library, :library_id, :institution, :code, :discovery_display_name,
                          :name, :primary_service_point_id, :details) do
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
     def self.from_hash(dyn)
       new(
         id: dyn.fetch('id'),
         campus: (Campus.new(**dyn.fetch('campus').slice('id', 'code')) if dyn['campus']),
+        campus_id: dyn['campusId'],
         library: (Library.new(**dyn.fetch('library').slice('id', 'code', 'name').symbolize_keys) if dyn['library']),
         library_id: dyn['libraryId'] || dyn.dig('library', 'id'),
         institution: (Institution.new(id: dyn.fetch('institutionId')) if dyn['institutionId']),
@@ -19,6 +20,10 @@ module Folio
       )
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+
+    def campus
+      to_h[:campus] || Folio::Types.campuses.find { |c| c.id == campus_id }
+    end
 
     def library
       to_h[:library] || Folio::Types.libraries.find_by(id: library_id)

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -69,7 +69,7 @@ class PatronRequest < ApplicationRecord
   end
 
   def pickup_service_point
-    Folio::Types.service_points.find_by(code: service_point_code)
+    selected_pickup_service_point || default_pickup_service_point
   end
 
   # FOLIO
@@ -113,13 +113,8 @@ class PatronRequest < ApplicationRecord
     'Pickup location'
   end
 
-  def destination_location
-    service_point = pickup_destinations.one? ? pickup_destinations.first : default_service_point_code
-    Folio::Types.service_points.find_by(code: service_point)
-  end
-
   def destination_library_code
-    destination_location&.library&.code
+    pickup_service_point&.library&.code
   end
 
   def destination_library_pseudopatron_code
@@ -285,6 +280,17 @@ class PatronRequest < ApplicationRecord
   end
 
   private
+
+  def selected_pickup_service_point
+    @selected_pickup_service_point ||= Folio::Types.service_points.find_by(code: service_point_code) if service_point_code.present?
+  end
+
+  def default_pickup_service_point
+    @default_pickup_service_point ||= begin
+      service_point = pickup_destinations.one? ? pickup_destinations.first : default_service_point_code
+      Folio::Types.service_points.find_by(code: service_point)
+    end
+  end
 
   # Returns default service point codes
   def default_pickup_service_points

--- a/app/services/folio/types.rb
+++ b/app/services/folio/types.rb
@@ -7,7 +7,7 @@ module Folio
   class Types
     class << self
       delegate  :policies, :circulation_rules, :criteria,
-                :locations, :libraries, :service_points, :patron_groups, to: :instance
+                :locations, :libraries, :campuses, :service_points, :patron_groups, to: :instance
     end
 
     def self.instance
@@ -82,6 +82,12 @@ module Folio
 
     def locations
       @locations ||= LocationsStore.new(get_type('locations'))
+    end
+
+    def campuses
+      @campuses ||= get_type('campuses').map do |c|
+        Folio::Campus.new(**c.slice('id', 'code').symbolize_keys)
+      end
     end
 
     def get_type(type)

--- a/app/views/patron_requests/_pickup_destination.html.erb
+++ b/app/views/patron_requests/_pickup_destination.html.erb
@@ -19,7 +19,7 @@
     </div>
 <% else %>
     <div class="mb-2">
-        <strong><%= f.object.single_location_label %>:</strong> <%= f.object.destination_location&.name %>
+        <strong><%= f.object.single_location_label %>:</strong> <%= f.object.pickup_service_point&.name %>
     </div>
-    <%= f.hidden_field :service_point_code, :value => f.object.destination_location&.code %>
+    <%= f.hidden_field :service_point_code, :value => f.object.pickup_service_point&.code %>
 <% end %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -175,7 +175,7 @@
                       </span>
                       <span> at </span>
                       <span data-patronRequest-target="destination">
-                        <%= f.object.destination_location&.name %>
+                        <%= f.object.pickup_service_point&.name %>
                       </span>
                     </div>
                 </div>

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     name { 'Location name' }
     discovery_display_name { 'Discovery display name' }
     campus { Folio::Campus.new(id: 'uuid', code: 'SUL') }
+    campus_id { 'uuid' }
     library { Folio::Library.new(id: 'uuid', code: 'LIB') }
     library_id { 'uuid' }
     primary_service_point_id { nil }

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -190,6 +190,27 @@ FactoryBot.define do
     end
   end
 
+  factory :single_law_holding, class: 'Folio::Instance' do
+    id { '123' }
+
+    title { 'Item Title' }
+
+    format { ['Book'] }
+
+    items do
+      [
+        build(:item,
+              barcode: '12345678',
+              callnumber: 'ABC 123',
+              effective_location: build(:law_location))
+      ]
+    end
+
+    initialize_with do
+      new(**attributes)
+    end
+  end
+
   factory :scannable_only_holdings, class: 'Folio::Instance' do
     id { '1234' }
     title { 'Item Title' }

--- a/spec/models/patron_request_spec.rb
+++ b/spec/models/patron_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PatronRequest do
   let(:bib_data) { instance_double(Folio::Instance, title: 'Title') }
 
   before do
-    allow(Folio::Instance).to receive(:fetch).with('a12345').and_return(bib_data)
+    allow(Folio::Instance).to receive(:fetch).with(request.instance_hrid).and_return(bib_data)
   end
 
   describe '#bib_data' do
@@ -65,6 +65,40 @@ RSpec.describe PatronRequest do
       request.barcode = '1234567890'
 
       expect(request.barcodes).to eq(['1234567890'])
+    end
+  end
+
+  describe '#pickup_service_point' do
+    let(:bib_data) { build(:sal3_holdings) }
+
+    context 'after the user has selected a service point' do
+      let(:attr) { { service_point_code: 'GREEN-LOAN' } }
+
+      it 'returns the selected service point' do
+        expect(request.pickup_service_point).to have_attributes(name: 'Green Library')
+      end
+    end
+
+    context 'with an item that must be picked up at a particular service point' do
+      let(:bib_data) { build(:single_mediated_holding) }
+      let(:attr) { { origin_location_code: 'ART-LOCKED-LARGE' } }
+
+      it 'returns the service point' do
+        expect(request.pickup_service_point).to have_attributes(name: 'Art & Architecture Library (Bowes)')
+      end
+    end
+
+    context 'with a law item' do
+      let(:attr) { { instance_hrid: 'a123', origin_location_code: 'LAW-STACKS1' } }
+      let(:bib_data) { build(:single_law_holding) }
+
+      it 'returns the law service point by default' do
+        expect(request.pickup_service_point).to have_attributes(name: 'Law Library (Crown)')
+      end
+    end
+
+    it 'returns the default service point' do
+      expect(request.pickup_service_point).to have_attributes(name: 'Green Library')
     end
   end
 


### PR DESCRIPTION
We've ended up with two methods that are pretty similar -- one for the service point the user selected, and one for the default service point if the user hasn't selected anything. I'm not sure that's a distinction we need to make?