### PR TITLE
Show the name of the reading room Aeon items can be used in

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -158,4 +158,12 @@ module RequestsHelper
     details = folio_types_location.details
     details.key?('pageAeonSite') && details['pageAeonSite'] == 'ARS' ? 'ARS' : current_request.origin_library_code
   end
+
+  # Get the name of the reading room where Aeon items will be prepared for use.
+  # A custom name can be set in the settings for each library; otherwise the
+  # default is the library name followed by "Reading Room".
+  def aeon_reading_room_name
+    library = Settings.libraries[aeon_reading_room_code] || Settings.libraries.default
+    library.reading_room_label || "#{library['label']} Reading Room"
+  end
 end

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -241,9 +241,7 @@
               <div class="d-flex flex-column flex-xl-row align-items-start justify-content-xl-between align-items-xl-center mb-3 gap-2 gap-xl-0">
                 <div class="text-black fw-semibold">Selected items</div>
                   <div class="text-cardinal">
-                    <span data-patronRequest-target="destination">
-                      <%= LibraryLocation.library_name_by_code(aeon_reading_room_code) %>
-                    </span>
+                    <span data-patronRequest-target="destination">Use in: <%= aeon_reading_room_name %></span>
                   </div>
               </div>
               <ul data-itemselector-target="availableItems" class="list-unstyled d-flex flex-wrap gap-2 bg-white p-3 m-0"></ul>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -326,6 +326,7 @@ libraries:
       email: specialcollections@stanford.edu
     folio_pickup_service_point_code: SPEC
     reading_room_url: https://library.stanford.edu/spc/using-our-collections
+    reading_room_label: Special Collections & University Archives Reading Room
     hold_pseudopatron: HOLD@SP
     hours:
       library_slug: spc

--- a/spec/features/create_aeon_patron_request_spec.rb
+++ b/spec/features/create_aeon_patron_request_spec.rb
@@ -32,14 +32,27 @@ RSpec.describe 'Creating an Aeon patron request', :js do
     it 'provides a link to the reading room info for the library of the item' do
       expect(page).to have_link 'Special Collections Reading Room service page', href: 'https://library.stanford.edu/spc/using-our-collections'
     end
-  end
 
-  context 'handles reading room info display for locations like SAL3-PAGE-AS' do
-    let(:bib_data) { :sal3_as_holding }
+    context 'when the item is in SAL3 but will be paged to a reading room' do
+      let(:bib_data) { :sal3_as_holding }
 
-    it 'provides a link to the ARS reading room if the origin location is SAL3' do
-      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-PAGE-AS')
-      expect(page).to have_link 'Archive of Recorded Sound Reading Room service page', href: 'https://library.stanford.edu/libraries/archive-recorded-sound'
+      it 'provides a link to the appropriate reading room' do
+        visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-PAGE-AS')
+        expect(page).to have_link 'Archive of Recorded Sound Reading Room service page', href: 'https://library.stanford.edu/libraries/archive-recorded-sound'
+      end
+    end
+
+    context 'when there are multiple items' do
+      let(:bib_data) { :special_collections_holdings }
+
+      it 'identifies the reading room where the items will be prepared' do
+        visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SPEC-STACKS')
+        click_on 'Continue'
+        check 'patron_request_barcodes_12345678'
+        check 'patron_request_barcodes_87654321'
+        click_on 'Continue'
+        expect(page).to have_content 'Use in: Special Collections & University Archives Reading Room'
+      end
     end
   end
 


### PR DESCRIPTION
This puts more specific text in the place where we normally
show the estimated pickup time, indicating that the items will
be used in a particular reading room. It also adds a special
name for SPEC's reading room, since it differs in Aeon and we
want to make Requests match Aeon instead of FOLIO.

Closes #2322
