### PR TITLE
Add some ActiveRecord validation for patron requests

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -5,11 +5,12 @@
 ###
 class PatronRequestsController < ApplicationController
   layout 'application_new'
-  load_and_authorize_resource instance_name: :request, new: :login
+  load_and_authorize_resource instance_name: :request
   skip_authorize_resource only: :new
   before_action :assign_new_attributes, only: [:new]
   before_action :authorize_new_request, only: [:new]
   before_action :associate_request_with_patron, only: [:new, :create]
+  before_action :redirect_aeon_pages, only: [:create]
   helper_method :current_request, :new_params
 
   def show; end
@@ -19,8 +20,6 @@ class PatronRequestsController < ApplicationController
   end
 
   def create
-    redirect_to current_request.finding_aid if current_request.aeon_page? && current_request.finding_aid?
-
     if @request.save && @request.submit_later
       redirect_to @request
     else
@@ -46,6 +45,12 @@ class PatronRequestsController < ApplicationController
     flash.now[:error] = t('sessions.login_by_sunetid.error_html') if sunetid_without_folio_account?
 
     render 'login'
+  end
+
+  def redirect_aeon_pages
+    return unless current_request.aeon_page? && current_request.finding_aid?
+
+    redirect_to current_request.finding_aid
   end
 
   def current_request

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -87,8 +87,18 @@ class Ability
     # ... and to check the status, you either need to be logged in or include a special token in the URL
     can :read, [Request, Page, HoldRecall, Scan, MediatedPage], user_id: user.id if user.sso_user?
 
-    can :login, PatronRequest
-    can [:new, :create], PatronRequest
+    can :new, PatronRequest
+    can :create, PatronRequest do |request|
+      request.selected_items.all? { |item| can?((request.scan? ? :scan : :request), item) }
+    end
+
+    # anyone can create title-level requests
+    can :create, PatronRequest do |request|
+      request.selected_items.none?
+    end
+
+    # anyone can start to create an Aeon page
+    can :create, PatronRequest, &:aeon_page?
     can :read, [PatronRequest], patron_id: user.patron.id if user.patron
 
     can :request, Folio::Item do |item|

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -94,6 +94,8 @@
         <% c.with_title.with_content('Scan or pickup request') %>
       <% end %>
     <% end %>
+  <% else %>
+    <%= f.hidden_field :request_type, value: can?(:request_scan, f.object) ? 'scan' : 'pickup' %>
   <% end %>
 
   <!-- item selector -->

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Creating a request' do
   end
 
   context 'with an SSO user' do
-    let(:current_user) { CurrentUser.new(username: user.sunetid, patron_key: user.patron_key, shibboleth: true) }
+    let(:current_user) { CurrentUser.new(username: user.sunetid, patron_key: user.patron_key, shibboleth: true, ldap_attributes:) }
+    let(:ldap_attributes) { {} }
 
     before do
       allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(patron_key: user.patron_key).and_return(patron)
@@ -78,6 +79,7 @@ RSpec.describe 'Creating a request' do
     context 'for a scan' do
       let(:bib_data) { build(:scannable_holdings) }
       let(:user) { create(:scan_eligible_user) }
+      let(:ldap_attributes) { { suAffiliation: Settings.scan_pilot_groups.first } }
 
       before do
         allow(current_user).to receive(:user_object).and_return(user)
@@ -133,6 +135,7 @@ RSpec.describe 'Creating a request' do
     context 'for an item that can be paged or scanned', :js do
       let(:bib_data) { build(:scannable_holdings) }
       let(:user) { create(:scan_eligible_user) }
+      let(:ldap_attributes) { { suAffiliation: Settings.scan_pilot_groups.first } }
 
       before do
         allow(current_user).to receive(:user_object).and_return(user)


### PR DESCRIPTION
FOLIO will do some validation for us when we place the request, but it's a little nicer for our patrons if we do it earlier by:
- checking they can create the type of request they're trying to,
- that they provided the required data to place requests in FOLIO/ILLiad, and
- that they provided a valid needed date and pickup location (where applicable)