### PR TITLE
Cache the item title in the database for better admin reporting

### DIFF
--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -7,7 +7,7 @@ class PatronRequest < ApplicationRecord
   class_attribute :bib_model_class, default: Settings.ils.bib_model.constantize
   store :data, accessors: [
     :barcodes, :folio_responses, :illiad_response_data, :scan_page_range, :scan_authors, :scan_title, :request_type,
-    :proxy, :estimated_delivery, :patron_name
+    :proxy, :estimated_delivery, :patron_name, :item_title
   ], coder: JSON
 
   delegate :instance_id, :finding_aid, :finding_aid?, to: :bib_data
@@ -20,6 +20,7 @@ class PatronRequest < ApplicationRecord
   validate :needed_date_is_valid, on: :create
 
   before_create do
+    self.item_title = bib_data&.title
     self.estimated_delivery = earliest_delivery_estimate(scan: scan?)&.dig('display_date')
   end
 
@@ -153,7 +154,7 @@ class PatronRequest < ApplicationRecord
 
   # @return [String] the title of the item
   def item_title
-    bib_data&.title
+    super || bib_data&.title
   end
 
   # Item stuff


### PR DESCRIPTION
Existing admin dashboards + mediated pages can show top-level information without retrieving bib data from FOLIO. Presumably we'll want to do something similar in the near future.