### PR TITLE
Prevent the item selector search from submitting the form on enter

### DIFF
--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -50,6 +50,9 @@
       <%= f.hidden_field :aeon_barcode, name: 'ItemNumber_1', value: single_barcode %>
     <% end %>
   <% end %>
+  <%# only allow submitting on enter if the final submit button is focused %>
+  <%# see: https://stackoverflow.com/a/51507806 %>
+  <button type="submit" disabled style="display: none" aria-hidden="true"></button>
 
   <!-- aeon items usage note -->
   <% if f.object.aeon_page? %>


### PR DESCRIPTION
This solution creates a hidden, non-interactable submit button
at the beginning of the form, which becomes its "default submit"
button according to the HTML spec. Because hitting enter will
attempt to activate this button and it's disabled, nothing happens.

If you have the final, real submit button focused and hit enter,
that will work, because the explicit target of that action is the
(non-disabled) submit button.

This ensures that no elements in the form are allowed to submit
it accidentally except the final submit button.

Fixes #2364
