### PR TITLE
Pickup destination applies to both available + unavailable items

### DIFF
--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -167,8 +167,9 @@
       <%= render AccordionStepComponent.new(request: f.object, id: 'pickup', classes: [('d-none' if scan_pickup)], form_id: f.id, step_index: (scan_or_pickup_step ||= step_enum.next), data: { 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
         <% c.with_title.with_content('Pickup request') %>
         <% c.with_body do %>
+          <%= render 'pickup_destination', f: %>
+
           <div class="selected-items-group">
-            <%= render 'pickup_destination', f: %>
             <div class="card">
               <div class="card-body bg-light rounded">
                 <div class="d-flex flex-column flex-xl-row align-items-start justify-content-xl-between align-items-xl-center mb-3 gap-2 gap-xl-0">


### PR DESCRIPTION
We've been suppressing the pickup location if the items are unavailable. I assume this was unintentional?

![Screenshot 2024-05-03 at 11 06 35](https://github.com/sul-dlss/sul-requests/assets/111218/45ef647c-a7d4-4d86-b177-f4f2b0aec995)
