### PR TITLE
Remove ineligible patron groups from ILB/scans

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,25 +46,19 @@ folio:
   standard_patron_group_names: ['staff', 'faculty', 'undergrad', 'graduate']
   default_service_point: 'GREEN-LOAN'
   ilb_eligible_patron_groups:
-    - courtesy
     - faculty
     - fellow
     - graduate
-    - lane-resident
     - postdoctoral
     - staff
-    - staff-casual
     - undergrad
     - visiting-scholar
   scan_pilot_groups:
-    - courtesy
     - faculty
     - fellow
     - graduate
-    - lane-resident
     - postdoctoral
     - staff
-    - staff-casual
     - undergrad
     - visiting-scholar
 


### PR DESCRIPTION
Per https://github.com/sul-dlss/sul-requests/issues/2160#issuecomment-2066980663, these groups should not be eligible for ILLiad-based services. 