### PR TITLE
Remove user header if we don't have a patron

### DIFF
--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -1,4 +1,4 @@
-<% if current_user&.patron %>
+<% unless current_user&.patron&.blank? %>
   <%= render 'user_header' %>
 <% end %>
 


### PR DESCRIPTION
I think our intent was to omit the header unless there was an actual patron record, but #2311 kinda broke that.