### PR TITLE
Specifying requirement for sponsor selection 

### DIFF
--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -86,12 +86,15 @@ export default class extends Controller {
   }
 
   // When the user says the request is for a sponsor, display the sponsor selection list
+  // Also require a sponsor selection only if the user selects that the request is for a sponsor. 
   toggleDisplaySponsorList(event) {
     if(event.target.value == 'share') {
       this.selectSponsorTarget.classList.remove('d-none')
+      this.sponsorRadioButtonTarget.required = true
     } else {
       this.selectSponsorTarget.classList.add('d-none')
       this.sponsorRadioButtonTarget.checked = false
+      this.sponsorRadioButtonTarget.required = false
     }
   }
 

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -90,11 +90,13 @@ export default class extends Controller {
   toggleDisplaySponsorList(event) {
     if(event.target.value == 'share') {
       this.selectSponsorTarget.classList.remove('d-none')
-      this.sponsorRadioButtonTarget.required = true
+      this.sponsorRadioButtonTargets.forEach(sponsorRadioButton => { sponsorRadioButton.required = true })
     } else {
       this.selectSponsorTarget.classList.add('d-none')
-      this.sponsorRadioButtonTarget.checked = false
-      this.sponsorRadioButtonTarget.required = false
+      this.sponsorRadioButtonTargets.forEach(sponsorRadioButton => {
+        sponsorRadioButton.required = false
+        sponsorRadioButton.checked = false
+      })
     }
   }
 

--- a/app/views/patron_requests/_list_sponsors_form.html.erb
+++ b/app/views/patron_requests/_list_sponsors_form.html.erb
@@ -26,7 +26,7 @@
         <div class="mt-2">
             <div class="mt-2">
                 <% f.object.patron.sponsor_names.sort.each do |sponsor_name| %>  
-                    <%= f.radio_button :for_sponsor_name, sponsor_name, :class => 'form-check-input', required: true, data: { 'patronRequest-target': 'sponsorRadioButton'} %>
+                    <%= f.radio_button :for_sponsor_name, sponsor_name, :class => 'form-check-input', data: { 'patronRequest-target': 'sponsorRadioButton'} %>
                     <%= f.label :for_sponsor_name, sponsor_name, :class => 'form-check-label ms-1 d-inline' %>
                 <% end %>
             </div>


### PR DESCRIPTION
The problem: The form was not proceeding to the next accordion step if the user selected "this request is for myself" because the sponsor selection radio button was also defined as required. 

What this pull request does:

- The sponsor selection radio button starts off as not required.  Whenever the user selects "this request is for myself", the sponsor selection radio buttons (i.e. buttons with sponsor names) are set to not required, allowing the form to continue.
- If, at any time, the user selects "this request is for a sponsor", then the sponsor radio buttons are set to required, making the user select a sponsor before being able to continue.  

Screenshots:

![Screenshot 2024-05-06 at 1 18 17 PM](https://github.com/sul-dlss/sul-requests/assets/2677207/059e88cc-e5c3-4a28-956d-431439760d24)

![Screenshot 2024-05-06 at 1 18 30 PM](https://github.com/sul-dlss/sul-requests/assets/2677207/0dd1a84f-689d-4df9-861d-fd98d027dabc)

![Screenshot 2024-05-06 at 1 18 40 PM](https://github.com/sul-dlss/sul-requests/assets/2677207/38822bef-ce91-4678-95b5-e86b2c264dd7)

![Screenshot 2024-05-06 at 1 18 52 PM](https://github.com/sul-dlss/sul-requests/assets/2677207/62ac60d1-6c11-44e3-975d-990a342622d0)
