### PR TITLE
Use the sponsor's patron id when submitting requests to FOLIO

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -76,7 +76,7 @@ class PatronRequestsController < ApplicationController
 
   def patron_request_params
     params.require(:patron_request).permit(:patron_email, :instance_hrid, :origin_location_code, :needed_date, :service_point_code, :proxy,
-                                           :for_sponsor_name, :for_sponsor,
+                                           :for_sponsor_id, :for_sponsor,
                                            :fulfillment_type, :request_type,
                                            :scan_page_range, :scan_authors, :scan_title,
                                            :barcode, barcodes: [])

--- a/app/jobs/submit_folio_patron_request_job.rb
+++ b/app/jobs/submit_folio_patron_request_job.rb
@@ -41,19 +41,19 @@ class SubmitFolioPatronRequestJob < ApplicationJob
     {}
   end
 
-  def folio_request_data_for_item(request, item)
+  def folio_request_data_for_item(request, item) # rubocop:disable Metrics/AbcSize
     FolioClient::CirculationRequestData.new(
       request_level: 'Item', request_type: best_request_type(request, item),
       instance_id: request.instance_id, item_id: item.id, holdings_record_id: item.holdings_record_id,
-      requester_id: patron_or_proxy_id(request), fulfillment_preference: 'Hold Shelf',
+      requester_id: patron_or_proxy_id(request), proxy_user_id: request.patron&.id, fulfillment_preference: 'Hold Shelf',
       pickup_service_point_id: request.pickup_service_point.id,
       patron_comments: request.request_comments, request_expiration_date: (Time.zone.today + 3.years).to_time.utc.iso8601
     )
   end
 
   def patron_or_proxy_id(request)
-    if request.proxy? && request.patron.proxy?
-      request.patron.proxy_sponsor_user_id
+    if request.for_sponsor?
+      request.for_sponsor_id
     else
       request.patron&.id || request.destination_library_pseudopatron&.id
     end

--- a/app/models/folio/null_patron.rb
+++ b/app/models/folio/null_patron.rb
@@ -52,7 +52,11 @@ module Folio
       []
     end
 
-    def proxy_group_names
+    def sponsors
+      []
+    end
+
+    def proxies
       []
     end
 

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -115,7 +115,7 @@ module Folio
     def proxies
       # Return display name for any proxies where 'requestForSponser' is yes.
       @proxies ||= proxies_of_response.filter_map do |info|
-        next nil unless info['requestForSponsor'].downcase == 'yes'
+        next nil unless info['requestForSponsor']&.downcase == 'yes'
 
         # Find the patron corresponding to the Folio user id for the proxy
         proxy_patron = self.class.find_by(patron_key: info['proxyUserId'])
@@ -127,7 +127,7 @@ module Folio
     def sponsors
       # Return display name for any proxies where 'requestForSponser' is yes.
       @sponsors ||= sponsors_for_response.filter_map do |info|
-        next nil unless info['requestForSponsor'].downcase == 'yes'
+        next nil unless info['requestForSponsor']&.downcase == 'yes'
 
         # Find the patron corresponding to the Folio user id for the sponsor
         sponsor_patron = self.class.find_by(patron_key: info['userId'])

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -118,7 +118,7 @@ module Folio
         next nil unless info['requestForSponsor'].downcase == 'yes'
 
         # Find the patron corresponding to the Folio user id for the proxy
-        proxy_patron = self.class.folio_client.find_patron_by_id(info['proxyUserId'])
+        proxy_patron = self.class.find_by(patron_key: info['proxyUserId'])
         proxy_patron.presence
       end
     end
@@ -130,7 +130,7 @@ module Folio
         next nil unless info['requestForSponsor'].downcase == 'yes'
 
         # Find the patron corresponding to the Folio user id for the sponsor
-        sponsor_patron = self.class.folio_client.find_patron_by_id(info['userId'])
+        sponsor_patron = self.class.find_by(patron_key: info['userId'])
         sponsor_patron.presence
       end
     end

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -135,10 +135,6 @@ module Folio
       end
     end
 
-    def proxy_sponsor_user_id
-      proxy_info&.dig('userId')
-    end
-
     def university_id
       user_info['externalSystemId']
     end

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -164,7 +164,7 @@ class FolioClient
   end
 
   CirculationRequestData = Data.define(:request_level, :request_type, :instance_id, :item_id, :holdings_record_id,
-                                       :requester_id, :fulfillment_preference, :pickup_service_point_id,
+                                       :requester_id, :proxy_user_id, :fulfillment_preference, :pickup_service_point_id,
                                        :patron_comments, :request_expiration_date) do
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def as_json
@@ -178,6 +178,7 @@ class FolioClient
         itemId: item_id,
         holdingsRecordId: holdings_record_id,
         requesterId: requester_id,
+        proxyUserId: proxy_user_id,
         requestDate: Time.zone.now.utc.iso8601,
         pickupServicePointId: pickup_service_point_id,
         patronComments: patron_comments,

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -138,26 +138,8 @@ class FolioClient
     check_response(response, title: 'Assign pin', context: { user_id: })
   end
 
-  # We sometimes want the full list of proxies and not just the first one
-  def all_proxy_group_info(user_id)
-    response = get_json('/proxiesfor', params: { query: CqlQuery.new(userId: user_id).to_query })
-
-    response['proxiesFor']
-  end
-
-  # Get proxies for this user id and return the first one
-  def proxy_group_info(user_id)
-    all_proxy_group_info(user_id)[0]
-  end
-
-  # For whom is this user id a proxy?
-  def proxy_info(user_id)
-    all_proxy_info(user_id)[0]
-  end
-
-  # We sometimes want the full list of sponsors for which this user is a proxy and not just the first one
-  def all_proxy_info(user_id)
-    response = get_json('/proxiesfor', params: { query: CqlQuery.new(proxyUserId: user_id).to_query })
+  def proxies(**args)
+    response = get_json('/proxiesfor', params: { query: CqlQuery.new(**args).to_query })
 
     response['proxiesFor']
   end

--- a/app/views/patron_requests/_list_proxies_form.html.erb
+++ b/app/views/patron_requests/_list_proxies_form.html.erb
@@ -4,9 +4,9 @@
     <div class="mt-2">
         <ul>
         <%
-            f.object.patron.proxy_group_names.sort.each do |proxy_group_name|
+            f.object.patron.proxies.sort.each do |proxy|
         %>
-            <li><%=proxy_group_name %></li>
+            <li><%= proxy.display_name %></li>
         <%
             end
         %>

--- a/app/views/patron_requests/_list_sponsors_form.html.erb
+++ b/app/views/patron_requests/_list_sponsors_form.html.erb
@@ -25,9 +25,9 @@
         </div>
         <div class="mt-2">
             <div class="mt-2">
-                <% f.object.patron.sponsor_names.sort.each do |sponsor_name| %>  
-                    <%= f.radio_button :for_sponsor_name, sponsor_name, :class => 'form-check-input', data: { 'patronRequest-target': 'sponsorRadioButton'} %>
-                    <%= f.label :for_sponsor_name, sponsor_name, :class => 'form-check-label ms-1 d-inline' %>
+                <% f.object.patron.sponsors.sort_by(&:display_name).each do |sponsor| %>
+                    <%= f.radio_button :for_sponsor_id, sponsor.id, class: 'form-check-input', data: { 'patronRequest-target': 'sponsorRadioButton'} %>
+                    <%= f.label :for_sponsor_id, sponsor.display_name, value: sponsor.id, class: 'form-check-label ms-1 d-inline' %>
                 <% end %>
             </div>
         </div>

--- a/app/views/patron_requests/_proxy.html.erb
+++ b/app/views/patron_requests/_proxy.html.erb
@@ -1,7 +1,7 @@
 <div class="row p-3 gap-3 flex-column flex-md-row">
-  <% if f.object.patron.proxy_group_names.any? %>
+  <% if f.object.patron.sponsor? %>
     <%= render 'list_proxies_form', f: %>
-  <% elsif f.object.patron.sponsor_names.any? %>
+  <% elsif f.object.patron.proxy? %>
     <%= render 'list_sponsors_form', f: %>
   <% end %>
 </div>

--- a/app/views/patron_requests/_scan_or_pickup.html.erb
+++ b/app/views/patron_requests/_scan_or_pickup.html.erb
@@ -1,11 +1,11 @@
 
 <fieldset class="mb-4">
   <legend class="fs-6"></legend>
-  <% if current_request.patron.proxy_group_names.any? %>
+  <% if f.object.patron.sponsor? %>
     <div class="alert alert-warning d-flex align-items-center d-none" data-patronRequest-target='proxyScanWarning'>
       <i class="bi bi-exclamation-triangle-fill me-2 text-warning fs-4"></i>Please be advised that scans are not sent to proxies.
     </div>
-  <% elsif current_request.patron.sponsor_names.any? %>
+  <% elsif f.object.patron.proxy? %>
     <div class="alert alert-warning d-flex align-items-center d-none" data-patronRequest-target='sponsorScanWarning'>
       <i class="bi bi-exclamation-triangle-fill me-2 text-warning fs-4"></i>Please be advised that scans are not sent to the sponsor.
     </div>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -69,7 +69,7 @@
   <% end %>
 
   <!-- proxy -->
-  <% if ( f.object.patron.proxy_group_names&.any? || f.object.patron.sponsor_names&.any? ) && !f.object.aeon_page? %>
+  <% if (f.object.patron.proxy? || f.object.patron.sponsor?) && !f.object.aeon_page? %>
     <%= render AccordionStepComponent.new(id: 'proxy', step_index: step_enum.next, form_id: f.id) do |c| %>
       <% c.with_title.with_content('Proxy/Sponsor') %>
       <% c.with_body do %>

--- a/spec/factories/patrons.rb
+++ b/spec/factories/patrons.rb
@@ -15,10 +15,8 @@ FactoryBot.define do
     stubs do
       {
         patron_blocks: [],
-        proxy_info: {},
-        proxy_group_info: {},
-        all_proxy_group_info: {},
-        all_proxy_info: {}
+        proxies: [],
+        sponsors: []
       }
     end
 
@@ -62,10 +60,8 @@ FactoryBot.define do
             message: 'Patron has reached maximum allowed outstanding fee/fine balance for his/her patron group'
           }
         ],
-        proxy_info: {},
-        proxy_group_info: {},
-        all_proxy_group_info: {},
-        all_proxy_info: {}
+        proxies: [],
+        sponsors: []
       }
     end
   end

--- a/spec/features/create_aeon_patron_request_spec.rb
+++ b/spec/features/create_aeon_patron_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Creating an Aeon patron request', :js do
                                    patron_description: 'faculty',
                                    patron_group_name: 'faculty',
                                    patron_group_id: '503a81cd-6c26-400f-b620-14c08943697c',
-                                   blocked?: false, proxy_group_names: [], sponsor_names: [],
+                                   blocked?: false, proxies: [], sponsors: [], sponsor?: false, proxy?: false,
                                    allowed_request_types: ['Hold', 'Recall', 'Page'])
   end
 

--- a/spec/models/folio/patron_spec.rb
+++ b/spec/models/folio/patron_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Folio::Patron do
     end
   end
 
-  describe '#proxy_group_names' do
+  describe '#proxies' do
     let(:fields) { { id: 'sponsor', personal: { firstName: 'Sponsor' } } }
     let(:patron_one) { instance_double(described_class, id: 'proxy1', display_name: 'Proxy One') }
     let(:patron_two) { instance_double(described_class, id: 'proxy2', display_name: 'Proxy Two') }
@@ -107,17 +107,17 @@ RSpec.describe Folio::Patron do
       allow(FolioClient).to receive(:new).and_return(stub_client)
       allow(stub_client).to receive(:find_patron_by_id).with('proxy1').and_return(patron_one)
       allow(stub_client).to receive(:find_patron_by_id).with('proxy2').and_return(patron_two)
-      allow(stub_client).to receive(:all_proxy_group_info).with('sponsor').and_return([
-                                                                                        { 'proxyUserId' => 'proxy1',
-                                                                                          'requestForSponsor' => 'Yes' },
-                                                                                        { 'proxyUserId' => 'proxy2',
-                                                                                          'requestForSponsor' => 'Yes' }
-                                                                                      ])
-      expect(patron.proxy_group_names.length).to eq 2
+      allow(stub_client).to receive(:proxies).with(userId: 'sponsor').and_return([
+                                                                                   { 'proxyUserId' => 'proxy1',
+                                                                                     'requestForSponsor' => 'Yes' },
+                                                                                   { 'proxyUserId' => 'proxy2',
+                                                                                     'requestForSponsor' => 'Yes' }
+                                                                                 ])
+      expect(patron.proxies.length).to eq 2
     end
   end
 
-  describe '#sponsor_names' do
+  describe '#sponsors' do
     let(:fields) { { id: 'proxy', personal: { firstName: 'Proxy' } } }
     let(:sponsor_one) { instance_double(described_class, id: 'sponsor1', display_name: 'Sponsor One') }
     let(:sponsor_two) { instance_double(described_class, id: 'sponsor2', display_name: 'Sponsor Two') }
@@ -127,13 +127,13 @@ RSpec.describe Folio::Patron do
       allow(FolioClient).to receive(:new).and_return(stub_client)
       allow(stub_client).to receive(:find_patron_by_id).with('sponsor1').and_return(sponsor_one)
       allow(stub_client).to receive(:find_patron_by_id).with('sponsor2').and_return(sponsor_two)
-      allow(stub_client).to receive(:all_proxy_info).with('proxy').and_return([
-                                                                                { 'userId' => 'sponsor1',
-                                                                                  'requestForSponsor' => 'Yes' },
-                                                                                { 'userId' => 'sponsor2',
-                                                                                  'requestForSponsor' => 'Yes' }
-                                                                              ])
-      expect(patron.sponsor_names.length).to eq 2
+      allow(stub_client).to receive(:proxies).with(proxyUserId: 'proxy').and_return([
+                                                                                      { 'userId' => 'sponsor1',
+                                                                                        'requestForSponsor' => 'Yes' },
+                                                                                      { 'userId' => 'sponsor2',
+                                                                                        'requestForSponsor' => 'Yes' }
+                                                                                    ])
+      expect(patron.sponsors.length).to eq 2
     end
   end
 end


### PR DESCRIPTION
- Normal requests use the requesting patron's id (or the destination's pseudopatron.)
- Requests for a sponsor (shared with their proxy group) should use the patron's id with a request comment that their proxies can pick it up
- Requests by a proxy on behalf of a sponsor should be placed using the sponsor's patron id.