### PR TITLE
Retrieve + display bound-with information

### DIFF
--- a/app/assets/stylesheets/application_redesign.scss
+++ b/app/assets/stylesheets/application_redesign.scss
@@ -325,3 +325,7 @@ label.btn-close {
     }
   }
 }
+
+.status.availability {
+  text-wrap: nowrap;
+}

--- a/app/models/folio/holdings_record.rb
+++ b/app/models/folio/holdings_record.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Folio
+  # Represents a holdings record in Folio.
+  class HoldingsRecord
+    attr_reader :call_number, :instance, :items, :bound_with_item
+
+    def initialize(call_number:, instance: nil, bound_with_item: nil, items: [], suppressed_from_discovery: false)
+      @call_number = call_number
+      @instance = instance
+      @bound_with_item = bound_with_item
+      @suppressed_from_discovery = suppressed_from_discovery
+      @items = items
+    end
+
+    def suppressed_from_discovery?
+      @suppressed_from_discovery
+    end
+
+    def self.from_hash(hash)
+      new(
+        call_number: hash.fetch('callNumber'),
+        instance: (Folio::Instance.from_dynamic(hash.fetch('instance')) if hash['instance']),
+        bound_with_item: (Folio::Item.from_hash(hash.fetch('boundWithItem')) if hash['boundWithItem']),
+        items: hash.fetch('items', []).map { |item| Folio::Item.from_hash(item) },
+        suppressed_from_discovery: hash['discoverySuppress']
+      )
+    end
+  end
+end

--- a/app/models/folio/holdings_record.rb
+++ b/app/models/folio/holdings_record.rb
@@ -3,9 +3,10 @@
 module Folio
   # Represents a holdings record in Folio.
   class HoldingsRecord
-    attr_reader :call_number, :instance, :items
+    attr_reader :id, :call_number, :instance, :items
 
-    def initialize(call_number:, instance: nil, bound_with_item: nil, items: [], suppressed_from_discovery: false)
+    def initialize(call_number:, id: nil, instance: nil, bound_with_item: nil, items: [], suppressed_from_discovery: false) # rubocop:disable Metrics/ParameterLists
+      @id = id
       @call_number = call_number
       @instance = instance
       @bound_with_item = bound_with_item
@@ -23,10 +24,11 @@ module Folio
 
     def self.from_hash(hash)
       new(
+        id: hash['id'],
         call_number: hash.fetch('callNumber'),
         instance: (Folio::Instance.from_dynamic(hash.fetch('instance')) if hash['instance']),
         bound_with_item: (Folio::Item.from_hash(hash.fetch('boundWithItem')) if hash['boundWithItem']),
-        items: hash.fetch('items', []).map { |item| Folio::Item.from_hash(item) },
+        items: hash.fetch('items', []).map { |item| Folio::Item.from_hash(item.reverse_merge('holdingsRecord' => hash)) },
         suppressed_from_discovery: hash['discoverySuppress']
       )
     end

--- a/app/models/folio/holdings_record.rb
+++ b/app/models/folio/holdings_record.rb
@@ -3,7 +3,7 @@
 module Folio
   # Represents a holdings record in Folio.
   class HoldingsRecord
-    attr_reader :call_number, :instance, :items, :bound_with_item
+    attr_reader :call_number, :instance, :items
 
     def initialize(call_number:, instance: nil, bound_with_item: nil, items: [], suppressed_from_discovery: false)
       @call_number = call_number
@@ -11,6 +11,10 @@ module Folio
       @bound_with_item = bound_with_item
       @suppressed_from_discovery = suppressed_from_discovery
       @items = items
+    end
+
+    def bound_with_item
+      @bound_with_item&.with_bound_with_child_holdings_record(self)
     end
 
     def suppressed_from_discovery?

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -95,7 +95,7 @@ module Folio
     end
 
     def items
-      holdings_records.flat_map(&:items).reject(&:suppressed_from_discovery?)
+      (holdings_records.flat_map(&:items) + holdings_records.filter_map(&:bound_with_item)).reject(&:suppressed_from_discovery?)
     end
 
     def holdings_records

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -31,14 +31,14 @@ module Folio
         end,
         electronic_access: json.fetch('electronicAccess', []),
         edition: json.fetch('editions', []),
-        items: json.fetch('items', []).map { |item| Folio::Item.from_hash(item) }
+        holdings_records: json.fetch('holdingsRecords', []).map { |hr| Folio::HoldingsRecord.from_hash(hr) }
       )
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
     def initialize(id:, hrid: '', title: '', contributors: [], pub_date: nil, pub_place: nil, publisher: nil, format: nil,
-                   isbn: [], oclcn: [], electronic_access: [], edition: [], items: [])
+                   isbn: [], oclcn: [], electronic_access: [], edition: [], holdings_records: [])
       @id = id
       @hrid = hrid
       @title = title
@@ -51,7 +51,7 @@ module Folio
       @oclcn = oclcn
       @electronic_access = electronic_access
       @edition = edition
-      @items = items
+      @holdings_records = holdings_records
     end
     # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
@@ -95,7 +95,11 @@ module Folio
     end
 
     def items
-      @items.reject(&:suppressed_from_discovery?)
+      holdings_records.flat_map(&:items).reject(&:suppressed_from_discovery?)
+    end
+
+    def holdings_records
+      @holdings_records.reject(&:suppressed_from_discovery?)
     end
 
     def holdings

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -95,7 +95,13 @@ module Folio
     end
 
     def items
-      (holdings_records.flat_map(&:items) + holdings_records.filter_map(&:bound_with_item)).reject(&:suppressed_from_discovery?)
+      @items ||= begin
+        actual_items = holdings_records.flat_map(&:items)
+        actual_items_ids = actual_items.map(&:id)
+        bound_with_items = holdings_records.filter_map(&:bound_with_item).reject { |x| x.id.in? actual_items_ids }
+
+        (actual_items + bound_with_items).reject(&:suppressed_from_discovery?)
+      end
     end
 
     def holdings_records

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -219,7 +219,11 @@ module Folio
           due_date: dyn['dueDate'],
           enumeration: dyn['enumeration'],
           instance: (Folio::Instance.from_dynamic(dyn['instance']) if dyn['instance']),
-          bound_with_holdings_per_item: dyn['boundWithHoldingsPerItem']&.map { |v| Folio::HoldingsRecord.from_hash(v) } || [],
+          bound_with_holdings_per_item: dyn['boundWithHoldingsPerItem']&.filter_map do |v|
+            next if v['id'].present? && v['id'] == dyn.dig('holdingsRecord', 'id')
+
+            Folio::HoldingsRecord.from_hash(v)
+          end || [],
           base_callnumber: dyn.dig('effectiveCallNumberComponents', 'callNumber'),
           type: dyn.dig('materialType', 'name'),
           full_enumeration: [dyn['volume'], dyn['enumeration'],

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -7,7 +7,8 @@ module Folio
   # NOTE, barcode and callnumber may be nil. see instance_hrid: 'in00000063826'
   class Item
     attr_reader :id, :barcode, :status, :type, :public_note, :effective_location, :permanent_location, :temporary_location,
-                :material_type, :loan_type, :holdings_record_id, :enumeration, :base_callnumber, :full_enumeration, :queue_length
+                :material_type, :loan_type, :holdings_record_id, :enumeration, :base_callnumber, :full_enumeration, :queue_length,
+                :instance, :bound_with_holdings_per_item, :bound_with_child_holdings_record
 
     # Other statuses that we aren't using include "Unavailable" and "Intellectual item"
     STATUS_CHECKED_OUT = 'Checked out'
@@ -90,6 +91,11 @@ module Folio
 
     def with_status(status)
       Folio::ItemWithStatus.new(self).with_status(status)
+    end
+
+    def with_bound_with_child_holdings_record(holdings_record)
+      @bound_with_child_holdings_record = holdings_record
+      self
     end
 
     # TODO: rename this to 'permanent_location_code' after migration

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -65,7 +65,7 @@ module Folio
                    type: nil, public_note: nil, material_type: nil, loan_type: nil, enumeration: nil,
                    full_enumeration: nil,
                    due_date: nil, id: nil, holdings_record_id: nil, suppressed_from_discovery: false,
-                   base_callnumber: nil, queue_length: 0)
+                   base_callnumber: nil, queue_length: 0, instance: nil, bound_with_holdings_per_item: [])
       @id = id
       @holdings_record_id = holdings_record_id
       @barcode = barcode.presence || id
@@ -83,6 +83,8 @@ module Folio
       @due_date = due_date
       @queue_length = queue_length
       @suppressed_from_discovery = suppressed_from_discovery
+      @instance = instance
+      @bound_with_holdings_per_item = bound_with_holdings_per_item
     end
     # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength, Metrics/AbcSize
 
@@ -210,6 +212,8 @@ module Folio
           status: dyn.dig('status', 'name'),
           due_date: dyn['dueDate'],
           enumeration: dyn['enumeration'],
+          instance: (Folio::Instance.from_dynamic(dyn['instance']) if dyn['instance']),
+          bound_with_holdings_per_item: dyn['boundWithHoldingsPerItem']&.map { |v| Folio::HoldingsRecord.from_hash(v) } || [],
           base_callnumber: dyn.dig('effectiveCallNumberComponents', 'callNumber'),
           type: dyn.dig('materialType', 'name'),
           full_enumeration: [dyn['volume'], dyn['enumeration'],

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -103,6 +103,7 @@ class FolioGraphqlClient
                 uri
               }
               holdingsRecords {
+                id
                 callNumber
                 discoverySuppress
                 boundWithItem {
@@ -121,6 +122,7 @@ class FolioGraphqlClient
                   #{item_fields}
 
                   boundWithHoldingsPerItem {
+                    id
                     callNumber
                     instance {
                       id

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -102,105 +102,23 @@ class FolioGraphqlClient
                 materialsSpecification
                 uri
               }
-              items {
-                id
-                barcode
+              holdingsRecords {
+                callNumber
                 discoverySuppress
-                volume
-                queueTotalLength
-                status {
-                  name
-                }
-                queueTotalLength
-                dueDate
-                materialType {
-                  id
-                  name
-                }
-                chronology
-                enumeration
-                effectiveCallNumberComponents {
-                  callNumber
-                }
-                notes {
-                  note
-                  itemNoteType {
-                    name
-                  }
-                }
-                effectiveLocation {
-                  id
-                  campusId
-                  libraryId
-                  institutionId
-                  code
-                  discoveryDisplayName
-                  name
-                  servicePoints {
+                boundWithItem {
+                  #{item_fields}
+
+                  instance {
                     id
-                    code
-                    pickupLocation
-                  }
-                  library {
-                    id
-                    code
-                  }
-                  campus {
-                    id
-                    code
-                  }
-                  details {
-                    pageAeonSite
-                    pageMediationGroupKey
-                    pageServicePoints {
-                      id
-                      code
+                    hrid
+                    title
+                    instanceType {
                       name
                     }
-                    scanServicePointCode
-                    availabilityClass
-                    searchworksTreatTemporaryLocationAsPermanentLocation
                   }
                 }
-                permanentLocation {
-                  id
-                  code
-                  details {
-                    pageAeonSite
-                    pageMediationGroupKey
-                    pageServicePoints {
-                      id
-                      code
-                      name
-                    }
-                    pagingSchedule
-                    scanServicePointCode
-                  }
-                }
-                temporaryLocation {
-                  id
-                  code
-                  discoveryDisplayName
-                }
-                permanentLoanTypeId
-                temporaryLoanTypeId
-                holdingsRecord {
-                  id
-                  effectiveLocation {
-                    id
-                    code
-                    details {
-                      pageAeonSite
-                      pageMediationGroupKey
-                      pageServicePoints {
-                        id
-                        code
-                        name
-                      }
-                      pagingSchedule
-                      scanServicePointCode
-                    }
-                  }
+                items {
+                  #{item_fields}
                 }
               }
             }
@@ -237,7 +155,122 @@ class FolioGraphqlClient
 
     data&.dig('data', 'servicePoints')
   end
+
   # rubocop:enable Metrics/MethodLength
+  def item_fields
+    <<-GQL
+      id
+      barcode
+      discoverySuppress
+      volume
+      queueTotalLength
+      status {
+        name
+      }
+      queueTotalLength
+      dueDate
+      materialType {
+        id
+        name
+      }
+      chronology
+      enumeration
+      effectiveCallNumberComponents {
+        callNumber
+      }
+      notes {
+        note
+        itemNoteType {
+          name
+        }
+      }
+      effectiveLocation {
+        id
+        campusId
+        libraryId
+        institutionId
+        code
+        discoveryDisplayName
+        name
+        servicePoints {
+          id
+          code
+          pickupLocation
+        }
+        library {
+          id
+          code
+        }
+        campus {
+          id
+          code
+        }
+        details {
+          pageAeonSite
+          pageMediationGroupKey
+          pageServicePoints {
+            id
+            code
+            name
+          }
+          scanServicePointCode
+          availabilityClass
+          searchworksTreatTemporaryLocationAsPermanentLocation
+        }
+      }
+      permanentLocation {
+        id
+        code
+        details {
+          pageAeonSite
+          pageMediationGroupKey
+          pageServicePoints {
+            id
+            code
+            name
+          }
+          pagingSchedule
+          scanServicePointCode
+        }
+      }
+      temporaryLocation {
+        id
+        code
+        discoveryDisplayName
+      }
+      permanentLoanTypeId
+      temporaryLoanTypeId
+      holdingsRecord {
+        id
+        effectiveLocation {
+          id
+          code
+          details {
+            pageAeonSite
+            pageMediationGroupKey
+            pageServicePoints {
+              id
+              code
+              name
+            }
+            pagingSchedule
+            scanServicePointCode
+          }
+        }
+      }
+      boundWithHoldingsPerItem {
+        callNumber
+        instance {
+          id
+          title
+          hrid
+          instanceType {
+            name
+          }
+        }
+      }
+    GQL
+  end
 
   def ping
     # Every GraphQL server supports the trivial query that asks for the "type name" of the top-level query

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -119,6 +119,18 @@ class FolioGraphqlClient
                 }
                 items {
                   #{item_fields}
+
+                  boundWithHoldingsPerItem {
+                    callNumber
+                    instance {
+                      id
+                      title
+                      hrid
+                      instanceType {
+                        name
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -255,17 +267,6 @@ class FolioGraphqlClient
             }
             pagingSchedule
             scanServicePointCode
-          }
-        }
-      }
-      boundWithHoldingsPerItem {
-        callNumber
-        instance {
-          id
-          title
-          hrid
-          instanceType {
-            name
           }
         }
       }

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -25,7 +25,7 @@
         <% single_item.bound_with_holdings_per_item.each do |bound_with_child| %>
           <li class="list-group-item d-flex bg-light">
             <span class="me-auto"><%= bound_with_child.instance.title %></span>
-            <span><%= bound_with_child.call_number %></span>
+            <span class="text-nowrap"><%= bound_with_child.call_number %></span>
           </li>
         <% end %>
       </ul>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -20,7 +20,7 @@
 
   <% if single_item.bound_with_holdings_per_item.any? && (single_item.instance.nil? || single_item.instance&.hrid == @patron_request.instance_hrid) %>
     <div class="card col-lg-8 shadow-sm">
-      <div class="card-header h6 bg-light">This item is bound with:</div>
+      <div class="card-header h6 bg-light">This item is bound with</div>
       <ul class="list-group list-group-flush">
         <% single_item.bound_with_holdings_per_item.each do |bound_with_child| %>
           <li class="list-group-item d-flex bg-light">
@@ -36,7 +36,7 @@
     <div class="lead fw-normal mb-4">Call number: <%= @patron_request.bib_data.holdings_records.first.call_number %></div>
 
     <div class="card col-lg-8 shadow-sm">
-      <div class="card-header h6 bg-light">This item is bound and shelved by:</div>
+      <div class="card-header h6 bg-light">This item is bound and shelved with</div>
       <div class="card-body bg-light">
         <div><%= single_item.instance.title %></div>
         <div>Call number: <%= callnumber_label(single_item) %></div>
@@ -173,7 +173,7 @@
 
                     <% if item.bound_with_holdings_per_item.any? %>
                       <span class="d-block mt-2 ms-4 py-2 bg-light">
-                        <span class="ms-3 text-cardinal">Bound with:</div>
+                        <span class="ms-3 text-cardinal">Bound with</div>
 
                         <ul class="list-group list-group-flush">
                           <% item.bound_with_holdings_per_item.each do |bound_with_child| %>
@@ -188,7 +188,7 @@
 
                     <% if item.instance&.hrid %>
                       <span class="d-block ms-4 mt-2 px-3 py-2 bg-light">
-                        <span class="text-cardinal">Bound with and shelved by:</span>
+                        <span class="text-cardinal">Bound with and shelved with</span>
                         <span class="d-block"><%= item.instance.title %></span>
                         <span class="d-block"><%= callnumber_label(item) %></span>
                       </span>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -9,11 +9,39 @@
 <h1 class="fw-semibold mt-4"><%= @patron_request.item_title %></h1>
 <% if @patron_request.selectable_items.one? %>
   <% single_item = @patron_request.selectable_items.first %>
-  <div class="lead fw-normal mb-4">Call number: <%= callnumber_label(single_item) %></div>
+  <% unless single_item.instance && single_item.instance&.hrid != @patron_request.instance_hrid %>
+    <div class="lead fw-normal mb-4">Call number: <%= callnumber_label(single_item) %></div>
+  <% end %>
   <% if single_item.public_note %>
     <span class="text-cardinal d-block ms-4">
       <%= single_item.public_note %>
     </span>
+  <% end %>
+
+  <% if single_item.bound_with_holdings_per_item.any? && (single_item.instance.nil? || single_item.instance&.hrid == @patron_request.instance_hrid) %>
+    <div class="card col-lg-8 shadow-sm">
+      <div class="card-header h6 bg-light">This item is bound with:</div>
+      <ul class="list-group list-group-flush">
+        <% single_item.bound_with_holdings_per_item.each do |bound_with_child| %>
+          <li class="list-group-item d-flex bg-light">
+            <span class="me-auto"><%= bound_with_child.instance.title %></span>
+            <span><%= bound_with_child.call_number %></span>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% if single_item.instance && single_item.instance&.hrid != @patron_request.instance_hrid %>
+    <div class="lead fw-normal mb-4">Call number: <%= @patron_request.bib_data.holdings_records.first.call_number %></div>
+
+    <div class="card col-lg-8 shadow-sm">
+      <div class="card-header h6 bg-light">This item is bound and shelved by:</div>
+      <div class="card-body bg-light">
+        <div><%= single_item.instance.title %></div>
+        <div>Call number: <%= callnumber_label(single_item) %></div>
+      </div>
+    </div>
   <% end %>
 <% end %>
 
@@ -127,7 +155,7 @@
               <% sort_holdings(f.object.selectable_items).each.with_index(1) do |item, index| %>
                 <% not_requestable = cannot?(:request, item) %>
                 <tr data-sortby-status="<%= item.status_text.downcase.gsub(' ', '_') %>" data-sortby-callnumber="<%= index %>" >
-                  <td class="align-middle">
+                  <td>
                     <label>
                       <%= f.check_box 'barcodes', { multiple: true, class: 'form-check-input', disabled: cannot?(:request, item), data: { 'itemselector-target': 'items', 'itemselector-id-param': item.id, 'itemselector-available-param': item.available?, 'itemselector-duequeueinfo-param': queue_length_display(item),  'itemselector-label-param': callnumber_label(item), action: 'itemselector#change' } }, item.barcode || item.id, "" %>
                       <% if f.object.aeon_page? %>
@@ -135,15 +163,38 @@
                         <%= f.hidden_field "aeon_barcode_#{item.barcode}", disabled: true, name: "ItemNumber_#{index}", value: item.barcode, data: { toggle: true } %>
                         <%= f.hidden_field "aeon_request_#{index}", disabled: true, name: 'Request', value: index, data: { toggle: true } %>
                       <% end %>
-                      <span class="form-check-label ms-1"><%= callnumber_label(item) %></span>
-                      <% if item.public_note %>
-                        <span class="text-cardinal d-block ms-4 mt-1">
-                          <%= item.public_note %>
-                        </span>
-                      <% end %>
+                      <span class="form-check-label ms-1"><%= item&.bound_with_child_holdings_record&.call_number || callnumber_label(item) %></span>
                     </label>
+                    <% if item.public_note %>
+                      <span class="text-cardinal d-block ms-4 mt-1">
+                        <%= item.public_note %>
+                      </span>
+                    <% end %>
+
+                    <% if item.bound_with_holdings_per_item.any? %>
+                      <span class="d-block mt-2 ms-4 py-2 bg-light">
+                        <span class="ms-3 text-cardinal">Bound with:</div>
+
+                        <ul class="list-group list-group-flush">
+                          <% item.bound_with_holdings_per_item.each do |bound_with_child| %>
+                            <li class="list-group-item bg-light">
+                              <span class="d-block"><%= bound_with_child.instance.title %></span>
+                              <span class="d-block"><%= bound_with_child.call_number %></span>
+                            </li>
+                          <% end %>
+                        </ul>
+                      </span>
+                    <% end %>
+
+                    <% if item.instance&.hrid %>
+                      <span class="d-block ms-4 mt-2 px-3 py-2 bg-light">
+                        <span class="text-cardinal">Bound with and shelved by:</span>
+                        <span class="d-block"><%= item.instance.title %></span>
+                        <span class="d-block"><%= callnumber_label(item) %></span>
+                      </span>
+                    <% end %>
                   </td>
-                  <td class="align-middle text-end">
+                  <td class="text-end">
                     <%= requests_patron_item_selector_label(item, not_requestable:) %>
                   </td>
                 </tr>

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -105,7 +105,25 @@ FactoryBot.define do
     initialize_with { new(**attributes) }
   end
 
-  factory :multiple_holdings, class: 'Folio::Instance' do
+  factory :holdings_record, class: 'Folio::HoldingsRecord' do
+    call_number { 'ABC 123' }
+    items { [] }
+    suppressed_from_discovery { false }
+
+    initialize_with { new(**attributes) }
+  end
+
+  factory :instance, class: 'Folio::Instance' do
+    id { '1234' }
+    title { 'Item Title' }
+    format { 'Book' }
+    holdings_records { [build(:holdings_record, items:)] }
+    items { [build(:item)] }
+
+    initialize_with { new(**attributes.except(:items)) }
+  end
+
+  factory :multiple_holdings, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Item Title' }
@@ -126,13 +144,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :sal3_holding, class: 'Folio::Instance' do
+  factory :sal3_holding, parent: :instance do
     id { '12345' }
     hrid { 'a12345' }
     title { 'Item Title' }
@@ -145,13 +159,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :sal3_as_holding, class: 'Folio::Instance' do
+  factory :sal3_as_holding, parent: :instance do
     id { '12345' }
     hrid { 'a12345' }
     title { 'Item Title' }
@@ -164,13 +174,9 @@ FactoryBot.define do
               effective_location: build(:page_as_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :single_holding, class: 'Folio::Instance' do
+  factory :single_holding, parent: :instance do
     id { '123' }
 
     title { 'Item Title' }
@@ -185,13 +191,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :mmstacks_holding, class: 'Folio::Instance' do
+  factory :mmstacks_holding, parent: :instance do
     id { '123' }
 
     title { 'Item Title' }
@@ -206,13 +208,9 @@ FactoryBot.define do
               effective_location: build(:mmstacks_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :single_law_holding, class: 'Folio::Instance' do
+  factory :single_law_holding, parent: :instance do
     id { '123' }
 
     title { 'Item Title' }
@@ -227,13 +225,9 @@ FactoryBot.define do
               effective_location: build(:law_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :scannable_only_holdings, class: 'Folio::Instance' do
+  factory :scannable_only_holdings, parent: :instance do
     id { '1234' }
     title { 'Item Title' }
 
@@ -248,13 +242,9 @@ FactoryBot.define do
               type: 'NONCIRC')
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :special_collections_holdings, class: 'Folio::Instance' do
+  factory :special_collections_holdings, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Special Collections Item Title' }
@@ -277,13 +267,9 @@ FactoryBot.define do
               effective_location: build(:spec_coll_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :special_collections_single_holding, class: 'Folio::Instance' do
+  factory :special_collections_single_holding, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Special Collections Item Title' }
@@ -301,13 +287,9 @@ FactoryBot.define do
               effective_location: build(:spec_coll_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :special_collections_finding_aid_holdings, class: 'Folio::Instance' do
+  factory :special_collections_finding_aid_holdings, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Special Collections Item Title' }
@@ -326,13 +308,9 @@ FactoryBot.define do
               effective_location: build(:spec_coll_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :sal3_holdings, class: 'Folio::Instance' do
+  factory :sal3_holdings, parent: :instance do
     id { '123456' }
     title { 'SAL3 Item Title' }
 
@@ -352,13 +330,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :scannable_holdings, class: 'Folio::Instance' do
+  factory :scannable_holdings, parent: :instance do
     id { '1234' }
     title { 'SAL Item Title' }
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
@@ -381,13 +355,9 @@ FactoryBot.define do
               effective_location: build(:scannable_location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :green_holdings, class: 'Folio::Instance' do
+  factory :green_holdings, parent: :instance do
     id { '1234' }
     title { 'Green Item Title' }
 
@@ -402,13 +372,9 @@ FactoryBot.define do
               effective_location: build(:green_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :page_lp_holdings, class: 'Folio::Instance' do
+  factory :page_lp_holdings, parent: :instance do
     id { '1234' }
     title { 'PAGE-LP Item Title' }
 
@@ -423,13 +389,9 @@ FactoryBot.define do
               effective_location: build(:page_lp_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :page_en_holdings, class: 'Folio::Instance' do
+  factory :page_en_holdings, parent: :instance do
     id { '1234' }
     title { 'PAGE-EN Item Title' }
 
@@ -444,13 +406,9 @@ FactoryBot.define do
               effective_location: build(:page_en_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :page_mp_holdings, class: 'Folio::Instance' do
+  factory :page_mp_holdings, parent: :instance do
     id { '1234' }
     title { 'PAGE-MP Item Title' }
 
@@ -470,13 +428,9 @@ FactoryBot.define do
               effective_location: build(:page_mp_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :many_holdings, class: 'Folio::Instance' do
+  factory :many_holdings, parent: :instance do
     id { '1234' }
     title { 'Item title' }
 
@@ -511,13 +465,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :single_mediated_holding, class: 'Folio::Instance' do
+  factory :single_mediated_holding, parent: :instance do
     id { '1234' }
     title { 'Item Title' }
 
@@ -532,13 +482,9 @@ FactoryBot.define do
               type: 'LCKSTK')
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :art_stacks_holding, class: 'Folio::Instance' do
+  factory :art_stacks_holding, parent: :instance do
     id { '1234' }
     title { 'Item Title' }
 
@@ -553,13 +499,9 @@ FactoryBot.define do
               type: 'STKS')
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :searchable_holdings, class: 'Folio::Instance' do
+  factory :searchable_holdings, parent: :instance do
     id { '1234' }
     title { 'Item Title' }
 
@@ -632,13 +574,9 @@ FactoryBot.define do
               type: 'LCKSTK')
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :searchable_spec_holdings, class: 'Folio::Instance' do
+  factory :searchable_spec_holdings, parent: :instance do
     id { '1234' }
     title { 'Item Title' }
 
@@ -689,13 +627,9 @@ FactoryBot.define do
               effective_location: build(:spec_coll_location))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :checkedout_holdings, class: 'Folio::Instance' do
+  factory :checkedout_holdings, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Checked out item' }
@@ -724,13 +658,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :sal3_stacks_searchworks_item, class: 'Folio::Instance' do
+  factory :sal3_stacks_searchworks_item, parent: :instance do
     id { '1234' }
     title { 'SAL3 stacks item' }
 
@@ -744,13 +674,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :on_order_instance, class: 'Folio::Instance' do
+  factory :on_order_instance, parent: :instance do
     id { 'a43e597a-d4b4-50ec-ad16-7fd49920831a' }
 
     title { 'HAZARDOUS MATERIALS : MANAGING THE INCIDENT.' }
@@ -758,13 +684,9 @@ FactoryBot.define do
     format { 'unspecified' }
 
     items { [] }
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :single_holding_multiple_items, class: 'Folio::Instance' do
+  factory :single_holding_multiple_items, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Multiple Items In Holding Title' }
@@ -787,13 +709,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :mixed_crez_holdings, class: 'Folio::Instance' do
+  factory :mixed_crez_holdings, parent: :instance do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Mixed CREZ holdings' }
@@ -818,13 +736,9 @@ FactoryBot.define do
               temporary_location: build(:location, code: 'GRE-CRES'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :empty_barcode_holdings, class: 'Folio::Instance' do
+  factory :empty_barcode_holdings, parent: :instance do
     id { '1234' }
     title { 'Empty Barcode Item Title' }
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
@@ -848,13 +762,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :missing_holdings, class: 'Folio::Instance' do
+  factory :missing_holdings, parent: :instance do
     id { '1234' }
     title { 'One Missing item' }
 
@@ -874,13 +784,9 @@ FactoryBot.define do
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
     end
-
-    initialize_with do
-      new(**attributes)
-    end
   end
 
-  factory :aged_to_lost_holdings, class: 'Folio::Instance' do
+  factory :aged_to_lost_holdings, parent: :instance do
     id { '1234' }
     title { 'One lost item' }
 
@@ -894,10 +800,6 @@ FactoryBot.define do
               status: 'Aged to Lost',
               effective_location: build(:location, code: 'SAL3-STACKS'))
       ]
-    end
-
-    initialize_with do
-      new(**attributes)
     end
   end
 end

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -348,16 +348,27 @@ RSpec.describe Folio::Instance do
     let(:instance_response) do
       <<~JSON
         {
-          "id": "a1a88348-363f-5b41-9937-13584daae527",
+          "id": "039f3c69-e115-5494-b036-5716fce3996e",
+          "hrid": "a6307113",
           "title": "Stanford Research Institute records, 1947-1966",
           "identifiers": [
             {
+              "value": "(Sirsi) a6307113",
+              "identifierTypeObject": {
+                "name": "System control number"
+              }
+            },
+            {
               "value": "(OCoLC-M)754864063",
-              "identifierTypeObject": null
+              "identifierTypeObject": {
+                "name": "OCLC"
+              }
             },
             {
               "value": "(OCoLC-I)755035981",
-              "identifierTypeObject": null
+              "identifierTypeObject": {
+                "name": "OCLC"
+              }
             }
           ],
           "instanceType": {
@@ -370,153 +381,322 @@ RSpec.describe Folio::Instance do
             }
           ],
           "publication": [],
+          "editions": [],
           "electronicAccess": [
             {
               "materialsSpecification": "Finding aid available online",
               "uri": "http://www.oac.cdlib.org/findaid/ark:/13030/kt7b69s0dh"
             }
           ],
-          "items": [
+          "holdingsRecords": [
             {
-              "barcode": "6307113-1001",
-              "status": {
-                "name": "Available"
-              },
-              "queueTotalLength": 0,
-              "materialType": null,
-              "chronology": null,
-              "enumeration": null,
-              "effectiveCallNumberComponents": {
-                "callNumber": "SC0801"
-              },
-              "notes": [
+              "callNumber": "SC0801",
+              "discoverySuppress": null,
+              "boundWithItem": null,
+              "items": [
                 {
-                  "note": ".COMMENT. c:pew; removed from 2191 collection",
-                  "itemNoteType": null
+                  "id": "4c5546cc-be22-5e2a-b8d6-5f5ade86b545",
+                  "barcode": "6307113-1001",
+                  "discoverySuppress": false,
+                  "volume": null,
+                  "queueTotalLength": 0,
+                  "status": {
+                    "name": "Available"
+                  },
+                  "dueDate": null,
+                  "materialType": {
+                    "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+                    "name": "book"
+                  },
+                  "chronology": null,
+                  "enumeration": null,
+                  "effectiveCallNumberComponents": {
+                    "callNumber": "SC0801"
+                  },
+                  "notes": [
+                    {
+                      "note": ".COMMENT. c:pew; removed from 2191 collection",
+                      "itemNoteType": {
+                        "name": "Tech Staff"
+                      }
+                    }
+                  ],
+                  "effectiveLocation": {
+                    "id": "635d2ddc-c7a1-46ce-b46d-336f1384c4dc",
+                    "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                    "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code": "SPEC-U-ARCHIVES",
+                    "discoveryDisplayName": "University Archives",
+                    "name": "Spec U-Archives",
+                    "servicePoints": [
+                      {
+                        "id": "0e924af7-785c-46eb-a5e2-060394822016",
+                        "code": "SPEC",
+                        "pickupLocation": true
+                      }
+                    ],
+                    "library": {
+                      "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "code": "SPEC-COLL"
+                    },
+                    "campus": {
+                      "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "code": "SUL"
+                    },
+                    "details": {
+                      "pageAeonSite": "SPECUA",
+                      "pageMediationGroupKey": null,
+                      "pageServicePoints": [],
+                      "scanServicePointCode": null,
+                      "availabilityClass": null,
+                      "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                    }
+                  },
+                  "permanentLocation": null,
+                  "temporaryLocation": null,
+                  "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                  "temporaryLoanTypeId": null,
+                  "holdingsRecord": {
+                    "id": "e7279a91-f912-5f8b-a420-f082e542e3cc",
+                    "effectiveLocation": {
+                      "id": "635d2ddc-c7a1-46ce-b46d-336f1384c4dc",
+                      "code": "SPEC-U-ARCHIVES",
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "pagingSchedule": null,
+                        "scanServicePointCode": null
+                      }
+                    }
+                  },
+                  "boundWithHoldingsPerItem": []
                 }
-              ],
-              "effectiveLocation": {
-                "id": "635d2ddc-c7a1-46ce-b46d-336f1384c4dc",
-                "campus": {
-                  "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                  "code": "SUL"
-                },
-                "library": {
-                  "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
-                },
-                "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                "code": "SPEC-U-ARCHIVES",
-                "discoveryDisplayName": "University Archives",
-                "name": "Spec U-Archives",
-                "details": {}
-              },
-              "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-              "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-              "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-              "temporaryLoanTypeId": null
+              ]
             },
             {
-              "barcode": "36105116223418",
-              "status": {
-                "name": "Available"
-              },
-              "queueTotalLength": 0,
-              "materialType": null,
-              "chronology": null,
-              "enumeration": "BOX 1",
-              "effectiveCallNumberComponents": {
-                "callNumber": "SC0801"
-              },
-              "notes": [],
-              "effectiveLocation": {
-                "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
-                "campus": {
-                  "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                  "code": "SUL"
+              "callNumber": "SC0801",
+              "discoverySuppress": false,
+              "boundWithItem": null,
+              "items": [
+                {
+                  "id": "86029649-5bc9-5ee5-8a46-bede3e1e7c8e",
+                  "barcode": "36105116223434",
+                  "discoverySuppress": false,
+                  "volume": null,
+                  "queueTotalLength": 0,
+                  "status": {
+                    "name": "Available"
+                  },
+                  "dueDate": null,
+                  "materialType": {
+                    "id": "69edaa1b-e40b-4f1c-8cb5-4b615ac6a664",
+                    "name": "archival"
+                  },
+                  "chronology": null,
+                  "enumeration": "BOX 3",
+                  "effectiveCallNumberComponents": {
+                    "callNumber": "SC0801"
+                  },
+                  "notes": [],
+                  "effectiveLocation": {
+                    "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                    "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                    "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code": "SPEC-SAL3-U-ARCHIVES",
+                    "discoveryDisplayName": "University Archives",
+                    "name": "Spec SAL3 U-Archives",
+                    "servicePoints": [
+                      {
+                        "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
+                        "code": "SAL3",
+                        "pickupLocation": false
+                      }
+                    ],
+                    "library": {
+                      "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "code": "SPEC-COLL"
+                    },
+                    "campus": {
+                      "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "code": "SUL"
+                    },
+                    "details": {
+                      "pageAeonSite": "SPECUA",
+                      "pageMediationGroupKey": null,
+                      "pageServicePoints": [],
+                      "scanServicePointCode": null,
+                      "availabilityClass": null,
+                      "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                    }
+                  },
+                  "permanentLocation": null,
+                  "temporaryLocation": null,
+                  "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                  "temporaryLoanTypeId": null,
+                  "holdingsRecord": {
+                    "id": "ff3f34d8-8d01-5317-bbf3-d8d265ca06fc",
+                    "effectiveLocation": {
+                      "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                      "code": "SPEC-SAL3-U-ARCHIVES",
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "pagingSchedule": null,
+                        "scanServicePointCode": null
+                      }
+                    }
+                  },
+                  "boundWithHoldingsPerItem": []
                 },
-                "library": {
-                  "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
+                {
+                  "id": "d721f44c-f37c-5cfc-b1b9-d4a45e49de3a",
+                  "barcode": "36105116223418",
+                  "discoverySuppress": false,
+                  "volume": null,
+                  "queueTotalLength": 0,
+                  "status": {
+                    "name": "Available"
+                  },
+                  "dueDate": null,
+                  "materialType": {
+                    "id": "69edaa1b-e40b-4f1c-8cb5-4b615ac6a664",
+                    "name": "archival"
+                  },
+                  "chronology": null,
+                  "enumeration": "BOX 1",
+                  "effectiveCallNumberComponents": {
+                    "callNumber": "SC0801"
+                  },
+                  "notes": [],
+                  "effectiveLocation": {
+                    "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                    "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                    "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code": "SPEC-SAL3-U-ARCHIVES",
+                    "discoveryDisplayName": "University Archives",
+                    "name": "Spec SAL3 U-Archives",
+                    "servicePoints": [
+                      {
+                        "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
+                        "code": "SAL3",
+                        "pickupLocation": false
+                      }
+                    ],
+                    "library": {
+                      "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "code": "SPEC-COLL"
+                    },
+                    "campus": {
+                      "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "code": "SUL"
+                    },
+                    "details": {
+                      "pageAeonSite": "SPECUA",
+                      "pageMediationGroupKey": null,
+                      "pageServicePoints": [],
+                      "scanServicePointCode": null,
+                      "availabilityClass": null,
+                      "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                    }
+                  },
+                  "permanentLocation": null,
+                  "temporaryLocation": null,
+                  "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                  "temporaryLoanTypeId": null,
+                  "holdingsRecord": {
+                    "id": "ff3f34d8-8d01-5317-bbf3-d8d265ca06fc",
+                    "effectiveLocation": {
+                      "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                      "code": "SPEC-SAL3-U-ARCHIVES",
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "pagingSchedule": null,
+                        "scanServicePointCode": null
+                      }
+                    }
+                  },
+                  "boundWithHoldingsPerItem": []
                 },
-                "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                "code": "SPEC-SAL3-U-ARCHIVES",
-                "discoveryDisplayName": "University Archives",
-                "name": "Spec SAL3 U-Archives",
-                "details": {}
-              },
-              "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-              "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-              "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-              "temporaryLoanTypeId": null
-            },
-            {
-              "barcode": "36105116223426",
-              "status": {
-                "name": "Available"
-              },
-              "queueTotalLength": 0,
-              "materialType": null,
-              "chronology": null,
-              "enumeration": "BOX 2",
-              "effectiveCallNumberComponents": {
-                "callNumber": "SC0801"
-              },
-              "notes": [],
-              "effectiveLocation": {
-                "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
-                "campus": {
-                  "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                  "code": "SUL"
-                },
-                "library": {
-                  "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
-                },
-                "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                "code": "SPEC-SAL3-U-ARCHIVES",
-                "discoveryDisplayName": "University Archives",
-                "name": "Spec SAL3 U-Archives",
-                "details": {}
-              },
-              "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-              "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-              "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-              "temporaryLoanTypeId": null
-            },
-            {
-              "barcode": "36105116223434",
-              "status": {
-                "name": "Available"
-              },
-              "queueTotalLength": 0,
-              "materialType": null,
-              "chronology": null,
-              "enumeration": "BOX 3",
-              "effectiveCallNumberComponents": {
-                "callNumber": "SC0801"
-              },
-              "notes": [],
-              "effectiveLocation": {
-                "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
-                "campus": {
-                  "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                  "code": "SUL"
-                },
-                "library": {
-                  "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                  "code": "SPEC-COLL"
-                },
-                "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                "code": "SPEC-SAL3-U-ARCHIVES",
-                "discoveryDisplayName": "University Archives",
-                "name": "Spec SAL3 U-Archives",
-                "details": {}
-              },
-              "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-              "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-              "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-              "temporaryLoanTypeId": null
+                {
+                  "id": "abd43d76-e798-5c35-877d-3598e4e49f54",
+                  "barcode": "36105116223426",
+                  "discoverySuppress": false,
+                  "volume": null,
+                  "queueTotalLength": 0,
+                  "status": {
+                    "name": "Available"
+                  },
+                  "dueDate": null,
+                  "materialType": {
+                    "id": "69edaa1b-e40b-4f1c-8cb5-4b615ac6a664",
+                    "name": "archival"
+                  },
+                  "chronology": null,
+                  "enumeration": "BOX 2",
+                  "effectiveCallNumberComponents": {
+                    "callNumber": "SC0801"
+                  },
+                  "notes": [],
+                  "effectiveLocation": {
+                    "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                    "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                    "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                    "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                    "code": "SPEC-SAL3-U-ARCHIVES",
+                    "discoveryDisplayName": "University Archives",
+                    "name": "Spec SAL3 U-Archives",
+                    "servicePoints": [
+                      {
+                        "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
+                        "code": "SAL3",
+                        "pickupLocation": false
+                      }
+                    ],
+                    "library": {
+                      "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "code": "SPEC-COLL"
+                    },
+                    "campus": {
+                      "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "code": "SUL"
+                    },
+                    "details": {
+                      "pageAeonSite": "SPECUA",
+                      "pageMediationGroupKey": null,
+                      "pageServicePoints": [],
+                      "scanServicePointCode": null,
+                      "availabilityClass": null,
+                      "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                    }
+                  },
+                  "permanentLocation": null,
+                  "temporaryLocation": null,
+                  "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                  "temporaryLoanTypeId": null,
+                  "holdingsRecord": {
+                    "id": "ff3f34d8-8d01-5317-bbf3-d8d265ca06fc",
+                    "effectiveLocation": {
+                      "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                      "code": "SPEC-SAL3-U-ARCHIVES",
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "pagingSchedule": null,
+                        "scanServicePointCode": null
+                      }
+                    }
+                  },
+                  "boundWithHoldingsPerItem": []
+                }
+              ]
             }
           ]
         }
@@ -531,16 +711,27 @@ RSpec.describe Folio::Instance do
       let(:instance_response) do
         <<~JSON
           {
-            "id": "a1a88348-363f-5b41-9937-13584daae527",
+            "id": "039f3c69-e115-5494-b036-5716fce3996e",
+            "hrid": "a6307113",
             "title": "Stanford Research Institute records, 1947-1966",
             "identifiers": [
               {
+                "value": "(Sirsi) a6307113",
+                "identifierTypeObject": {
+                  "name": "System control number"
+                }
+              },
+              {
                 "value": "(OCoLC-M)754864063",
-                "identifierTypeObject": null
+                "identifierTypeObject": {
+                  "name": "OCLC"
+                }
               },
               {
                 "value": "(OCoLC-I)755035981",
-                "identifierTypeObject": null
+                "identifierTypeObject": {
+                  "name": "OCLC"
+                }
               }
             ],
             "instanceType": {
@@ -553,154 +744,322 @@ RSpec.describe Folio::Instance do
               }
             ],
             "publication": [],
+            "editions": [],
             "electronicAccess": [
               {
                 "materialsSpecification": "Finding aid available online",
                 "uri": "http://www.oac.cdlib.org/findaid/ark:/13030/kt7b69s0dh"
               }
             ],
-            "items": [
+            "holdingsRecords": [
               {
-                "barcode": "6307113-1001",
-                "status": {
-                  "name": "Available"
-                },
-                "queueTotalLength": 0,
-                "materialType": null,
-                "chronology": null,
-                "enumeration": null,
-                "effectiveCallNumberComponents": {
-                  "callNumber": "SC0801"
-                },
-                "notes": [
+                "callNumber": "SC0801",
+                "discoverySuppress": null,
+                "boundWithItem": null,
+                "items": [
                   {
-                    "note": ".COMMENT. c:pew; removed from 2191 collection",
-                    "itemNoteType": null
+                    "id": "4c5546cc-be22-5e2a-b8d6-5f5ade86b545",
+                    "barcode": "6307113-1001",
+                    "discoverySuppress": false,
+                    "volume": null,
+                    "queueTotalLength": 0,
+                    "status": {
+                      "name": "Available"
+                    },
+                    "dueDate": null,
+                    "materialType": {
+                      "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+                      "name": "book"
+                    },
+                    "chronology": null,
+                    "enumeration": null,
+                    "effectiveCallNumberComponents": {
+                      "callNumber": "SC0801"
+                    },
+                    "notes": [
+                      {
+                        "note": ".COMMENT. c:pew; removed from 2191 collection",
+                        "itemNoteType": {
+                          "name": "Tech Staff"
+                        }
+                      }
+                    ],
+                    "effectiveLocation": {
+                      "id": "635d2ddc-c7a1-46ce-b46d-336f1384c4dc",
+                      "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                      "code": "SPEC-U-ARCHIVES",
+                      "discoveryDisplayName": "University Archives",
+                      "name": "Spec U-Archives",
+                      "servicePoints": [
+                        {
+                          "id": "0e924af7-785c-46eb-a5e2-060394822016",
+                          "code": "SPEC",
+                          "pickupLocation": true
+                        }
+                      ],
+                      "library": {
+                        "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "code": "SPEC-COLL"
+                      },
+                      "campus": {
+                        "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "code": "SUL"
+                      },
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "scanServicePointCode": null,
+                        "availabilityClass": null,
+                        "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                      }
+                    },
+                    "permanentLocation": null,
+                    "temporaryLocation": null,
+                    "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                    "temporaryLoanTypeId": null,
+                    "holdingsRecord": {
+                      "id": "e7279a91-f912-5f8b-a420-f082e542e3cc",
+                      "effectiveLocation": {
+                        "id": "635d2ddc-c7a1-46ce-b46d-336f1384c4dc",
+                        "code": "SPEC-U-ARCHIVES",
+                        "details": {
+                          "pageAeonSite": "SPECUA",
+                          "pageMediationGroupKey": null,
+                          "pageServicePoints": [],
+                          "pagingSchedule": null,
+                          "scanServicePointCode": null
+                        }
+                      }
+                    },
+                    "boundWithHoldingsPerItem": []
                   }
-                ],
-                "effectiveLocation": {
-                  "id": "635d2ddc-c7a1-46ce-b46d-336f1384c4dc",
-                  "campus": {
-                    "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                    "code": "SUL"
-                  },
-                  "library": {
-                    "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
-                  },
-                  "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                  "code": "SPEC-U-ARCHIVES",
-                  "discoveryDisplayName": "University Archives",
-                  "name": "Spec U-Archives",
-                  "details": {}
-                },
-                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-                "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-                "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-                "temporaryLoanTypeId": null
+                ]
               },
               {
-                "barcode": "36105116223418",
-                "status": {
-                  "name": "Available"
-                },
-                "queueTotalLength": 0,
-                "materialType": null,
-                "chronology": null,
-                "enumeration": "BOX 1",
-                "effectiveCallNumberComponents": {
-                  "callNumber": "SC0801"
-                },
-                "notes": [],
-                "effectiveLocation": {
-                  "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
-                  "campus": {
-                    "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                    "code": "SUL"
+                "callNumber": "SC0801",
+                "discoverySuppress": false,
+                "boundWithItem": null,
+                "items": [
+                  {
+                    "id": "86029649-5bc9-5ee5-8a46-bede3e1e7c8e",
+                    "barcode": "36105116223434",
+                    "discoverySuppress": false,
+                    "volume": null,
+                    "queueTotalLength": 0,
+                    "status": {
+                      "name": "Available"
+                    },
+                    "dueDate": null,
+                    "materialType": {
+                      "id": "69edaa1b-e40b-4f1c-8cb5-4b615ac6a664",
+                      "name": "archival"
+                    },
+                    "chronology": null,
+                    "enumeration": "BOX 3",
+                    "effectiveCallNumberComponents": {
+                      "callNumber": "SC0801"
+                    },
+                    "notes": [],
+                    "effectiveLocation": {
+                      "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                      "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                      "code": "SPEC-SAL3-U-ARCHIVES",
+                      "discoveryDisplayName": "University Archives",
+                      "name": "Spec SAL3 U-Archives",
+                      "servicePoints": [
+                        {
+                          "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
+                          "code": "SAL3",
+                          "pickupLocation": false
+                        }
+                      ],
+                      "library": {
+                        "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "code": "SPEC-COLL"
+                      },
+                      "campus": {
+                        "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "code": "SUL"
+                      },
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "scanServicePointCode": null,
+                        "availabilityClass": null,
+                        "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                      }
+                    },
+                    "permanentLocation": null,
+                    "temporaryLocation": null,
+                    "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                    "temporaryLoanTypeId": null,
+                    "holdingsRecord": {
+                      "id": "ff3f34d8-8d01-5317-bbf3-d8d265ca06fc",
+                      "effectiveLocation": {
+                        "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                        "code": "SPEC-SAL3-U-ARCHIVES",
+                        "details": {
+                          "pageAeonSite": "SPECUA",
+                          "pageMediationGroupKey": null,
+                          "pageServicePoints": [],
+                          "pagingSchedule": null,
+                          "scanServicePointCode": null
+                        }
+                      }
+                    },
+                    "boundWithHoldingsPerItem": []
                   },
-                  "library": {
-                    "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
+                  {
+                    "id": "d721f44c-f37c-5cfc-b1b9-d4a45e49de3a",
+                    "barcode": "36105116223418",
+                    "discoverySuppress": false,
+                    "volume": null,
+                    "queueTotalLength": 0,
+                    "status": {
+                      "name": "Available"
+                    },
+                    "dueDate": null,
+                    "materialType": {
+                      "id": "69edaa1b-e40b-4f1c-8cb5-4b615ac6a664",
+                      "name": "archival"
+                    },
+                    "chronology": null,
+                    "enumeration": "BOX 1",
+                    "effectiveCallNumberComponents": {
+                      "callNumber": "SC0801"
+                    },
+                    "notes": [],
+                    "effectiveLocation": {
+                      "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                      "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                      "code": "SPEC-SAL3-U-ARCHIVES",
+                      "discoveryDisplayName": "University Archives",
+                      "name": "Spec SAL3 U-Archives",
+                      "servicePoints": [
+                        {
+                          "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
+                          "code": "SAL3",
+                          "pickupLocation": false
+                        }
+                      ],
+                      "library": {
+                        "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "code": "SPEC-COLL"
+                      },
+                      "campus": {
+                        "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "code": "SUL"
+                      },
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "scanServicePointCode": null,
+                        "availabilityClass": null,
+                        "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                      }
+                    },
+                    "permanentLocation": null,
+                    "temporaryLocation": null,
+                    "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                    "temporaryLoanTypeId": null,
+                    "holdingsRecord": {
+                      "id": "ff3f34d8-8d01-5317-bbf3-d8d265ca06fc",
+                      "effectiveLocation": {
+                        "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                        "code": "SPEC-SAL3-U-ARCHIVES",
+                        "details": {
+                          "pageAeonSite": "SPECUA",
+                          "pageMediationGroupKey": null,
+                          "pageServicePoints": [],
+                          "pagingSchedule": null,
+                          "scanServicePointCode": null
+                        }
+                      }
+                    },
+                    "boundWithHoldingsPerItem": []
                   },
-                  "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                  "code": "SPEC-SAL3-U-ARCHIVES",
-                  "discoveryDisplayName": "University Archives",
-                  "name": "Spec SAL3 U-Archives",
-                  "details": {}
-                },
-                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-                "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-                "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-                "temporaryLoanTypeId": null
-              },
-              {
-                "barcode": "36105116223426",
-                "status": {
-                  "name": "Available"
-                },
-                "queueTotalLength": 0,
-                "materialType": null,
-                "chronology": null,
-                "enumeration": "BOX 2",
-                "effectiveCallNumberComponents": {
-                  "callNumber": "SC0801"
-                },
-                "notes": [],
-                "effectiveLocation": {
-                  "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
-                  "campus": {
-                    "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                    "code": "SUL"
-                  },
-                  "library": {
-                    "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
-                  },
-                  "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                  "code": "SPEC-SAL3-U-ARCHIVES",
-                  "discoveryDisplayName": "University Archives",
-                  "name": "Spec SAL3 U-Archives",
-                  "details": {}
-                },
-                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-                "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-                "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-                "temporaryLoanTypeId": null
-              },
-              {
-                "barcode": "36105116223434",
-                "discoverySuppress": true,
-                "status": {
-                  "name": "Available"
-                },
-                "queueTotalLength": 0,
-                "materialType": null,
-                "chronology": null,
-                "enumeration": "BOX 3",
-                "effectiveCallNumberComponents": {
-                  "callNumber": "SC0801"
-                },
-                "notes": [],
-                "effectiveLocation": {
-                  "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
-                  "campus": {
-                    "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
-                    "code": "SUL"
-                  },
-                  "library": {
-                    "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
-                    "code": "SPEC-COLL"
-                  },
-                  "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                  "code": "SPEC-SAL3-U-ARCHIVES",
-                  "discoveryDisplayName": "University Archives",
-                  "name": "Spec SAL3 U-Archives",
-                  "details": {}
-                },
-                "permanentLocation": { "id": "uuid", "code": "SPEC-STACKS" },
-                "holdingsRecord": { "effectiveLocation": { "code": "SPEC-STACKS" } },
-                "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-                "temporaryLoanTypeId": null
+                  {
+                    "id": "abd43d76-e798-5c35-877d-3598e4e49f54",
+                    "barcode": "36105116223426",
+                    "discoverySuppress": true,
+                    "volume": null,
+                    "queueTotalLength": 0,
+                    "status": {
+                      "name": "Available"
+                    },
+                    "dueDate": null,
+                    "materialType": {
+                      "id": "69edaa1b-e40b-4f1c-8cb5-4b615ac6a664",
+                      "name": "archival"
+                    },
+                    "chronology": null,
+                    "enumeration": "BOX 2",
+                    "effectiveCallNumberComponents": {
+                      "callNumber": "SC0801"
+                    },
+                    "notes": [],
+                    "effectiveLocation": {
+                      "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                      "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                      "libraryId": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                      "institutionId": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                      "code": "SPEC-SAL3-U-ARCHIVES",
+                      "discoveryDisplayName": "University Archives",
+                      "name": "Spec SAL3 U-Archives",
+                      "servicePoints": [
+                        {
+                          "id": "3a306665-eec7-4a40-8f4d-608585b2a394",
+                          "code": "SAL3",
+                          "pickupLocation": false
+                        }
+                      ],
+                      "library": {
+                        "id": "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "code": "SPEC-COLL"
+                      },
+                      "campus": {
+                        "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "code": "SUL"
+                      },
+                      "details": {
+                        "pageAeonSite": "SPECUA",
+                        "pageMediationGroupKey": null,
+                        "pageServicePoints": [],
+                        "scanServicePointCode": null,
+                        "availabilityClass": null,
+                        "searchworksTreatTemporaryLocationAsPermanentLocation": null
+                      }
+                    },
+                    "permanentLocation": null,
+                    "temporaryLocation": null,
+                    "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+                    "temporaryLoanTypeId": null,
+                    "holdingsRecord": {
+                      "id": "ff3f34d8-8d01-5317-bbf3-d8d265ca06fc",
+                      "effectiveLocation": {
+                        "id": "150b8273-b10b-4907-b43f-a3d4f89bc79f",
+                        "code": "SPEC-SAL3-U-ARCHIVES",
+                        "details": {
+                          "pageAeonSite": "SPECUA",
+                          "pageMediationGroupKey": null,
+                          "pageServicePoints": [],
+                          "pagingSchedule": null,
+                          "scanServicePointCode": null
+                        }
+                      }
+                    },
+                    "boundWithHoldingsPerItem": []
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
and introduce `Folio::HoldingsRecord` to match FOLIO data structures (and give us a consistent way to get at the normal + bound-with items).

![Screenshot 2024-05-09 at 14 35 10](https://github.com/sul-dlss/sul-requests/assets/111218/5e35900a-b972-47d7-b715-5b4590661b96)

![Screenshot 2024-05-09 at 14 36 16](https://github.com/sul-dlss/sul-requests/assets/111218/6877ee17-4458-452a-ba8f-eddb934a8604)

![Screenshot 2024-05-09 at 14 36 56](https://github.com/sul-dlss/sul-requests/assets/111218/b63805b9-a390-48dc-b718-85c8fdec28d8)

![Screenshot 2024-05-09 at 14 37 19](https://github.com/sul-dlss/sul-requests/assets/111218/19bf6d0a-26f5-4ade-b62b-44d07818a5f9)
