### PR TITLE
Render the needed after date control for mediated pages with multiple items

### DIFF
--- a/app/views/patron_requests/_not_needed_after_date.html.erb
+++ b/app/views/patron_requests/_not_needed_after_date.html.erb
@@ -1,4 +1,9 @@
 <div class="p-3 pt-0">
-    <%= f.label :needed_date, 'Not needed after', class: 'required-label py-2' %>
-    <%= f.date_field :needed_date, required: true, min: Date.today, value: Time.zone.today + 1.year, class: 'form-control' %>
+    <% if f.object.mediateable? %>
+        <%= f.label :needed_date, 'I plan to visit on:', class: 'required-label py-2' %>
+        <%= f.date_field :needed_date, required: true, min: f.object.earliest_delivery_estimate['date'], value: f.object.earliest_delivery_estimate['date'], class: 'form-control' %>
+    <% else %>
+        <%= f.label :needed_date, 'Not needed after', class: 'required-label py-2' %>
+        <%= f.date_field :needed_date, required: true, min: Date.today, value: Time.zone.today + 1.year, class: 'form-control' %>
+    <% end %>
 </div>

--- a/app/views/patron_requests/_request_preferences.html.erb
+++ b/app/views/patron_requests/_request_preferences.html.erb
@@ -13,5 +13,4 @@
     <%= f.label :fulfillment_type_hold, 'Wait for a Stanford copy to become available', class: 'form-check-label' %>
   </div>
 </fieldset>
-<%= render 'not_needed_after_date', f: %>
 <% end %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -164,6 +164,7 @@
         <% c.with_title.with_content('Pickup request') %>
         <% c.with_body do %>
           <%= render 'pickup_destination', f: %>
+          <%= render 'not_needed_after_date', f: f if f.object.mediateable? && f.object.requires_needed_date? %>
 
           <div class="selected-items-group">
             <div class="card">
@@ -201,6 +202,9 @@
                 <ul data-itemselector-target="unavailableItems" class="list-unstyled d-flex flex-wrap gap-2 p-3 m-0"></ul>
                 <hr class="styled-hr">
                 <%= render 'request_preferences', f: %>
+                <% if f.object.holdable_recallable_items.any? && !f.object.mediateable? %>
+                  <%= render 'not_needed_after_date', f: %>
+                <% end %>
               </div>
             </div>
           </div>
@@ -315,14 +319,10 @@
                 </div>
               </div>
             </div>
-            <% if f.object.requires_needed_date? %>
-                <%= f.label :needed_date, 'I plan to visit on:', :class => 'required-label py-2' %>
-                <%= f.date_field :needed_date, :required => true, value:  f.object.earliest_delivery_estimate['date'], min: f.object.earliest_delivery_estimate['date'], class: 'd-block rounded border mb-4' %>
-            <% end %>
         <% end %>
         <%= render 'pickup_destination', f: %>
         <%= render 'request_preferences', f: %>
-        <% if f.object.title_only? %>
+        <% if f.object.holdable_recallable_items.any? || f.object.requires_needed_date? || f.object.title_only? %>
           <%= render 'not_needed_after_date', f: %>
         <% end %>
       <% end %>


### PR DESCRIPTION
E.g. https://searchworks.stanford.edu/view/5324386 requires a needed by date, even though the items are technically "available".