### PR TITLE
Remove mediation notice for e.g. SAL3-PAGE-MP

### DIFF
--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -307,7 +307,7 @@
             <%= queue_length_display(f.object.selectable_items.first, prefix: 'Item status: ', title_only: f.object.title_only?) %>
           </div>
         </div>
-        <% if f.object.mediateable? %>
+        <% if f.object.mediateable? && f.object.requires_needed_date? %>
             <div class="alert alert-info d-flex" role="alert">
               <div class="bi bi-info-circle-fill d-flex justify-content-center display-6 col-1 ms-3 align-self-center text-primary"></div>
               <div class="p-3 flex-grow-1">


### PR DESCRIPTION
Fixes #2452 (by suppressing the notice that suggests the object is mediated at all... which is apparently the desired behavior from years ago 🤷‍♂️ )