### PR TITLE
Send the patron-provided author to Illiad for scan requests

### DIFF
--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -456,7 +456,7 @@ class PatronRequest < ApplicationRecord
                                     RequestType: 'Article',
                                     SpecIns: 'Scan and Deliver Request',
                                     PhotoJournalTitle: bib_data.title,
-                                    PhotoArticleAuthor: bib_data.author,
+                                    PhotoArticleAuthor: scan_authors,
                                     Location: origin_library_code,
                                     ReferenceNumber: origin_location_code,
                                     PhotoArticleTitle: scan_title,

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe 'Creating a request', :js do
         expect(page).to have_content 'Copyright notice'
         fill_in 'Page range', with: '1-15'
         fill_in 'Title of article or chapter', with: 'Some title'
+        fill_in 'Author(s)', with: 'Some author'
 
         expect do
           perform_enqueued_jobs do
@@ -105,6 +106,11 @@ RSpec.describe 'Creating a request', :js do
           end
           expect(page).to have_content 'We received your scan request'
         end.to change(PatronRequest, :count).by(1)
+
+        expect(PatronRequest.last).to have_attributes(
+          scan_title: 'Some title',
+          scan_authors: 'Some author'
+        )
       end
     end
 

--- a/spec/models/patron_request_spec.rb
+++ b/spec/models/patron_request_spec.rb
@@ -426,4 +426,27 @@ RSpec.describe PatronRequest do
       end
     end
   end
+
+  describe '#illiad_request_params' do
+    let(:bib_data) { build(:scannable_holdings) }
+    let(:item) { bib_data.items.first }
+
+    context 'when request type is scan' do
+      let(:attr) { { request_type:, scan_authors:, scan_title:, scan_page_range:, origin_location_code: 'SAL3-STACKS' } }
+      let(:request_type) { 'scan' }
+      let(:scan_authors) { 'Scan Authors' }
+      let(:scan_title) { 'Scan Title' }
+      let(:scan_page_range) { '1-10' }
+
+      it 'returns the correct ILLiad request params for scan request' do
+        expect(request.illiad_request_params(item)).to include(
+          RequestType: 'Article',
+          ItemNumber: item.barcode,
+          PhotoArticleTitle: scan_title,
+          PhotoJournalInclusivePages: scan_page_range,
+          PhotoArticleAuthor: scan_authors
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a regression from the old `Illiadable` logic: https://github.com/sul-dlss/sul-requests/pull/1898

Fixes VUF-9795