### PR TITLE
Add a location detail to indicate we prefer to send the request to Illiad

### DIFF
--- a/app/controllers/paging_schedule_controller.rb
+++ b/app/controllers/paging_schedule_controller.rb
@@ -11,7 +11,7 @@ class PagingScheduleController < ApplicationController
   end
 
   before_action only: [:show, :open] do
-    render plain: 'Locations not found', status: :not_found unless params[:origin].present? && params[:destination].present?
+    render plain: 'Locations not found', status: :not_found unless params[:origin_library].present? && params[:destination].present?
   end
 
   before_action :load_schedule, only: [:show, :open]
@@ -47,14 +47,22 @@ class PagingScheduleController < ApplicationController
   private
 
   def load_schedule
-    @schedule = PagingSchedule.for(request_for_schedule)
+    @schedule = PagingSchedule.for(from: origin_location, to: destination_library_code, library_code: fallback_library_code)
   end
 
-  def request_for_schedule
-    Request.new(
-      origin: params[:origin],
-      origin_location: params[:origin_location],
-      destination: params[:destination]
-    )
+  def origin_location
+    @origin_location ||= Folio::Types.locations.find_by(code: params[:origin_location])
+  end
+
+  def destination_library_code
+    params[:destination]
+  end
+
+  def fallback_library_code
+    return origin_location.library.code if origin_location.present?
+
+    Honeybadger.notify('PagingScheduleController#load_schedule: origin_location not found', context: { params: })
+
+    params[:origin_library]
   end
 end

--- a/app/controllers/paging_schedule_controller.rb
+++ b/app/controllers/paging_schedule_controller.rb
@@ -53,6 +53,7 @@ class PagingScheduleController < ApplicationController
   def request_for_schedule
     Request.new(
       origin: params[:origin],
+      origin_location: params[:origin_location],
       destination: params[:destination]
     )
   end

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -189,7 +189,7 @@ export default class extends Controller {
 
   async updateEarliestAvailable(event) {
     if (this.hasEarliestAvailableTarget) {
-      const url = new URL(this.earliestAvailableTarget.src + "/../" + event.currentTarget.value);
+      const url = new URL(this.earliestAvailableTarget.src.replace(/\/to\/[^/\?]+/, '/to/' + event.currentTarget.value));
       this.earliestAvailableTarget.src = url;
     }
 

--- a/app/jobs/submit_patron_request_job.rb
+++ b/app/jobs/submit_patron_request_job.rb
@@ -41,12 +41,13 @@ class SubmitPatronRequestJob < ApplicationJob
   #   The item can be recalled, AND
   #     The item has a status indicating it won't be available soon, OR
   #     The item has an existing request queue
-  def send_to_illiad?(patron_request, item) # rubocop:disable Metrics/CyclomaticComplexity
+  def send_to_illiad?(patron_request, item) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     return true if patron_request.scan?
     return false unless patron_request.patron&.ilb_eligible?
     return true if item.status == Folio::Item::STATUS_AGED_TO_LOST
     return false unless patron_request.fulfillment_type == 'recall'
     return false unless item.hold_recallable?(patron_request.patron)
+    return true if item.illiad_preferred?
 
     item.status.in?(illiad_recall_statuses) || item.queue_length.positive?
   end

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -210,6 +210,10 @@ module Folio
       permanent_location.details['pageAeonSite']
     end
 
+    def illiad_preferred?
+      permanent_location.pages_prefer_to_send_via_illiad?
+    end
+
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def self.from_hash(dyn)
       new(id: dyn['id'],

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -28,5 +28,9 @@ module Folio
     def library
       to_h[:library] || Folio::Types.libraries.find_by(id: library_id)
     end
+
+    def pages_prefer_to_send_via_illiad?
+      details['pagePreferSendIlliad'] == 'true'
+    end
   end
 end

--- a/app/models/paging_schedule.rb
+++ b/app/models/paging_schedule.rb
@@ -17,6 +17,7 @@ module PagingSchedule
 
       schedule_or_default = schedule_for_request(request) || default_schedule(request)
       raise ScheduleNotFound unless schedule_or_default.present?
+      raise ScheduleNotFound if request.folio_location&.pages_prefer_to_send_via_illiad?
 
       schedule_or_default
     end

--- a/app/models/paging_schedule.rb
+++ b/app/models/paging_schedule.rb
@@ -4,7 +4,7 @@
 #  PagingSchedule takes a requested item and can
 #  read the paging schedule configuration and estimate a date of arrival.
 ###
-module PagingSchedule
+class PagingSchedule
   class << self
     def schedule
       @schedule ||= Settings.paging_schedule.map do |sched|
@@ -12,50 +12,78 @@ module PagingSchedule
       end
     end
 
-    def for(request, scan: false)
-      return schedule_for_request_scan(request) if scan
+    def for(from:, to:, scan: false, library_code: nil)
+      instance = new(from:, to:, library_code:)
 
-      schedule_or_default = schedule_for_request(request) || default_schedule(request)
-      raise ScheduleNotFound unless schedule_or_default.present?
-      raise ScheduleNotFound if request.folio_location&.pages_prefer_to_send_via_illiad?
-
-      schedule_or_default
+      if scan
+        instance.schedule_for_request_scan
+      else
+        instance.schedule_for_request
+      end
     end
 
     def worst_case_delivery_day
       (Time.zone.today + worst_case_days_later.days)
     end
 
-    private
-
-    def schedule_for_request(request)
-      schedule.detect do |sched|
-        sched.from == request.origin_library_code &&
-          sched.to == request.destination_library_code &&
-          sched.by_time?(request.created_at)
-      end
-    end
-
-    def schedule_for_request_scan(request)
-      schedule.detect do |sched|
-        sched.from == request.origin_library_code &&
-          sched.to == request.scan_code &&
-          sched.by_time?(request.created_at)
-      end
-    end
-
-    def default_schedule(request)
-      s = schedule.detect do |sched|
-        sched.from == request.origin_library_code &&
-          sched.to == :anywhere &&
-          sched.by_time?(request.created_at)
-      end
-      s&.for(request.destination_library_code)
-    end
-
     def worst_case_days_later
       schedule.filter_map(&:business_days_later).max + Settings.worst_case_paging_padding
     end
+  end
+
+  attr_reader :from, :to, :library_code, :time
+
+  def initialize(from:, to:, time: nil, library_code: nil)
+    @from = from
+    @to = to
+    @library_code = library_code
+    @time = time || Time.zone.now
+  end
+
+  def schedule
+    self.class.schedule
+  end
+
+  def schedule_for_request
+    schedule_or_default = schedule_for_destination || default_schedule
+
+    raise ScheduleNotFound unless schedule_or_default.present?
+    raise ScheduleNotFound if from&.pages_prefer_to_send_via_illiad?
+
+    schedule_or_default
+  end
+
+  def schedule_for_request_scan
+    schedule.detect do |sched|
+      sched.from == origin_library_code &&
+        sched.to == destination_library_code &&
+        sched.by_time?(time)
+    end
+  end
+
+  def schedule_for_destination
+    schedule.detect do |sched|
+      sched.from == origin_library_code &&
+        sched.to == destination_library_code &&
+        sched.by_time?(time)
+    end
+  end
+
+  def default_schedule
+    s = schedule.detect do |sched|
+      sched.from == origin_library_code &&
+        sched.to == :anywhere &&
+        sched.by_time?(time)
+    end
+    s&.for(to)
+  end
+
+  def origin_library_code
+    from&.library&.code || @library_code
+  end
+
+  def destination_library_code
+    @destination_library_code ||= Settings.ils.pickup_destination_class.constantize.new(to).library_code || to
   end
 
   ###
@@ -93,8 +121,7 @@ module PagingSchedule
       @will_arrive_text ||= will_arrive_after
     end
 
-    def by_time?(created_at = nil)
-      created_at ||= Time.zone.now
+    def by_time?(created_at)
       case
       when before
         created_at < Time.zone.parse(before)

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -285,7 +285,8 @@ class PatronRequest < ApplicationRecord
   # @return [Hash] the earliest delivery estimate for the request
   def earliest_delivery_estimate(scan: false)
     if any_items_avaliable?
-      paging_info = PagingSchedule.for(self, scan:).earliest_delivery_estimate
+      paging_info = PagingSchedule.for(from: folio_location, to: default_service_point_code, time: created_at,
+                                       scan:).earliest_delivery_estimate
       { 'date' => Date.parse(paging_info.to_s), 'display_date' => paging_info.to_s }
     else
       { 'date' => Time.zone.today, 'display_date' => 'No date/time estimate' }

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -58,6 +58,12 @@ class Request < ActiveRecord::Base
     @library_location ||= LibraryLocation.new(origin, origin_location)
   end
 
+  # Get the FOLIO location object for the origin location code.
+  # @return [Folio::Location]
+  def folio_location
+    @folio_location ||= Folio::Types.locations.find_by(code: library_location.folio_location_code)
+  end
+
   def active_messages
     library_location.active_messages.for_type(Message.notification_type(self))
   end

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -230,7 +230,7 @@
                         <% if f.object.pickup_destinations.one? && f.object.earliest_delivery_estimate %>
                           <%= f.object.earliest_delivery_estimate['display_date'] %>
                         <% else %>
-                          <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin: f.object.origin_library_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
+                          <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin: f.object.origin_library_code, origin_location: f.object.origin_location_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
                             Loading..
                           <% end %>
                         <% end %>
@@ -350,7 +350,7 @@
           <% if f.object.pickup_destinations.one? && f.object.earliest_delivery_estimate %>
             <%= f.object.earliest_delivery_estimate['display_date'] %>
           <% elsif f.object.any_items_avaliable? %>
-            <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin: f.object.origin_library_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
+            <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin: f.object.origin_library_code, origin_location: f.object.origin_location_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
               Loading..
             <% end %>
           <% else %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -230,7 +230,7 @@
                         <% if f.object.pickup_destinations.one? && f.object.earliest_delivery_estimate %>
                           <%= f.object.earliest_delivery_estimate['display_date'] %>
                         <% else %>
-                          <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin: f.object.origin_library_code, origin_location: f.object.origin_location_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
+                          <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin_library: f.object.origin_library_code, origin_location: f.object.origin_location_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
                             Loading..
                           <% end %>
                         <% end %>
@@ -350,7 +350,7 @@
           <% if f.object.pickup_destinations.one? && f.object.earliest_delivery_estimate %>
             <%= f.object.earliest_delivery_estimate['display_date'] %>
           <% elsif f.object.any_items_avaliable? %>
-            <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin: f.object.origin_library_code, origin_location: f.object.origin_location_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
+            <%= turbo_frame_tag('earliestAvailable', src: paging_schedule_url(origin_library: f.object.origin_library_code, origin_location: f.object.origin_location_code, destination: f.object.service_point_code || f.object.default_service_point_code), data: { 'patronRequest-target' => 'earliestAvailable'}) do %>
               Loading..
             <% end %>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,8 @@ Rails.application.routes.draw do
   post '/sessions/register_visitor', to: 'sessions#register_visitor', as: :register_visitor
 
   resources :paging_schedule, only: :index
-  get 'paging_schedule/:origin(/:destination)' => 'paging_schedule#show', as: :paging_schedule
-  get 'paging_schedule/:origin/:destination/:date' => 'paging_schedule#open', as: :open_hours
+  get 'paging_schedule/from/:origin_library(/to/:destination)' => 'paging_schedule#show', as: :paging_schedule
+  get 'paging_schedule/from/:origin_library/to/:destination/:date' => 'paging_schedule#open', as: :open_hours
 
   get 'circ-check' => 'circ_check#index', as: :circ_check
   post 'circ-check' => 'circ_check#show', as: :circ_check_item

--- a/spec/controllers/paging_schedule_controller_spec.rb
+++ b/spec/controllers/paging_schedule_controller_spec.rb
@@ -31,24 +31,24 @@ RSpec.describe PagingScheduleController do
       let(:estimate) { double(earliest_delivery_estimate: { a: 'a', b: 'b' }) }
 
       it 'is accessible by anonymous users' do
-        get :show, params: { origin: 'SAL3', destination: 'GREEN' }
+        get :show, params: { origin_library: 'SAL3', origin_location: 'UNKNOWN', destination: 'GREEN' }
         expect(response).to be_successful
       end
 
       it 'returns json when requested' do
-        get :show, params: { origin: 'SAL3', destination: 'GREEN', format: 'json' }
+        get :show, params: { origin_library: 'SAL3', origin_location: 'UNKNOWN', destination: 'GREEN', format: 'json' }
         expect(response.parsed_body).to eq('a' => 'a', 'b' => 'b')
       end
 
       it 'returns the estimate as a string when HTML is requested' do
-        get :show, params: { origin: 'SAL3', destination: 'GREEN', format: 'html' }
+        get :show, params: { origin_library: 'SAL3', origin_location: 'UNKNOWN', destination: 'GREEN', format: 'html' }
         expect(response.body).to have_content('{:a=>"a", :b=>"b"}')
       end
     end
 
     describe 'when both the origin and destination are not present' do
       it 'responds with a 404' do
-        get :show, params: { origin: 'SAL3' }
+        get :show, params: { origin_library: 'SAL3' }
         expect(response).not_to be_successful
         expect(response).to have_http_status :not_found
       end
@@ -60,7 +60,7 @@ RSpec.describe PagingScheduleController do
       end
 
       it 'responds with a 404 error' do
-        get :show, params: { origin: 'DOES-NOT-EXIST', destination: 'NOT-REAL' }
+        get :show, params: { origin_library: 'DOES-NOT-EXIST', origin_location: 'UNKNOWN', destination: 'NOT-REAL' }
         expect(response).not_to be_successful
         expect(response).to have_http_status :not_found
       end
@@ -70,7 +70,7 @@ RSpec.describe PagingScheduleController do
   describe 'open' do
     context 'with a bad date' do
       it 'responds with a 404' do
-        get :open, params: { origin: 'SAL3', destination: 'GREEN', date: 'tomorrow' }
+        get :open, params: { origin_library: 'SAL3', origin_location: 'UNKNOWN', destination: 'GREEN', date: 'tomorrow' }
 
         expect(response).not_to be_successful
         expect(response).to have_http_status :not_found
@@ -85,7 +85,7 @@ RSpec.describe PagingScheduleController do
       let(:estimate) { double(valid?: true) }
 
       it 'return a success code' do
-        get :open, params: { origin: 'SAL3', destination: 'GREEN', date: '2015-05-12' }
+        get :open, params: { origin_library: 'SAL3', origin_location: 'UNKNOWN', destination: 'GREEN', date: '2015-05-12' }
 
         expect(response).to be_successful
         expect(response.body).to eq 'true'
@@ -100,7 +100,7 @@ RSpec.describe PagingScheduleController do
       let(:estimate) { double(valid?: false) }
 
       it 'returns an error' do
-        get :open, params: { origin: 'SAL3', destination: 'GREEN', date: '2015-05-12' }
+        get :open, params: { origin_library: 'SAL3', origin_location: 'UNKNOWN', destination: 'GREEN', date: '2015-05-12' }
 
         expect(response).to be_successful
         expect(response.body).to eq 'false'

--- a/spec/jobs/submit_patron_request_job_spec.rb
+++ b/spec/jobs/submit_patron_request_job_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe SubmitPatronRequestJob do
       end
     end
 
+    context 'when the item is in a library that we prefer to send to ILLiad' do
+      before do
+        allow(bib_data.items[0]).to receive(:illiad_preferred?).and_return(true)
+      end
+
+      it 'requests items via ILLiad' do
+        described_class.perform_now(request)
+        expect(SubmitIlliadPatronRequestJob).to have_received(:perform_now).with(request, bib_data.items[0].id)
+      end
+    end
+
     context 'when the item has a request queue' do
       before do
         allow(bib_data.items[0]).to receive(:queue_length).and_return(1)

--- a/spec/models/paging_schedule_spec.rb
+++ b/spec/models/paging_schedule_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe PagingSchedule do
         described_class.for(build(:page, origin: 'DOES-NOT-EXIST', destination: 'SOMEWHERE-ELSE'))
       end.to raise_error(PagingSchedule::ScheduleNotFound)
     end
+
+    it 'raises an error if the location is probably sending via ILLiad' do
+      page = build(:page, origin: 'SAL3', destination: 'GREEN')
+      allow(page).to receive(:folio_location).and_return(double(pages_prefer_to_send_via_illiad?: true))
+      expect do
+        described_class.for(page)
+      end.to raise_error(PagingSchedule::ScheduleNotFound)
+    end
   end
 
   describe '.worst_case_delivery_day' do


### PR DESCRIPTION
... and refactor `PagingSchedule` to decouple it from the old `Request` model (and know something about the origin location, so we don't provide estimates for those Illiad-prefered locations.