### PR TITLE
Allow the `pagingSchedule` location detail to override the FOLIO library code used for paging schedules

### DIFF
--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -32,5 +32,9 @@ module Folio
     def pages_prefer_to_send_via_illiad?
       details['pagePreferSendIlliad'] == 'true'
     end
+
+    def paging_schedule_origin_library_code
+      details['pagingSchedule'] || library&.code
+    end
   end
 end

--- a/app/models/paging_schedule.rb
+++ b/app/models/paging_schedule.rb
@@ -79,7 +79,7 @@ class PagingSchedule
   end
 
   def origin_library_code
-    from&.library&.code || @library_code
+    from&.paging_schedule_origin_library_code || @library_code
   end
 
   def destination_library_code
@@ -127,6 +127,8 @@ class PagingSchedule
         created_at < Time.zone.parse(before)
       when after
         created_at >= Time.zone.parse(after)
+      else # the schedule doesn't specify before/after
+        true
       end
     end
 

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -77,6 +77,17 @@ FactoryBot.define do
     details { { 'pageAeonSite' => 'SPECUA' } }
   end
 
+  factory :prefer_illiad_location, parent: :location do
+    code { 'SAL-PAGE-GR' }
+    details { { 'pagePreferSendIlliad' => 'true' } }
+  end
+
+  factory :paging_schedule_override_location, parent: :location do
+    code { 'GRE-HH-SVA' }
+    library { Folio::Library.new(id: 'f6b5519e-88d9-413e-924d-9ed96255f72e', code: 'GREEN') }
+    details { { 'pagingSchedule' => 'SVA' } }
+  end
+
   factory :book_material_type, class: 'Folio::MaterialType' do
     id { '1a54b431-2e4f-452d-9cae-9cee66c9a892' }
     name { 'book' }


### PR DESCRIPTION
We were using this with the old `Request` implementation, but dropped it in the `PatronRequest` re-write for some unknown reason.

We use this for pageable locations that keep different hours from their actual library (e.g. coordinate SAL3 locations, or (soon) GRE-HH-SVA). 