### PR TITLE
updating the logo

### DIFF
--- a/app/assets/stylesheets/application_redesign.scss
+++ b/app/assets/stylesheets/application_redesign.scss
@@ -330,12 +330,18 @@ label.btn-close {
   text-wrap: nowrap;
 }
 
+// Temporary styles copied from the component library. Remove after moving to the component library.
 .navbar-logo {
-  background-color: #{$su-cardinal};
-  mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/StanfordLibraries-logo.svg");
-  mask-repeat: no-repeat;
-  mask-position: 0 center;
   overflow: hidden;
   text-indent: 100%;
   white-space: nowrap;
+  width: 250px;
+
+  &.polychrome {
+    background-color: transparent;
+    mask-image: none;
+    background-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-02-20/styles/StanfordLibraries-logo-poly.svg");
+    background-repeat: no-repeat;
+    background-position: 0 center;
+  }
 }

--- a/app/assets/stylesheets/application_redesign.scss
+++ b/app/assets/stylesheets/application_redesign.scss
@@ -330,7 +330,7 @@ label.btn-close {
   text-wrap: nowrap;
 }
 
-.navbar-logo, .prefooter-logo {
+.navbar-logo {
   background-color: #{$su-cardinal};
   mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/StanfordLibraries-logo.svg");
   mask-repeat: no-repeat;

--- a/app/assets/stylesheets/application_redesign.scss
+++ b/app/assets/stylesheets/application_redesign.scss
@@ -329,3 +329,13 @@ label.btn-close {
 .status.availability {
   text-wrap: nowrap;
 }
+
+.navbar-logo, .prefooter-logo {
+  background-color: #{$su-cardinal};
+  mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/StanfordLibraries-logo.svg");
+  mask-repeat: no-repeat;
+  mask-position: 0 center;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+}

--- a/app/views/shared/_sul_header.html.erb
+++ b/app/views/shared/_sul_header.html.erb
@@ -2,7 +2,7 @@
 <div id="sul-header" class="bg-white text-cardinal py-1 fs-7">
   <div class="container d-flex flex-column flex-sm-row gap-1 gap-sm-0 justify-content-between align-items-center">
  
-    <a class="navbar-logo mb-1" 
+    <a class="navbar-logo mb-0" 
       href="https://library.stanford.edu"
       >Stanford University Libraries
     </a>

--- a/app/views/shared/_sul_header.html.erb
+++ b/app/views/shared/_sul_header.html.erb
@@ -2,10 +2,11 @@
 <div id="sul-header" class="bg-white text-cardinal py-1 fs-7">
   <div class="container d-flex flex-column flex-sm-row gap-1 gap-sm-0 justify-content-between align-items-center">
  
-    <a class="navbar-logo mb-0" 
+    <a
+      class="mb-0 navbar-brand navbar-logo polychrome"
       href="https://library.stanford.edu"
-      >Stanford University Libraries
-    </a>
+      >Stanford University Libraries</a
+    >
     <nav aria-label="header menu">
       <ul class="list-unstyled d-flex gap-4 m-0">
         <% if current_user.sso_user? || current_user.library_id_user? %>

--- a/app/views/shared/_sul_header.html.erb
+++ b/app/views/shared/_sul_header.html.erb
@@ -1,11 +1,11 @@
 <!-- SUL header -->
 <div id="sul-header" class="bg-white text-cardinal py-1 fs-7">
   <div class="container d-flex flex-column flex-sm-row gap-1 gap-sm-0 justify-content-between align-items-center">
-    <%= link_to 'https://library.stanford.edu' do %>
-      <%= tag.span t('.sul'), class: "visually-hidden" %>
-      <%= image_tag "sul-logo.svg", class: "sul-logo d-none d-md-block", alt: "", height: 25 %>
-      <%= image_tag "sul-logo-stacked.svg", class: "sul-logo d-md-none", alt: "", height: 25 %>
-    <% end %>
+ 
+    <a class="navbar-logo mb-1" 
+      href="https://library.stanford.edu"
+      >Stanford University Libraries
+    </a>
     <nav aria-label="header menu">
       <ul class="list-unstyled d-flex gap-4 m-0">
         <% if current_user.sso_user? || current_user.library_id_user? %>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Home Page' do
 
     it 'renders the page' do
       expect(page).to have_title('Requests : Stanford Libraries')
-      expect(page).to have_css('.sul-logo')
+      expect(page).to have_css('.navbar-logo')
       expect(page).to have_link('My Account')
       expect(page).to have_link('Feedback')
 


### PR DESCRIPTION
What this PR does:
Replace the SUL logo with the new logo.

Before:
![Screenshot 2025-01-31 at 3 36 11 PM](https://github.com/user-attachments/assets/5e8bcfd6-f94f-4ff7-975f-6a5108e575b7)


After:
![Screenshot 2025-01-31 at 3 45 28 PM](https://github.com/user-attachments/assets/0fc8db55-a1d3-49cf-b7cc-6faa91f81e36)



Note: There is a 1 px height difference between the updated white bar and the old one. Hopefully that is ok. 