### PR TITLE
Update alert text when a Library cardholder tries to page an item for which they are ineligible based on folio circrules.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,15 +9,15 @@ class Ability
   include CanCan::Ability
 
   def self.anonymous
-    @anonymous ||= Ability.new(User.new(name: 'generic', email: 'external-user@example.com'))
+    @anonymous ||= Ability.new(NullUser.new(name: 'generic', email: 'external-user@example.com'))
   end
 
   def self.with_a_library_id
-    @with_a_library_id ||= Ability.new(User.new(library_id: '0000000000'))
+    @with_a_library_id ||= Ability.new(NullUser.new(library_id: '0000000000'))
   end
 
   def self.sso
-    @sso ||= Ability.new(User.new(sunetid: 'generic'))
+    @sso ||= Ability.new(NullUser.new(sunetid: 'generic'))
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
@@ -94,7 +94,7 @@ class Ability
     can :create, Scan if user.super_admin? || in_scan_pilot_group?(user)
 
     # ... and to check the status, you either need to be logged in or include a special token in the URL
-    can :read, [Request, Page, HoldRecall, Scan, MediatedPage], user_id: user.id if user.sso_user?
+    can :read, [Request, Page, HoldRecall, Scan, MediatedPage], user_id: user.id if user.sso_user? && user.id
 
     can :new, PatronRequest do |request|
       request.aeon_page? || can?(:request_pickup, request) || can?(:request_scan, request)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,6 +20,10 @@ class Ability
     @sso ||= Ability.new(NullUser.new(sunetid: 'generic'))
   end
 
+  def self.faculty
+    @faculty ||= Ability.new(NullUser.new(sunetid: 'generic', placeholder_patron_group: 'faculty'))
+  end
+
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
   # The CanCan DSL requires a complex initialization method
   def initialize(user, token = nil)
@@ -130,7 +134,7 @@ class Ability
 
     can :request_pickup, PatronRequest do |request|
       request.selectable_items.any? do |item|
-        can? :request, item
+        can?(:request, item)
       end
     end
 

--- a/app/models/folio/null_patron.rb
+++ b/app/models/folio/null_patron.rb
@@ -9,10 +9,11 @@ module Folio
 
     attr_reader :user
 
-    def initialize(user = nil, display_name: nil, email: nil)
+    def initialize(user = nil, display_name: nil, email: nil, patron_group_name: nil)
       @user = user
       @display_name = display_name
       @email = email
+      @patron_group_name = patron_group_name || 'visitor'
     end
 
     def display_name
@@ -25,6 +26,7 @@ module Folio
 
     # this returns the full patronGroup object
     def patron_group
+      @patron_group ||= Folio::Types.patron_groups.values.find { |v| v['group'] == @patron_group_name }
       @patron_group ||= self.class.visitor_patron_group
     end
 

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+###
+#  User class for authenticating via SSO
+###
+class NullUser
+  attr_reader :name, :email, :library_id, :sunetid, :placeholder_patron_group
+
+  def initialize(name: nil, email: nil, library_id: nil, sunetid: nil, placeholder_patron_group: nil)
+    @name = name
+    @email = email
+    @library_id = library_id
+    @sunetid = sunetid
+    @placeholder_patron_group = placeholder_patron_group
+  end
+
+  def id = nil
+
+  def proxy?
+    false
+  end
+
+  def sponsor?
+    false
+  end
+
+  def to_email_string
+    ''
+  end
+
+  def barcode
+    library_id
+  end
+
+  def university_id
+    univ_id
+  end
+
+  def email_address
+    email
+  end
+
+  def sso_user?
+    sunetid.present?
+  end
+
+  def library_id_user?
+    library_id.present?
+  end
+
+  def name_email_user?
+    name.present? && email.present?
+  end
+
+  def super_admin? = false
+  def site_admin? = false
+  def ldap_groups = []
+  def affiliation = []
+  def student_type = []
+  def email_from_symphony = nil
+
+  def patron
+    placeholder_patron
+  end
+
+  private
+
+  def placeholder_patron
+    @placeholder_patron ||= Folio::NullPatron.new(self, patron_group_name: @placeholder_patron_group)
+  end
+end

--- a/app/views/patron_requests/unauthorized.html.erb
+++ b/app/views/patron_requests/unauthorized.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>Request: <%= @patron_request.item_title %><% end %>
+<%- contact_info = @patron_request.contact_info -%>
 
 <% if current_user&.patron %> <%= render 'user_header' %> <% end %>
 
@@ -9,16 +10,21 @@
 </div>
 <% end %>
 
-<div class="alert alert-danger shadow-sm d-flex gap-3 align-items-center mt-4 col-lg-8">
-  <i class="bi bi-exclamation-triangle-fill fs-3"></i>
-  <div>
-    <span class="fw-bold">
-      Oops! This item is not requestable at this time.
-    </span>
-    <br />
-    <span>
-      <%- contact_info = @patron_request.contact_info -%>
-      Please contact <%= mail_to(contact_info[:email], contact_info[:email], class: 'alert-link') %> or call <%= contact_info[:phone] %> for assistance.
-    </span>
+<% if Ability.faculty.can?(:request_pickup, @patron_request) # if a "faculty" patron could have requested it or there aren't pickup locations available... it's probably the patron group %>
+  <div class="alert alert-danger text-cardinal mt-4 col-lg-8">
+    This item is not available to request for <i><%= current_user&.patron&.patron_group&.dig('desc')&.sub(/cardholders?\.?$/, '') || 'Stanford Libraries' %></i> cardholders. If you have questions about library access, please contact <%= mail_to(contact_info[:email], contact_info[:email], class: 'alert-link') %> or call <%= contact_info[:phone] %> for assistance.
   </div>
-</div>
+<% else %>
+  <div class="alert alert-danger shadow-sm d-flex gap-3 align-items-center mt-4 col-lg-8">
+    <i class="bi bi-exclamation-triangle-fill fs-3"></i>
+    <div>
+      <span class="fw-bold">
+        Oops! This item is not requestable at this time.
+      </span>
+      <br />
+      <span>
+        Please contact <%= mail_to(contact_info[:email], contact_info[:email], class: 'alert-link') %> or call <%= contact_info[:phone] %> for assistance.
+      </span>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'Creating a request', :js do
     stub_bib_data_json(bib_data)
     # this line prevents ArgumentError: SMTP To address may not be blank
     ActionMailer::Base.perform_deliveries = false
+
+    allow(Settings.ils.patron_model.constantize).to receive(:find_by).with(patron_key: 'generic').and_return(build(:patron))
   end
 
   after do
@@ -334,7 +336,7 @@ RSpec.describe 'Creating a request', :js do
         fill_in 'PIN', with: '54321'
 
         click_on 'Login'
-        expect(page).to have_content('This item is not requestable at this time')
+        expect(page).to have_content('This item is not available to request for Stanford Libraries cardholders.')
       end
     end
 


### PR DESCRIPTION
Fixes #2647 

<img width="858" alt="Screenshot 2025-04-16 at 09 30 51" src="https://github.com/user-attachments/assets/3ec43d7e-2c9a-4598-ba33-f4d4cc08bf54" />

TODO: 
- [ ] figure out what we're doing with the patron group `desc` field (singular/plural? include "cardholder" or not?)