### PR TITLE
Set the default pickup location to Green if the patron can't pick it …

### DIFF
--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -222,6 +222,8 @@ class PatronRequest < ApplicationRecord
   def default_service_point_code(allowed_service_points: pickup_destinations)
     @default_service_point_code ||= if default_service_point_for_campus.in? allowed_service_points
                                       default_service_point_for_campus
+                                    elsif Settings.folio.default_service_point.in? allowed_service_points
+                                      Settings.folio.default_service_point
                                     else
                                       allowed_service_points.first
                                     end

--- a/spec/models/patron_request_spec.rb
+++ b/spec/models/patron_request_spec.rb
@@ -219,6 +219,16 @@ RSpec.describe PatronRequest do
         expect(request.default_service_point_code).to eq 'GREEN-LOAN'
       end
     end
+
+    context 'for a sul-purchased patron' do
+      let(:attr) { { instance_hrid: 'a123', origin_location_code: 'LAW-STACKS1' } }
+      let(:bib_data) { build(:single_law_holding) }
+      let(:patron) { build(:purchased_patron) }
+
+      it 'returns GREEN-LOAN by default (because the patron cannot access Law)' do
+        expect(request.default_service_point_code).to eq 'GREEN-LOAN'
+      end
+    end
   end
 
   describe '#pickup_destinations' do


### PR DESCRIPTION
…up the default service point for the origin campus

... or, we don't want a lot of people paging stuff to Hopkins just because it's first in the FOLIO service points response 🤷‍♂️ 