### PR TITLE
Remove unused delegate

### DIFF
--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -21,7 +21,7 @@ class FolioClient
 
   attr_reader :base_url
 
-  delegate :locations, :service_points, to: :folio_graphql_client
+  delegate :service_points, to: :folio_graphql_client
 
   def initialize(url: Settings.folio.okapi_url, tenant: Settings.folio.tenant)
     uri = URI.parse(url)


### PR DESCRIPTION
`locations` is not defined in FolioGraphqlClient. The multiple definitions of locations are causing a linter error (see https://github.com/sul-dlss/sul-requests/pull/2676).