### PR TITLE
Query for item level queue length conditionally

### DIFF
--- a/spec/services/folio_graphql_client_spec.rb
+++ b/spec/services/folio_graphql_client_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FolioGraphqlClient do
+  describe '#instance' do
+    let(:client) { described_class.new }
+    let(:hrid) { 'a12345' }
+    let(:instance_id) { 'fbb5d9bb-1c21-56f9-86ef-f95c0e67ff95' }
+    let(:item_a) { '00068cd0-cd46-5e03-be75-1c1494665f89' }
+    let(:item_b) { '0021a44b-5bfb-53e0-89e0-6c1a9a73d7e7' }
+    let(:instance_queue_length) { 0 }
+    let(:instance_data) do
+      {
+        'id' => instance_id,
+        'hrid' => hrid,
+        'title' => 'Test Title',
+        'queueTotalLength' => instance_queue_length,
+        'holdingsRecords' => [{ 'items' =>
+                                [
+                                  { 'id' => item_b, 'barcode' => '123' },
+                                  { 'id' => item_a, 'barcode' => '456' }
+                                ] }]
+      }
+    end
+
+    context 'when the instance has a queueTotalLength of 0' do
+      before do
+        allow(client).to receive(:instance_data).with(hrid:).and_return(instance_data)
+      end
+
+      it 'sets queueTotalLength to 0 for all contained items without an additional query' do
+        data = client.instance(hrid:)
+        items = data['holdingsRecords'][0]['items']
+        expect(items).to include(hash_including('id' => item_a, 'queueTotalLength' => 0))
+        expect(items).to include(hash_including('id' => item_b, 'queueTotalLength' => 0))
+      end
+    end
+
+    context 'when the instance has a non-zero queueTotalLength' do
+      let(:instance_queue_length) { 3 }
+      let(:items_queue_length_data) do
+        {
+          'holdingsRecords' => [{ 'items' =>
+                                  [
+                                    { 'id' => item_a, 'queueTotalLength' => 2 },
+                                    { 'id' => item_b, 'queueTotalLength' => 1 }
+                                  ] }]
+        }
+      end
+
+      before do
+        allow(client).to receive(:instance_data).with(hrid:).and_return(instance_data)
+        allow(client).to receive(:items_queue_length).with(hrid:).and_return(items_queue_length_data)
+      end
+
+      it 'fetches and merges queueTotalLength for the items' do
+        data = client.instance(hrid:)
+        items = data['holdingsRecords'][0]['items']
+        expect(items).to include(hash_including('id' => item_a, 'queueTotalLength' => 2))
+        expect(items).to include(hash_including('id' => item_b, 'queueTotalLength' => 1))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/sul-dlss/sul-requests/issues/1676

## What this does
TLDR: Checks the `queueTotalLength` from the instance first. Only query `queueTotalLength` at the item level if that is non-zero.

* Removes `queueTotalLength` from `item_fields`. Adds it back explicitly to the `boundWithItem` portion of the instance query. I don't think we can make assumptions about bound withs here.
* Adds `queueTotalLength` to the instance level of the instance query
* If `queueTotalLength` is 0 for the instance, sets all the item level `queueTotalLength` to 0. Based on the [API docs](https://s3.amazonaws.com/foliodocs/api/mod-circulation/r/circulation.html) and what I'm seeing I think this a valid assumption (e.g., `/circulation/requests/queue/instance/#{id}` contains all the requests for items in that instance)
* If `queueTotalLength` is non-zero, run a specific query for the item level queue lengths and merge that into the instance data

## Why would we want to do this?
Having `queueTotalLength` in `item_fields` causes folio-graphql to run one unique Folio API query (`/circulation/requests/queue/item/#{id}`) for each item which can be time consuming. We have instances with many items. Most instances/items do not have queues.

## How much time does this save when the instance queue length is 0?
Some. Not enough, but meaningful for instances with a large number of items.

Before:
```ruby
sul-requests(dev)*   puts Benchmark.measure { FolioGraphqlClient.new.instance(hrid: 'L17') }
sul-requests(dev)> end
  0.006563   0.004457   0.011020 (  7.055010)
  0.005537   0.003091   0.008628 (  6.775460)
  0.004782   0.001473   0.006255 (  6.520238)
sul-requests(dev)* 3.times do
sul-requests(dev)*   puts Benchmark.measure { FolioGraphqlClient.new.instance(hrid: 'L284') }
sul-requests(dev)> end
  0.047194   0.017478   0.064672 (  9.883716)
  0.006027   0.002250   0.008277 (  9.527961)
  0.005904   0.002884   0.008788 (  9.650898)
sul-requests(dev)* 3.times do
```

After:
```ruby
sul-requests(dev)* 3.times do
sul-requests(dev)*   puts Benchmark.measure { FolioGraphqlClient.new.instance(hrid: 'L17') }
sul-requests(dev)> end
  0.009764   0.005406   0.015170 (  6.293825)
  0.008824   0.001706   0.010530 (  5.968284)
  0.005665   0.002254   0.007919 (  5.830505)
sul-requests(dev)* 3.times do
sul-requests(dev)*   puts Benchmark.measure { FolioGraphqlClient.new.instance(hrid: 'L284') }
sul-requests(dev)> end
  0.008519   0.003153   0.011672 (  8.610549)
  0.010763   0.011110   0.021873 (  8.345573)
  0.008871   0.001811   0.010682 (  8.181223)
```