### PR TITLE
fix search for request_type

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -37,10 +37,7 @@ class ReportsController < ApplicationController
 
     @data = @data.where(service_point_code: params['service_point_code']) if params['service_point_code']
 
-    if params['request_type']
-      request_type = params['request_type'].map { |v| v == 'page' ? nil : v }
-      @data = @data.where(request_type:).or(@data.where(fulfillment_type: params['request_type']))
-    end
+    @data = @data.select { |record| params['request_type'].include?(record.type.downcase) } if params['request_type']
 
     @data = @data.select { |record| params['origin_library_code'].include?(record.origin_library_code) } if params['origin_library_code']
     @data


### PR DESCRIPTION
The query is a holdover from when we weren't using type on the record for the column. This is simpler and should fix the issue that on prod page isn't exporting. I am guessing it is because in my local instance request_type for page = nil but I don't think that is true on prod. 