### PR TITLE
switch to using label for request_type

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -37,7 +37,7 @@ class ReportsController < ApplicationController
 
     @data = @data.where(service_point_code: params['service_point_code']) if params['service_point_code']
 
-    @data = @data.select { |record| params['request_type'].include?(record.type.downcase) } if params['request_type']
+    @data = @data.select { |record| params['request_type'].include?(record.type) } if params['request_type']
 
     @data = @data.select { |record| params['origin_library_code'].include?(record.origin_library_code) } if params['origin_library_code']
     @data

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -8,7 +8,7 @@
   <div class="form-group mb-3">
      <%= f.label :request_type, 'Request type:' %><br>
      <% Settings.patron_request_type_mapping.each do |type, label| %>
-      <%= check_box_tag "request_type[]", type, params['request_type']&.include?(type.to_s), id: "request_type_#{type}" %>
+      <%= check_box_tag "request_type[]", label, id: "request_type_#{type}" %>
       <%= label_tag "request_type_#{type}", label %><br>
     <% end %>
   </div>


### PR DESCRIPTION
I realized after https://github.com/sul-dlss/sul-requests/pull/2691 that this would fix page but break mediated page because the request_type for mediated page is mediated and it wouldn't find the right type. This will fix this issue and remove the need to do string manipulation because type uses Settings.patron_request_type_mapping so they should never be different for filtering. I also removed the checkboxes check because this no longer uses params, an early version did but I could get the csv to download and update the params.