### PR TITLE
Remove reference to obsolete model in data_removal rake task

### DIFF
--- a/lib/tasks/data_removal.rake
+++ b/lib/tasks/data_removal.rake
@@ -6,8 +6,6 @@ namespace :data_removal do
     t = ActiveSupport::Duration.build(Settings.data_cleanup.age).ago
     raise 'Date is too recent' if t > 1.month.ago
 
-    Request.obsolete(t).delete_all
-
     PatronRequest.obsolete(t).delete_all
   end
 end


### PR DESCRIPTION
Fixes #2727

At stand-up on 9/30/2025 we decided that we want to keep pruning data from `PatronRequest`. So we will keep the rake task but remove reference to the model that no longer exists.