### PR TITLE
Stop using removed 'without' bundler flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,8 @@ pipeline {
           rvm use 3.4.1@sul-requests --create
           gem install bundler
 
-          bundle install --without production
+          bundle config set without 'production'
+          bundle install
 
           # Deploy it
           bundle exec cap $DEPLOY_ENVIRONMENT deploy
@@ -70,7 +71,8 @@ pipeline {
           rvm use 3.4.1@sul-requests --create
           gem install bundler
 
-          bundle install --without production
+          bundle config set without 'production'
+          bundle install
 
           # Deploy it
           bundle exec cap $DEPLOY_ENVIRONMENT deploy
@@ -114,7 +116,8 @@ pipeline {
           rvm use 3.4.1@sul-requests --create
           gem install bundler
 
-          bundle install --without production
+          bundle config set without 'production'
+          bundle install
 
           # Deploy it
           bundle exec cap $DEPLOY_ENVIRONMENT deploy
@@ -159,7 +162,8 @@ pipeline {
           rvm use 3.4.1@sul-requests --create
           gem install bundler
 
-          bundle install --without production
+          bundle config set without 'production'
+          bundle install
 
           # Deploy it
           bundle exec cap $DEPLOY_ENVIRONMENT deploy


### PR DESCRIPTION
> The `--without` flag has been removed because it relied on being remembered
across bundler invocations, which bundler no longer does. Instead please use
`bundle config set without 'production'`, and stop using this flag