### PR TITLE
Unpin connection_pool gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,5 +124,3 @@ gem 'rack-attack'
 gem 'bot_challenge_page'
 
 gem "csv", "~> 3.3"
-
-gem 'connection_pool', '~> 2.5' # pinned until fix for https://github.com/rails/rails/issues/56291 is released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -528,7 +528,6 @@ DEPENDENCIES
   capistrano-shared_configs
   capybara
   config
-  connection_pool (~> 2.5)
   cssbundling-rails (~> 1.1)
   csv (~> 3.3)
   debug


### PR DESCRIPTION
The fix was included in Rails 8.1.2 so we can unpin this now: https://github.com/rails/rails/pull/56292