### PR TITLE
Handle error in okcomputer check of Folio

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -25,6 +25,9 @@ class OkapiCheck < OkComputer::Check
       mark_failure
       mark_message 'Unable to connect to OKAPI'
     end
+  rescue # FolioClient raises when response is not 200
+    mark_failure
+    mark_message 'OKAPI not responding with 200'
   end
 end
 


### PR DESCRIPTION
This prevents Honeybadger from logging errors on every uptime check in dev when Folio is offline