### PR TITLE
Make request filters nicer to use.

### DIFF
--- a/app/components/search_form_component.html.erb
+++ b/app/components/search_form_component.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="form-group mb-3">
     <% if searchable %>
-      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
         Request Type
       </button>
     <% else %>
@@ -23,7 +23,7 @@
   </div>
   <div class="form-group mb-3">
     <% if searchable %>
-      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside">
         Origin Library
       </button>
     <% else %>
@@ -40,7 +40,7 @@
   </div>
   <div class="form-group mb-3">
     <% if searchable %>
-      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside">
         Destination Library
       </button>
     <% else %>


### PR DESCRIPTION
Before:
<img width="1015" height="238" alt="Screenshot 2026-01-29 at 09 54 30" src="https://github.com/user-attachments/assets/2b2e8b29-2a23-411a-a505-7c3d782066ca" />

After:
<img width="901" height="216" alt="Screenshot 2026-01-29 at 09 54 39" src="https://github.com/user-attachments/assets/9c8150ed-6c95-4218-83d6-68579fa5038f" />
