### PR TITLE
Fix return value of 404 response from Aeon requests for username

### DIFF
--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -39,7 +39,7 @@ class AeonClient
     when 200
       parse_json(response).map { |data| Aeon::Request.from_dynamic(data) }
     when 404
-      raise NotFoundError, "No Aeon account found for #{username}"
+      []
     else
       raise "Aeon API error: #{response.status}"
     end


### PR DESCRIPTION
404 for this endpoint means there are no requests