### PR TITLE
Fix herb lint in AccordionStepComponent and apply herb to components too

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,6 +20,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Herb analyze
-        run: bundle exec herb analyze app/views --non-interactive --no-log-file
+        run: bundle exec herb analyze app --non-interactive --no-log-file
       - name: Run tests
         run: bundle exec rake

--- a/app/components/accordion_step_component.html.erb
+++ b/app/components/accordion_step_component.html.erb
@@ -5,9 +5,9 @@
       <h2 class="accordion-title fw-semibold fs-5 mb-0">
         <%= title %>
       </h2>
-      <button class="btn btn-link edit-button align-items-center" data-action="click->patronRequest#editForm analytics#send" data-analytics-category-param="Accordion" data-analytics-action-param="Edit" aria-controls="<%= id %>">
-        <i class="bi bi-pencil me-1"></i> Edit
-      </button>
+    </button>
+    <button class="btn btn-link edit-button align-items-center" data-action="click->patronRequest#editForm analytics#send" data-analytics-category-param="Accordion" data-analytics-action-param="Edit" aria-controls="<%= id %>">
+      <i class="bi bi-pencil me-1"></i> Edit
     </button>
   </div>
 


### PR DESCRIPTION
Fixes #2917 (by just doing what browsers were auto-correcting our markup to in the first place 🤷‍♂️ )