### PR TITLE
Add Aeon::User#appointments to get the user's appointments with associated items

### DIFF
--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -6,6 +6,8 @@ module Aeon
     attr_reader :id, :username, :reading_room_id, :start_time, :stop_time,
                 :name, :appointment_status, :reading_room, :creation_date
 
+    attr_accessor :requests
+
     def self.from_dynamic(dyn) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       new(
         id: dyn['id'],

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -32,5 +32,11 @@ module Aeon
     def requests
       @requests ||= self.class.aeon_client.requests_for(username:)
     end
+
+    def appointments
+      @appointments ||= self.class.aeon_client.appointments_for(username:).each do |appointment|
+        appointment.requests = requests.select { |request| request.appointment_id == appointment.id }
+      end
+    end
   end
 end

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -56,6 +56,19 @@ class AeonClient
     end
   end
 
+  def appointments_for(username:, context: 'both', pending_only: true)
+    response = get("Users/#{CGI.escape(username)}/appointments", params: { context: context, pendingOnly: pending_only })
+
+    case response.status
+    when 200
+      response.body.map { |data| Aeon::Appointment.from_dynamic(data) }
+    when 404
+      []
+    else
+      raise "Aeon API error: #{response.status}"
+    end
+  end
+
   private
 
   def get(path, params: nil)


### PR DESCRIPTION
Part of #2914.

I don't see a way to paginate the appointments or requests, query just the requests for an appointment, or any other sort of filtering we'd want to do, but maybe faking it is good enough for now 🤷‍♂️ 