### PR TITLE
Update request component to reflect new queue model

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -380,12 +380,17 @@ label.btn-close {
     padding: 4px 12px;
   }
 
+  .draft {
+    color: var(--stanford-black);
+    background-color: var(--stanford-10-black);
+  }
+
   .pending {
     color: var(--stanford-digital-blue-dark);
     background-color: rgba(var(--stanford-digital-blue-rgb), 0.1);
   }
 
-  .completed {
+  .ready {
     color: var(--stanford-digital-green);
     background-color: rgba(var(--stanford-digital-green-rgb), 0.1);
   }

--- a/app/components/aeon/request_component.html.erb
+++ b/app/components/aeon/request_component.html.erb
@@ -2,11 +2,11 @@
   <div class="card-header fw-semibold p-3 ps-2 d-flex gap-1 flex-row align-items-md-center justify-content-between">
     <div class="d-flex flex-wrap gap-1">
       <span>
-        <span class="rounded-pill <%= status %>">
+        <span class="rounded-pill <%= status_class %>">
           <i class="bi bi-<%= status_icon %> align-middle me-1"></i><%= status_text %>
         </span>
       </span>
-      <% if appointment? %>
+      <% if show_appointment? %>
       <span class="appointment-details ms-1">
         <span class="fw-bold text-green"><%= appointment_date %></span>
         <span class="fw-normal text-nowrap text-green"><%= appointment_time_range %></span>

--- a/app/components/aeon/request_component.rb
+++ b/app/components/aeon/request_component.rb
@@ -7,7 +7,7 @@ module Aeon
 
     delegate :appointment?, :appointment, :aeon_link, :pages, :volume, :format, :title,
              :date, :document_type, :call_number, :transaction_status, :transaction_date,
-             :transaction_number, :editable?, :completed?, :submitted?, :digital?, to: :request
+             :transaction_number, :draft?, :editable?, :completed?, :submitted?, :digital?, :physical?, :scan_delivered?, to: :request
 
     def initialize(request:)
       @request = request
@@ -38,25 +38,31 @@ module Aeon
       'Reading room use'
     end
 
-    def status
-      if completed?
-        :completed
-      else
+    def status_class
+      if completed? || scan_delivered? || (submitted? && appointment?)
+        :ready
+      elsif submitted?
         :pending
+      else
+        :draft
       end
     end
 
     def status_icon
-      case status
+      case status_class
       when :pending
         'clock'
-      when :completed
+      when :ready
         'check2-circle'
       end
     end
 
     def appointment_date
       appointment.start_time.strftime('%b %-d, %Y') if appointment?
+    end
+
+    def show_appointment?
+      appointment? && !draft?
     end
 
     def appointment_time_range

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -117,6 +117,8 @@ module Aeon
     end
 
     def in_completed_queue?
+      return false if draft?
+
       photoduplication_queue&.completed? || transaction_queue&.completed?
     end
 

--- a/spec/components/aeon/request_component_spec.rb
+++ b/spec/components/aeon/request_component_spec.rb
@@ -5,16 +5,107 @@ require 'rails_helper'
 RSpec.describe Aeon::RequestComponent, type: :component do
   let(:request) { build(:aeon_request) }
 
-  before do
-    allow(request).to receive(:completed?).and_return(true)
-    render_inline(described_class.new(request:))
+  context 'digitization requests' do
+    let(:request) { build(:aeon_request, :digitized) }
+
+    context 'when in draft' do
+      before do
+        allow(request).to receive_messages(draft?: true)
+        render_inline(described_class.new(request:))
+      end
+
+      it 'shows the draft status' do
+        expect(page).to have_css '.draft'
+        expect(page).to have_text 'Digitization'
+        expect(page).to have_no_text 'Digitization ready'
+        expect(page).to have_no_text 'Digitization pending'
+      end
+    end
+
+    context 'when the digitization has been sent to the user' do
+      before do
+        allow(request).to receive_messages(completed?: true, scan_delivered?: true)
+        render_inline(described_class.new(request:))
+      end
+
+      it 'shows that the scan has been delivered' do
+        expect(page).to have_css '.ready'
+        expect(page).to have_text 'Digitization ready'
+        expect(page).to have_text 'Throwing a sinker ball at 94 mpg with wicked movement'
+        expect(page).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/12345678'
+      end
+    end
+
+    context 'when the digitization request is in process' do
+      before do
+        allow(request).to receive_messages(completed?: false, scan_delivered?: false, submitted?: true)
+        render_inline(described_class.new(request:))
+      end
+
+      it 'shows that digitization is pending' do
+        expect(page).to have_css '.pending'
+        expect(page).to have_text 'Digitization pending'
+      end
+    end
   end
 
-  it 'renders' do
-    expect(page).to have_text('Throwing a sinker ball at 94 mpg with wicked movement')
-    expect(page).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/12345678'
-    expect(page).to have_text('Mar 11, 2024')
-    expect(page).to have_text('1 pm - 1:15 pm (PDT)')
-    expect(page).to have_text('Field Reading Room')
+  context 'reading room requests' do
+    context 'when in draft' do
+      before do
+        allow(request).to receive_messages(draft?: true)
+      end
+
+      context 'with an appointment' do
+        let(:request) { build(:aeon_request) }
+
+        before do
+          render_inline(described_class.new(request:))
+        end
+
+        it 'shows the draft status with no appointment details' do
+          expect(page).to have_css '.draft'
+          expect(page).to have_no_text 'Mar 11, 2024'
+          expect(page).to have_no_text '1 pm - 1:15 pm (PDT)'
+          expect(page).to have_no_text 'Field Reading Room'
+        end
+      end
+    end
+
+    context 'when submitted' do
+      before do
+        allow(request).to receive_messages(completed?: false, draft?: false, submitted?: true)
+      end
+
+      context 'with an appointment' do
+        let(:request) { build(:aeon_request) }
+
+        before do
+          render_inline(described_class.new(request:))
+        end
+
+        it 'shows the appointment details' do
+          expect(page).to have_css '.ready'
+          expect(page).to have_text 'Reading room use'
+          expect(page).to have_text 'Mar 11, 2024'
+          expect(page).to have_text '1 pm - 1:15 pm (PDT)'
+          expect(page).to have_text 'Field Reading Room'
+          expect(page).to have_text 'Throwing a sinker ball at 94 mpg with wicked movement'
+          expect(page).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/12345678'
+        end
+      end
+
+      context 'without an appointment' do
+        let(:request) { build(:aeon_request, :without_appointment) }
+
+        before do
+          render_inline(described_class.new(request:))
+        end
+
+        it 'shows the pending reading room use status' do
+          expect(page).to have_css '.pending'
+          expect(page).to have_text 'Reading room use'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
* Restores the behavior of the request component status text after I changed the methods we use to describe state in https://github.com/sul-dlss/sul-requests/pull/2931.
* Adds tests. It seems like we'll be able to use this single component for many cases and I can't keep track any more...
* A little churn on `status` changing back to `status_class`. I think @dnoneill had it right the first time around, `status_class` is better.
* Adds draft colors and stops showing the appointment details when in draft in anticipation of showing a warning in https://github.com/sul-dlss/sul-requests/issues/2849.