### PR TITLE
Add 'cleared' parameter to created users

### DIFF
--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -37,7 +37,7 @@ class AeonClient
   end
 
   def create_user(username:, auth_type: 'Default')
-    response = post('Users', { username:, authType: auth_type })
+    response = post('Users', { username:, authType: auth_type, cleared: 'No' })
 
     case response.status
     when 201


### PR DESCRIPTION
Apparently Aeon throws a NPE when creating requests if this isn't set 🤷