### PR TITLE
do not show cancelled requests on appointment, stub warning for draft on appointment

### DIFF
--- a/app/components/aeon/appointment_component.html.erb
+++ b/app/components/aeon/appointment_component.html.erb
@@ -11,7 +11,12 @@
       <ul class="list-group list-group-flush">
         <% appointment.requests.each do |request| %>
           <li class="list-group-item">
-            <h4><%= request.title %></h4>
+            <h4>
+              <%= request.title %>
+              <% if request.draft? %>
+                <span class="text-warning ms-2"><i class="bi bi-exclamation-triangle me-1"></i>Draft</span>
+              <% end %>
+            </h4>
             <div class="d-flex flex-row align-items-center">
               <div class="me-4">Call number: <%= request.call_number %></div>
 

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -47,7 +47,7 @@ module Aeon
 
     def appointments
       @appointments ||= self.class.aeon_client.appointments_for(username:).sort_by(&:sort_key).each do |appointment|
-        appointment.requests = requests.select { |request| request.appointment_id == appointment.id }
+        appointment.requests = requests.select { |request| !request.cancelled? && request.appointment_id == appointment.id }
       end
     end
   end


### PR DESCRIPTION
Right now appointments are showing cancelled appointments as well as submitted. 
<img width="578" height="537" alt="Screenshot 2026-02-18 at 11 16 54 AM" src="https://github.com/user-attachments/assets/36189d40-e06d-4730-811b-d5ace2e8a548" />

This is the fix 
<img width="712" height="396" alt="Screenshot 2026-02-18 at 12 57 33 PM" src="https://github.com/user-attachments/assets/7efecbb3-51c6-407b-bffa-4f6869f09aee" />

