### PR TITLE
update duration selectors to respect aeon max/min appointment times

### DIFF
--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -27,7 +27,7 @@ class AeonAppointmentsController < ApplicationController
     @date = Date.parse(params.expect(:date))
     @available_appointments = AeonClient.new.available_appointments(reading_room_id: params.expect(:reading_room_id),
                                                                     date: @date, include_next_available: true)
-
+    @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
     respond_to do |format|
       format.html
       format.json

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -1,10 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["availability"]
-
-  connect() {
-  }
+  static targets = ["availability", "duration", "fieldset"]
 
   async refreshDateMetadata() {
     const formData = new FormData(this.element);
@@ -26,6 +23,17 @@ export default class extends Controller {
     } catch (error) {
       console.error("Error fetching availability data:", error);
     }
+  }
+
+  filterDurationFields() {
+    const data = this.fieldsetTarget.dataset;
+    const maxDuration = data.maxSlot;
+    const minDuration = data.minSlot;
+    this.durationTargets.forEach((duration) => {
+      const seconds = parseInt(duration.dataset.seconds);
+      if (maxDuration < seconds || minDuration > seconds) { duration.classList.add('d-none') }
+      else { duration.classList.remove('d-none') }
+    });
   }
 
   refreshAvailability() {

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -33,12 +33,14 @@
       <legend class="fs-6 fw-semibold">Duration</legend>
 
       <% [30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours].each do |duration| %>
-        <%= f.radio_button :duration, duration.to_i, class: 'btn-check', checked: (@appointment.start_time && @appointment.stop_time ? (@appointment.stop_time - @appointment.start_time) : 30.minutes) == duration, data: { action: 'appointment#applyDurationFilter' } %>
-        <%= f.label "duration_#{duration.to_i}", duration.inspect, class: 'btn' %>
+        <span class="duration-selector" data-appointment-target="duration" data-seconds="<%= duration %>">
+          <%= f.radio_button :duration, duration.to_i, class: 'btn-check', checked: (@appointment.start_time && @appointment.stop_time ? (@appointment.stop_time - @appointment.start_time) : 30.minutes) == duration, data: { action: 'appointment#applyDurationFilter' } %>
+          <%= f.label "duration_#{duration.to_i}", duration.inspect, class: 'btn' %>
+        </span>
       <% end %>
     </fieldset>
 
-    <turbo-frame id="available_appointments" data-action="turbo:frame-load->appointment#applyDurationFilter" data-appointment-target="availability" src="<%= available_aeon_appointments_url(@appointment.reading_room_id, @appointment.date || Time.zone.now.iso8601, selected: @appointment.start_time.strftime('%-I:%M %p')) if @appointment.reading_room_id %>">
+    <turbo-frame id="available_appointments" data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_appointments_url(@appointment.reading_room_id, @appointment.date || Time.zone.now.iso8601, selected: @appointment.start_time.strftime('%-I:%M %p')) if @appointment.reading_room_id %>">
       <fieldset class="mb-3">
         <legend class="fs-6 fw-semibold">Available time slots</legend>
         <% if @appointment.reading_room_id && @appointment.date %>

--- a/app/views/aeon_appointments/available.html.erb
+++ b/app/views/aeon_appointments/available.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: Aeon::Appointment.new) do |f| %>
   <turbo-frame id="available_appointments">
-    <fieldset class="mb-3">
+    <fieldset class="mb-3" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
       <legend class="fs-6 fw-semibold">Available time slots</legend>
       <% @available_appointments.select { |x| x.start_time.to_date == @date }.each do |appointment| %>
         <%= f.radio_button :start_time, appointment.start_time.strftime('%-I:%M %p'), id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { maximum_appointment_length: appointment.maximum_appointment_length }, class: 'btn-check', checked: @selected_time == appointment.start_time.strftime('%-I:%M %p') %>

--- a/app/views/aeon_appointments/available.json.jbuilder
+++ b/app/views/aeon_appointments/available.json.jbuilder
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+json.max_slot_time @appointment_lengths.max
+json.min_slot_time @appointment_lengths.min
 json.slots @available_appointments do |appointment_slot|
   json.start_time appointment_slot.start_time
 end


### PR DESCRIPTION
Before the other three reading rooms were showing 4 hours when they should only be showing 3

closes #2976 




https://github.com/user-attachments/assets/be9dd87e-c798-40c2-b9cf-b43ee10a562e




