### PR TITLE
Rename aeon_link to item_url

### DIFF
--- a/app/components/aeon/request_component.html.erb
+++ b/app/components/aeon/request_component.html.erb
@@ -61,8 +61,8 @@
           <i replace_with_icon></i><%= document_type %><% if date %> (<%= date %>)<% end %>
         </div>
         <div>Call number: <%= call_number %></div>
-        <% if searchworks_link %>
-          <div><a href="<%= searchworks_link %>" class="su-underline">View in SearchWorks<i class="ms-1 bi bi-arrow-up-right"></i></a></div>
+        <% if searchworks_url %>
+          <div><a href="<%= searchworks_url %>" class="su-underline">View in SearchWorks<i class="ms-1 bi bi-arrow-up-right"></i></a></div>
         <% end %>
       </div>
       <% if format_info %>

--- a/app/components/aeon/request_component.rb
+++ b/app/components/aeon/request_component.rb
@@ -5,7 +5,7 @@ module Aeon
   class RequestComponent < ViewComponent::Base
     attr_reader :request
 
-    delegate :appointment?, :appointment, :aeon_link, :pages, :volume, :format, :title,
+    delegate :appointment?, :appointment, :item_url, :pages, :volume, :format, :title,
              :date, :document_type, :call_number, :transaction_status, :transaction_date,
              :transaction_number, :draft?, :editable?, :completed?, :submitted?, :digital?, :physical?, :scan_delivered?, to: :request
 
@@ -13,10 +13,10 @@ module Aeon
       @request = request
     end
 
-    def searchworks_link
-      return unless aeon_link&.include?('searchworks')
+    def searchworks_url
+      return unless item_url&.include?('searchworks')
 
-      aeon_link
+      item_url
     end
 
     def format_info

--- a/app/controllers/archives_requests_controller.rb
+++ b/app/controllers/archives_requests_controller.rb
@@ -65,7 +65,7 @@ class ArchivesRequestsController < ApplicationController
       author: @ead.creator,
       call_number: "#{@ead.identifier} #{volume['series']}",
       volume: volume['subseries'],
-      aeon_link: @ead.collection_permalink,
+      item_url: @ead.collection_permalink,
       shipping_option: params[:shipping_option],
       identifier: @ead.identifier,
       site: map_repository_to_site_code(@ead.repository)

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -3,7 +3,7 @@
 module Aeon
   # Wraps an Aeon request record
   class Request
-    attr_reader :aeon_link, :appointment, :appointment_id, :author, :call_number,
+    attr_reader :item_url, :appointment, :appointment_id, :author, :call_number,
                 :creation_date, :date, :document_type, :format, :pages, :photoduplication_status,
                 :location, :shipping_option, :site, :start_time, :stop_time, :title, :transaction_date,
                 :transaction_number, :transaction_status, :username, :volume
@@ -14,7 +14,7 @@ module Aeon
 
     def self.from_dynamic(dyn) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       new(
-        aeon_link: dyn['itemInfo1'],
+        item_url: dyn['itemInfo1'],
         appointment: dyn['appointment'] ? Appointment.from_dynamic(dyn['appointment']) : nil,
         appointment_id: dyn['appointmentID'],
         author: dyn['itemAuthor'],
@@ -40,12 +40,12 @@ module Aeon
       )
     end
 
-    def initialize(aeon_link: nil, appointment: nil, appointment_id: nil, # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists, Metrics/MethodLength
+    def initialize(item_url: nil, appointment: nil, appointment_id: nil, # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists, Metrics/MethodLength
                    author: nil, call_number: nil, creation_date: nil, date: nil,
                    document_type: nil, format: nil, location: nil, pages: nil, photoduplication_status: nil, photoduplication_date: nil,
                    shipping_option: nil, start_time: nil, stop_time: nil, title: nil, transaction_date: nil,
                    transaction_number: nil, transaction_status: nil, username: nil, volume: nil, site: nil)
-      @aeon_link = aeon_link
+      @item_url = item_url
       @appointment = appointment
       @appointment_id = appointment_id
       @author = author

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -166,7 +166,7 @@ class AeonClient
   # Submit an archives request to Aeon
   # @param username [String] the user's Aeon username, which is an email
   def submit_archives_request(username:, title:, author: nil, call_number: nil, volume: nil,
-                              aeon_link: nil, shipping_option: nil, identifier: nil,
+                              item_url: nil, shipping_option: nil, identifier: nil,
                               site: nil, citation: nil, date: nil,
                               info_2: nil, info_3: nil, info_4: nil, info_5: nil,
                               sub_title: nil, special_request: nil)
@@ -176,7 +176,7 @@ class AeonClient
       itemAuthor: author,
       itemCitation: citation,
       itemDate: date,
-      itemInfo1: aeon_link,
+      itemInfo1: item_url,
       itemInfo2: info_2,
       itemInfo3: info_3,
       itemInfo4: info_4,

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -64,7 +64,7 @@
     <%= f.hidden_field :aeon_title, name: 'ItemTitle', value: f.object.bib_data.title %>
     <%= f.hidden_field :aeon_author, name: 'ItemAuthor', value: f.object.bib_data.author %>
     <%= f.hidden_field :aeon_date, name: 'ItemDate', value: f.object.bib_data.pub_date %>
-    <%= f.hidden_field :aeon_link, name: 'ItemInfo1', value: f.object.bib_data.view_url %>
+    <%= f.hidden_field :item_url, name: 'ItemInfo1', value: f.object.bib_data.view_url %>
   <% end %>
   <% if f.object.selectable_items.one? || f.object.barcodes&.one? %>
     <% single_item = f.object.selectable_items.first %>

--- a/spec/factories/aeon.rb
+++ b/spec/factories/aeon.rb
@@ -74,7 +74,7 @@ FactoryBot.define do
     pages { nil }
     shipping_option { nil }
     volume { nil }
-    aeon_link { 'https://searchworks.stanford.edu/view/12345678' }
+    item_url { 'https://searchworks.stanford.edu/view/12345678' }
     date { nil }
     appointment_id { 23 }
     appointment { build(:aeon_appointment) }


### PR DESCRIPTION
I think we now know that `itemInfo1` is used uniformly (hopefully) in Aeon for the item's URL.
