### PR TITLE
Use Ead::Request to figure out the appropriate reading room is.

### DIFF
--- a/app/controllers/archives_requests_controller.rb
+++ b/app/controllers/archives_requests_controller.rb
@@ -7,8 +7,7 @@ class ArchivesRequestsController < ApplicationController
 
   def new
     @ead = EadClient.fetch(ead_url_param)
-    @ead_url = ead_url_param
-    @reading_room = AeonClient.new.find_reading_room(repository: @ead.library)
+    @ead_request = Ead::Request.new(user: current_user, ead: @ead)
   end
 
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity

--- a/app/models/ead/request.rb
+++ b/app/models/ead/request.rb
@@ -31,6 +31,17 @@ module Ead
       end
     end
 
+    def site
+      return nil unless repository
+
+      # TODO: Fallback to SPECUA? Other logic?
+      REPOSITORY_TO_SITE_CODE[repository] || 'SPECUA'
+    end
+
+    def reading_room
+      @reading_room ||= aeon_client.reading_rooms.find { |rr| rr.sites.include?(site) }
+    end
+
     private
 
     def as_aeon_create_request_data(volume) # rubocop:disable Metrics/MethodLength
@@ -40,7 +51,7 @@ module Ead
         item_author: creator,
         item_citation: nil,
         item_date: nil,
-        item_info1: @ead.collection_permalink,
+        item_info1: collection_permalink,
         item_info2: nil,
         item_info3: nil,
         item_info4: nil,
@@ -49,17 +60,10 @@ module Ead
         item_title: title,
         item_volume: volume['subseries'],
         shipping_option: shipping_option,
-        site: map_repository_to_site_code(repository),
+        site: site,
         special_request: nil,
         username: user.email_address
       )
-    end
-
-    def map_repository_to_site_code(repository)
-      return nil unless repository
-
-      # TODO: Fallback to SPECUA? Other logic?
-      REPOSITORY_TO_SITE_CODE[repository] || 'SPECUA'
     end
 
     def aeon_client

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -109,11 +109,6 @@ class AeonClient
     handle_response(response, as_class: Aeon::ReadingRoom, not_found: [])
   end
 
-  def find_reading_room(repository:)
-    site_code = map_repository_to_site_code(repository)
-    reading_rooms.find { |rr| rr.sites.include?(site_code) }
-  end
-
   def find_queue(id:, type:)
     return unless id && type
 

--- a/app/views/archives_requests/new.html.erb
+++ b/app/views/archives_requests/new.html.erb
@@ -15,7 +15,7 @@
           <p>Conditions Governing Use: <%= @ead.conditions_governing_use || 'Not available' %></p>
           <p>Conditions Governing Access: <%= @ead.conditions_governing_access || 'Not available' %></p>
           <p>Cite As: <%= @ead.cite_as || 'Not available' %></p>
-          <p>Source URL: <%= @ead_url %></p>
+          <p>Source URL: <%= @ead.url %></p>
         </div>
       </div>
       <%= form_with id: 'archives-request', url: archives_requests_path, class: 'accordion', data: { controller: 'patronRequest archives-request', turbo: false } do |f| %>
@@ -31,7 +31,7 @@
                 <% end %>
                 <span class="text-cardinal ms-2 mt-1">
                   Earliest appointment available:
-                  <turbo-frame id="earliest_appointment" src="/aeon_appointments/available/<%= @reading_room.id %>/<%= Date.today %>"></turbo-frame>
+                  <turbo-frame id="earliest_appointment" src="/aeon_appointments/available/<%= @ead_request.reading_room&.id %>/<%= Date.today %>"></turbo-frame>
                 </span>
               </div>
               <div class="mt-4">
@@ -133,7 +133,7 @@
                 </dd>
               </dl>
             </div>
-            <%= f.hidden_field :ead_url, value: @ead_url %>
+            <%= f.hidden_field :ead_url, value: @ead.url %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
I suspect we're going to need `Ead::Request` to support edit requests anyway, so it seems fine to initialize it for a new request too.