### PR TITLE
clean up styling on ead request sidebar

### DIFF
--- a/app/views/archives_requests/new.html.erb
+++ b/app/views/archives_requests/new.html.erb
@@ -138,25 +138,29 @@
         <% end %>
       <% end %>
     </div>
-    <div class="col-4">
+    <aside class="col-4">
       <h2>Contact information</h2>
       <div>
         <% if @ead.repository %>
-          <h3><%= link_to @ead.repository, @ead.repository_contact[:website] %></h3>
+          <h3>
+            <%= link_to @ead.repository_contact[:website] do  %>
+              <%= @ead.repository %><i class="bi bi-arrow-up-right ms-1"></i>
+            <% end %>
+          </h3>
         <% end %>
         <% if @ead.repository_contact[:address] %>
           <p>
-            <% @ead.repository_contact[:address].each do |line| %>
-              <%= line %><br>
+            <% @ead.repository_contact[:address].each_with_index do |line, index| %>
+              <div <% if index == 0 %>class="fw-semibold"<% end %>><%= line %></div>
             <% end %>
           </p>
         <% end %>
         <% if @ead.repository_contact[:email] %>
           <p>
-            Email: <%= mail_to @ead.repository_contact[:email] %>
+            <span class="fw-semibold">Email: </span><%= mail_to @ead.repository_contact[:email] %>
           </p>
         <% end %>
       </div>
-    </div>
+    </aside>
   </div>
 </div>


### PR DESCRIPTION
Closes #3002 
Before:
<img width="1137" height="398" alt="Screenshot 2026-02-19 at 5 48 15 PM" src="https://github.com/user-attachments/assets/c5c3047f-8f57-47da-92aa-979220e0ef5e" />

After:
<img width="953" height="486" alt="Screenshot 2026-02-19 at 6 08 24 PM" src="https://github.com/user-attachments/assets/d33d4490-cc48-4e95-96d3-d4db0764f5cb" />

Figma:
<img width="376" height="354" alt="Screenshot 2026-02-19 at 5 48 50 PM" src="https://github.com/user-attachments/assets/56ee9768-6bd3-48f2-a87f-462eb34257c4" />
