### PR TITLE
Add a reference number to coalesce Aeon transactions with a logic patron request

### DIFF
--- a/app/controllers/archives_requests_controller.rb
+++ b/app/controllers/archives_requests_controller.rb
@@ -24,7 +24,11 @@ class ArchivesRequestsController < ApplicationController
     @ead = EadClient.fetch(params[:ead_url])
 
     items = params[:volumes]&.reject(&:blank?)&.map { |json_str| JSON.parse(json_str) }
-    @request = Ead::Request.new(user: current_user, ead: @ead, items:, shipping_option: params[:shipping_option])
+    @request = Ead::Request.new(user: current_user,
+                                ead: @ead,
+                                items:,
+                                shipping_option: params[:shipping_option],
+                                reference_number: "UUID:#{request.uuid}")
 
     results = @request.create_aeon_requests!
 

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -5,7 +5,8 @@ module Aeon
   class Request
     attr_reader :item_url, :appointment, :appointment_id, :author, :call_number,
                 :creation_date, :date, :document_type, :format, :pages, :photoduplication_status,
-                :location, :shipping_option, :site, :start_time, :stop_time, :title, :transaction_date,
+                :location, :reference_number, :shipping_option, :site,
+                :start_time, :stop_time, :title, :transaction_date,
                 :transaction_number, :transaction_status, :username, :volume
 
     def self.aeon_client
@@ -29,6 +30,7 @@ module Aeon
         pages: dyn['itemInfo5'],
         photoduplication_date: photoduplication_date ? Time.zone.parse(photoduplication_date) : nil,
         photoduplication_status: dyn['photoduplicationStatus'],
+        reference_number: dyn['referenceNumber'],
         site: dyn['site'],
         start_time: dyn['startTime'],
         stop_time: dyn['stopTime'],
@@ -44,7 +46,7 @@ module Aeon
     def initialize(item_url: nil, appointment: nil, appointment_id: nil, # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists, Metrics/MethodLength
                    author: nil, call_number: nil, creation_date: nil, date: nil,
                    document_type: nil, format: nil, location: nil, pages: nil, photoduplication_status: nil, photoduplication_date: nil,
-                   shipping_option: nil, start_time: nil, stop_time: nil, title: nil, transaction_date: nil,
+                   reference_number: nil, shipping_option: nil, start_time: nil, stop_time: nil, title: nil, transaction_date: nil,
                    transaction_number: nil, transaction_status: nil, username: nil, volume: nil, site: nil)
       @item_url = item_url
       @appointment = appointment
@@ -59,6 +61,7 @@ module Aeon
       @pages = pages
       @photoduplication_status = photoduplication_status
       @photoduplication_date = photoduplication_date
+      @reference_number = reference_number
       @shipping_option = shipping_option
       @start_time = start_time
       @stop_time = stop_time
@@ -114,6 +117,10 @@ module Aeon
 
     def writable?
       cancelled? || appointment.editable?
+    end
+
+    def coalesce_key
+      reference_number || transaction_number
     end
 
     private

--- a/app/models/ead/request.rb
+++ b/app/models/ead/request.rb
@@ -4,7 +4,7 @@ module Ead
   ##
   # Model for EAD-based requests
   class Request
-    attr_reader :user, :ead, :items, :shipping_option
+    attr_reader :user, :ead, :items, :request_data
 
     # Maps from the value in EAD to Aeon's valid site codes
     REPOSITORY_TO_SITE_CODE = {
@@ -15,11 +15,11 @@ module Ead
 
     delegate :title, :creator, :call_number, :identifier, :repository, :collection_permalink, to: :ead
 
-    def initialize(user:, ead:, items: [], shipping_option: nil)
+    def initialize(user:, ead:, items: [], **request_data)
       @user = user
       @ead = ead
       @items = items
-      @shipping_option = shipping_option
+      @request_data = request_data
     end
 
     def create_aeon_requests!
@@ -59,10 +59,11 @@ module Ead
         item_subtitle: nil,
         item_title: title,
         item_volume: volume['subseries'],
-        shipping_option: shipping_option,
+        shipping_option: nil,
         site: site,
         special_request: nil,
-        username: user.email_address
+        username: user.email_address,
+        **request_data
       )
     end
 

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -127,7 +127,7 @@ class AeonClient
 
   CreateRequestData = Data.define(:call_number, :ead_number, :item_author, :item_citation, :item_date, :item_info1, :item_info2,
                                   :item_info3, :item_info4, :item_info5, :item_subtitle, :item_title, :item_volume,
-                                  :shipping_option, :site, :special_request, :username) do
+                                  :reference_number, :shipping_option, :site, :special_request, :username) do
     def as_json # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       {
         callNumber: call_number,
@@ -143,6 +143,7 @@ class AeonClient
         itemSubTitle: item_subtitle,
         itemTitle: item_title,
         itemVolume: item_volume,
+        referenceNumber: reference_number,
         shippingOption: shipping_option,
         site: site,
         specialRequest: special_request,
@@ -156,7 +157,7 @@ class AeonClient
         call_number: nil, ead_number: nil,
         item_author: nil, item_citation: nil, item_date: nil,
         item_info1: nil, item_info2: nil, item_info3: nil, item_info4: nil, item_info5: nil,
-        item_subtitle: nil, item_title: nil, item_volume: nil,
+        item_subtitle: nil, item_title: nil, item_volume: nil, reference_number: nil,
         shipping_option: nil, site: nil, special_request: nil,
         username: nil
       )


### PR DESCRIPTION
Optimistically, we'll want something like this to keep the Aeon requests organized the way the user thinks about them (e.g. something like #2971)