### PR TITLE
Add placeholder accordion steps for EAD appointment + digitization steps

### DIFF
--- a/app/views/archives_requests/new.html.erb
+++ b/app/views/archives_requests/new.html.erb
@@ -84,7 +84,35 @@
             <% end %>
           <% end %>
         <% end %>
-        <%= render AccordionStepComponent.new(id: 'submit', step_index: step_enum.next, form_id: f.id, submit: true, submit_text: 'Submit to Aeon', cancel: false) do |component| %>
+
+        <%= render AccordionStepComponent.new(id: 'scan-or-pickup-placeholder', form_id: f.id, step_index: (scan_or_pickup_step ||= step_enum.next), data: { 'patronrequest-forRequestType': 'none' }) do |c| %>
+          <% c.with_title.with_content('Appointment or Digitization') %>
+        <% end %>
+
+        <%= render AccordionStepComponent.new(request: f.object, id: 'pickup', classes: ['d-none'], form_id: f.id, step_index: (scan_or_pickup_step ||= step_enum.next), data: { 'patronrequest-forRequestType': 'pickup' }) do |c| %>
+          <% c.with_title.with_content('Appointment') %>
+          <% c.with_body do %>
+            TODO: Appointment
+          <% end %>
+        <% end %>
+
+        <%= render AccordionStepComponent.new(request: f.object, id: 'scan', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { 'patronrequest-forRequestType': 'scan' }) do |c| %>
+          <% c.with_title.with_content('Digitization') %>
+
+          <% c.with_body do %>
+            TODO: Digitization
+          <% end %>
+        <% end %>
+
+        <%= render AccordionStepComponent.new(request: f.object, id: 'terms', classes: ['d-none'], step_index: step_enum.next, form_id: f.id, data: { 'patronrequest-forRequestType': 'scan' }) do |c| %>
+          <% c.with_title.with_content('Terms') %>
+
+          <% c.with_body do %>
+            TODO: Terms
+          <% end %>
+        <% end %>
+
+        <%= render AccordionStepComponent.new(id: 'submit', step_index: '-', form_id: f.id, submit: true, submit_text: 'Submit to Aeon', cancel: false) do |component| %>
           <% component.with_title.with_content('Review and submit') %>
           <% component.with_body do %>
             <div class="mb-4">
@@ -132,7 +160,7 @@
       <div>
         <% if @ead.repository %>
           <h3>
-            <%= link_to @ead.repository_contact[:website] do  %>
+            <%= link_to @ead.repository_contact[:website] do %>
               <%= @ead.repository %><i class="bi bi-arrow-up-right ms-1"></i>
             <% end %>
           </h3>

--- a/spec/features/archives_request_spec.rb
+++ b/spec/features/archives_request_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe 'Requesting an item from an EAD', :js do
     check 'Box 12'
     click_button 'Continue'
 
+    # In the Appointment step
+    click_button 'Continue'
+
+    # In the (temporary) review step
     click_button 'Submit to Aeon'
 
     expect(page).to have_content('All 1 request(s) submitted successfully!')


### PR DESCRIPTION
<img width="670" height="421" alt="Screenshot 2026-02-20 at 12 50 38" src="https://github.com/user-attachments/assets/ca10e608-5726-4218-a0a2-8ce98dc6b568" />

Getting these in early to hopefully reduce merge conflicts later 🤷 