### PR TITLE
Always use the container name (passed through the Aeon's itemVolume)

### DIFF
--- a/app/views/archives_requests/_series_contents.html.erb
+++ b/app/views/archives_requests/_series_contents.html.erb
@@ -10,9 +10,7 @@
     <% 
       container_name = display_group.name
       group = display_group.contents
-      # Use container name as subseries if we're directly under the series (no subseries nesting)
-      subseries_name = parent_title == series_title ? container_name : parent_title
-      checkbox_id = volume_checkbox_id(series_title: series_title, subseries_name: subseries_name)
+      checkbox_id = volume_checkbox_id(series_title: series_title, subseries_name: container_name)
       content_id = "container-items-#{checkbox_id}"
     %>
     <div class="mt-3 mb-2 d-flex align-items-start gap-2">
@@ -27,7 +25,7 @@
       <%= f.check_box :volumes, 
             { multiple: true, class: 'form-check-input mt-1', id: checkbox_id, 
               data: { action: 'change->archives-request#updateVolumesDisplay' } }, 
-            volume_value(series_title: series_title, subseries_name: subseries_name), 
+            volume_value(series_title: series_title, subseries_name: container_name),
             nil %>
       <div class="flex-grow-1">
         <%= label_tag checkbox_id, container_name, class: 'form-check-label' %>

--- a/spec/features/archives_request_spec.rb
+++ b/spec/features/archives_request_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
     expect(stub_aeon_client).to have_received(:create_request).with(an_object_having_attributes(
                                                                       username: user.email_address,
                                                                       call_number: 'SC0097 Computers and Typesetting',
+                                                                      item_volume: 'Box 12',
                                                                       site: 'SPECUA'
                                                                     ))
   end


### PR DESCRIPTION
I suspect we want subseries eventually, but as-is we end up omitting the box number entirely as far as I can tell. This should get us to parity with Aeon 🤷 