### PR TITLE
Use the Aeon user to submit the patron request

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -35,7 +35,7 @@ class PatronRequestsController < ApplicationController
 
   def create
     if @patron_request.aeon_page?
-      @patron_request.submit_aeon_request
+      @patron_request.submit_aeon_request(username: current_user.aeon.username)
       redirect_to @patron_request
     elsif @patron_request.save && @patron_request.submit_later
       redirect_to @patron_request

--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -6,9 +6,8 @@ class SubmitAeonPatronRequestJob < ApplicationJob
   queue_as :default
   retry_on Faraday::ConnectionFailed
 
-  def perform(patron_request)
+  def perform(patron_request, username:)
     aeon_requests = patron_request.aeon_requests
-    username = patron_request.patron.email
 
     aeon_requests.each do |aeon_request|
       submit_aeon_request(username, aeon_request)

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -246,8 +246,8 @@ class PatronRequest < ApplicationRecord
     SubmitPatronRequestJob.perform_later(self)
   end
 
-  def submit_aeon_request
-    SubmitAeonPatronRequestJob.perform_now(self)
+  def submit_aeon_request(username:)
+    SubmitAeonPatronRequestJob.perform_now(self, username:)
   end
 
   # @return [Folio::Instance]

--- a/spec/jobs/submit_aeon_patron_request_job_spec.rb
+++ b/spec/jobs/submit_aeon_patron_request_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SubmitAeonPatronRequestJob do
 
     describe '#map_json' do
       it 'correctly maps the Aeon request object to an Aeon client payload' do
-        mapped_json = described_class.new.map_json(request.patron.email, request.aeon_requests.first)
+        mapped_json = described_class.new.map_json('aeon_username', request.aeon_requests.first)
         expect(JSON.parse(mapped_json)).to match(hash_including(
                                                    'callNumber' => 'ABC 123',
                                                    'documentType' => 'Monograph',


### PR DESCRIPTION
This is against the `aeonForm` branch.

`patron_request.patron.email` is the Folio user. This is quick swap to the aeon user to unblock. Requests don't go through otherwise.