### PR TITLE
Test more of the new SearchWorks Aeon request process

### DIFF
--- a/app/views/patron_requests/_digitization_options.html.erb
+++ b/app/views/patron_requests/_digitization_options.html.erb
@@ -18,18 +18,18 @@
           </div>
           <div class="mt-3 d-flex">
             <div class="fw-bold me-2">Is this for publication? </div>
-            <%= field.radio_button :publication, 'Yes', :class => 'form-check-input', :disabled => f.object.selectable_items.many? %>
-            <%= field.label :publication, :class => 'form-check-label ms-2 me-3' do %>
+            <%= field.radio_button :publication, 'Yes', class: 'form-check-input', disabled: f.object.selectable_items.many? %>
+            <%= field.label :publication_yes, class: 'form-check-label ms-2 me-3' do %>
               Yes
             <% end %>
 
-            <%= field.radio_button :publication, 'No', :disabled => true, :class => 'form-check-input', :disabled => f.object.selectable_items.many? %>
-            <%= field.label :publication, :class => 'form-check-label ms-2 me-3' do %>
+            <%= field.radio_button :publication, 'No', class: 'form-check-input', disabled: f.object.selectable_items.many? %>
+            <%= field.label :publication_no, class: 'form-check-label ms-2 me-3' do %>
               No
             <% end %>
           </div>
           <div class="mt-3 mb-2">
-            <%= field.label :digitization_special, 'Additional Information', :class => 'fw-bold py-2' %>
+            <%= field.label :digitization_special, 'Additional information', :class => 'fw-bold py-2' %>
             <%= field.text_area :digitization_special, :class => 'form-control', :rows => 3 , :disabled => f.object.selectable_items.many? %>
             <small class="text-cardinal mt-4">Limit 255 characters.</small> 
           </div>

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -21,7 +21,7 @@
   </div>
 
   <div class='mt-3 mb-2'>
-    <%= f.label :aeon_reading_special, 'Additional Information', :class => 'fw-bold py-2' %>
+    <%= f.label :aeon_reading_special, 'Additional information', :class => 'fw-bold py-2' %>
     <%= f.text_area :aeon_reading_special, :class => 'form-control', :rows => 3 %>
     <small class='text-cardinal mt-4'>Limit 255 characters.</small> 
   </div>

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -61,9 +61,23 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
       click_button 'Continue'
 
       fill_in 'Requested pages', with: 'Pages 1-10'
+      choose 'Yes'
+      fill_in 'Additional information', with: 'Testing only'
 
       click_button 'Continue'
       check 'I agree to these terms'
+
+      expect(page).to have_button 'Submit request'
+    end
+
+    it 'allows the user to submit a reading room request' do
+      choose 'Reading room appointment'
+
+      click_button 'Continue'
+
+      fill_in 'Additional information', with: 'Testing only'
+
+      expect(page).to have_button 'Submit request'
     end
   end
 


### PR DESCRIPTION
I wanted to do this yesterday but was fighting capybara 'unable to find xyz that is not disabled' issues. Turns out it was a label for ID mismatch.

I think it makes sense to wait until https://github.com/sul-dlss/sul-requests/issues/3056 is in before taking these even futher.