### PR TITLE
Add basic library contact info to SearchWorks Aeon requests

### DIFF
--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -113,7 +113,32 @@
 <% end %>
 </div>
 <aside class="col-4">
+  <% library_code = @patron_request.origin_library_code %>
+  <% library = Settings.libraries[library_code] %>
+  <% if library %>
   <h2>Contact information</h2>
+  <div>
+      <h3>
+        <% if library.reading_room_url %>
+          <%= link_to library.reading_room_url do %>
+            <%= library.label %><i class="bi bi-arrow-up-right ms-1"></i>
+          <% end %>
+        <% else %>
+          <%= library.label %>
+        <% end %>
+      </h3>
+      <% if library.contact_info&.phone %>
+        <p class="mb-1">
+          <span class="fw-semibold">Phone: </span><%= library.contact_info.phone %>
+        </p>
+      <% end %>
+      <% if library.contact_info&.email %>
+        <p>
+          <span class="fw-semibold">Email: </span><%= mail_to library.contact_info.email %>
+        </p>
+      <% end %>
+  </div>
+  <% end %>
 </aside>
 </div>
 </div>


### PR DESCRIPTION
Marlo already noticed the empty contact info column so maybe that's confusing. We can add what we have at hand.

<img width="1020" height="218" alt="Screenshot 2026-02-26 at 3 48 21 PM" src="https://github.com/user-attachments/assets/549bfe35-8f66-4038-89b2-7b83946f3f7f" />
