### PR TITLE
Use consistent size and alignment for finding aid elements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -490,6 +490,10 @@ label.btn-close {
   }
 }
 
+.disclosure-icon {
+  font-size: 1rem;
+}
+
 .redesign-required-label::after {
   content: '*required';
   color: var(--stanford-cardinal);

--- a/app/views/archives_requests/_series_contents.html.erb
+++ b/app/views/archives_requests/_series_contents.html.erb
@@ -50,9 +50,15 @@
     <% 
       checkbox_id = volume_checkbox_id(series_title: series_title || display_group.title, subseries_name: display_group.title)
     %>
-    <div class="mb-2">
+    <div class="mb-2 d-flex align-items-start gap-2">
+      <% if nested %>
+        <%# Hidden spacer to align with containers that have a disclosure toggle %>
+        <span class="btn btn-sm p-0 ms-2 invisible" aria-hidden="true">
+          <i class="bi bi-chevron-right disclosure-icon"></i>
+        </span>
+      <% end %>
       <%= f.check_box :volumes, 
-            { multiple: true, class: 'form-check-input me-2', id: checkbox_id, 
+            { multiple: true, class: "form-check-input mt-1 #{'ms-2' unless nested}", id: checkbox_id, 
               data: { action: 'change->archives-request#updateVolumesDisplay' } }, 
               volume_value(series_title: series_title || display_group.title, subseries_name: display_group.title),
             nil %>
@@ -71,7 +77,7 @@
     <div class="my-1">
       <%# Subseries header (collapsible) %>
       <%= link_to "##{subseries_id}", 
-            class: 'series-header btn btn-link text-decoration-none text-start p-0 mb-2 d-flex align-items-center gap-2',
+            class: 'series-header btn btn-link text-decoration-none text-start p-0 ms-2 mb-2 d-flex align-items-center gap-2',
             data: { bs_toggle: 'collapse' },
             aria: { expanded: false, controls: subseries_id } do %>
         <i class="bi bi-chevron-right disclosure-icon"></i>
@@ -80,7 +86,7 @@
       <% end %>
       <%# Subseries content (recursive) %>
       <div id="<%= subseries_id %>" class="collapse mt-2 ms-3" data-archives-series-target="content">
-        <%= render partial: 'series_contents', locals: { contents: display_group.contents, f: f, parent_title: display_group.title, series_title: series_title || display_group.title } %>
+        <%= render partial: 'series_contents', locals: { contents: display_group.contents, f: f, parent_title: display_group.title, series_title: series_title || display_group.title, nested: true } %>
       </div>
     </div>
   <% end %>

--- a/app/views/archives_requests/new.html.erb
+++ b/app/views/archives_requests/new.html.erb
@@ -67,7 +67,7 @@
                   <button class="btn btn-link su-underline" data-action="click->archives-series#collapseAll"><i class="bi bi-chevron-double-down me-1"></i>Collapse all</button>
                 </div>
                 <%# Loop through each series in the collection %>
-                <%= render partial: 'series_contents', locals: { contents: Ead::DisplayGroup.build_display_groups(@ead.series_and_subseries), f: f, series_title: nil, parent_title: nil } %>
+                <%= render partial: 'series_contents', locals: { contents: Ead::DisplayGroup.build_display_groups(@ead.series_and_subseries), f: f, series_title: nil, parent_title: nil, nested: false } %>
               </div>
             <% end %>
           <% end %>

--- a/spec/views/archives_requests/_series_contents.html.erb_spec.rb
+++ b/spec/views/archives_requests/_series_contents.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'archives_requests/_series_contents.html.erb' do
       display_groups = Ead::DisplayGroup.build_display_groups(items)
 
       render partial: 'archives_requests/series_contents',
-             locals: { contents: display_groups, f: form_builder, parent_title: parent_title, series_title: parent_title }
+             locals: { contents: display_groups, f: form_builder, parent_title: parent_title, series_title: parent_title, nested: false }
 
       # Should have container label with badge showing count
       expect(rendered).to have_css('.form-check-label', text: 'Box 9')
@@ -69,7 +69,7 @@ RSpec.describe 'archives_requests/_series_contents.html.erb' do
       display_groups = Ead::DisplayGroup.build_display_groups(items)
 
       render partial: 'archives_requests/series_contents',
-             locals: { contents: display_groups, f: form_builder, parent_title: parent_title, series_title: parent_title }
+             locals: { contents: display_groups, f: form_builder, parent_title: parent_title, series_title: parent_title, nested: false }
 
       # Should have individual checkboxes for each item
       expect(rendered).to have_css('.form-check-label', text: 'Standalone Item 1')
@@ -106,7 +106,7 @@ RSpec.describe 'archives_requests/_series_contents.html.erb' do
       display_groups = Ead::DisplayGroup.build_display_groups(items)
 
       render partial: 'archives_requests/series_contents',
-             locals: { contents: display_groups, f: form_builder, parent_title: parent_title, series_title: parent_title }
+             locals: { contents: display_groups, f: form_builder, parent_title: parent_title, series_title: parent_title, nested: false }
 
       # Should have subseries header with title and badge
       expect(rendered).to have_css('span', text: 'Subseries A')


### PR DESCRIPTION
Closes #3093 

<img width="330" height="185" alt="Screenshot 2026-02-26 at 5 19 22 PM" src="https://github.com/user-attachments/assets/edde54b1-afaf-47c6-92e3-a4c07d3c5795" />
<img width="449" height="274" alt="Screenshot 2026-02-26 at 5 19 55 PM" src="https://github.com/user-attachments/assets/1564db71-744a-4ea7-8d23-c124a7816ab0" />
<img width="280" height="138" alt="Screenshot 2026-02-26 at 5 20 19 PM" src="https://github.com/user-attachments/assets/95a792d3-df77-4761-aaf2-de46b74082db" />
<img width="514" height="184" alt="Screenshot 2026-02-26 at 5 20 38 PM" src="https://github.com/user-attachments/assets/202ad60d-1198-4ef5-9c4b-7317d0260d39" />
