### PR TITLE
At least validate we've on the confirmation page.

### DIFF
--- a/spec/features/archives_request_spec.rb
+++ b/spec/features/archives_request_spec.rb
@@ -74,9 +74,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       page.execute_script("document.querySelector('select').dispatchEvent(new Event('input', { bubbles: true }))")
       click_button 'Submit to Aeon'
 
-      # TODO: Submissions tests, submissions page will continue to change so skipping for now
-      # expect(page).to have_content('All 1 request(s) submitted successfully!')
-
+      expect(page).to have_content('We received your reading room access request')
       expect(stub_aeon_client).to have_received(:create_request).with(an_object_having_attributes(
                                                                         username: user.email_address,
                                                                         call_number: 'SC0097 Computers and Typesetting',
@@ -108,8 +106,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'I agree to these terms'
       click_button 'Submit to Aeon'
 
-      # TODO: Submissions tests, submissions page will continue to change so skipping for now
-      # expect(page).to have_content('All 1 request(s) submitted successfully!')
+      expect(page).to have_content('We received your digitization request')
       expect(stub_aeon_client).to have_received(:create_request).with(an_object_having_attributes(
                                                                         username: user.email_address,
                                                                         item_info5: 'Pages 1-10',


### PR DESCRIPTION
Otherwise the tests can be flappy (because it can check if the stub was triggered before we even get there..) 