### PR TITLE
stub out login page for ead

### DIFF
--- a/app/controllers/archives_requests_controller.rb
+++ b/app/controllers/archives_requests_controller.rb
@@ -12,10 +12,11 @@ class ArchivesRequestsController < ApplicationController
   end
 
   def new
-    authorize! :new, Aeon::Request
-
     @ead = EadClient.fetch(ead_url_param)
     @ead_request = Ead::Request.new(user: current_user, ead: @ead, params: (params[:ead_request] ? new_params : {}))
+    return if can?(:new, Aeon::Request)
+
+    render 'login'
   end
 
   # This is the action triggered by the form submission to create an Aeon request.

--- a/app/views/archives_requests/login.html.erb
+++ b/app/views/archives_requests/login.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>Request: <%= @ead.title %><% end %>
+
+<h1 class="fw-semibold my-3 fs-1">
+  <%= @ead.title %>
+</h1>
+<p class="mb-4 lead fw-normal">
+    Stanford Libraries provides various request services for added convenience, but their availability
+    depends on factors such as your affiliation, material type, status, and location. Access through
+    SUNet ID grants broader privileges than library cardholder or visitor access.
+</p>
+<div class="row flex-column flex-sm-row landing-page mb-3">
+  <div class="col-sm-6">
+      <div class="card">
+          <h2 class="card-header bg-white fw-normal h1">Stanford community</h2>
+          <div class="card-body">
+              <%= link_to 'Log in with SUNet ID', login_by_sunetid_url(referrer: request.original_url), data: { turbo: false }, class: 'btn btn-md btn-secondary btn-full mb-2' %>
+              <p>
+                  As a member of the Stanford community, including <b>faculty, students, staff, post-docs, fellows, and visiting scholars</b>, you are issued a SUNet ID. With this ID, you can access more additional services, including requesting items from partner libraries or receiving digital scans via email.
+              </p>
+              <a href="https://library.stanford.edu/services/borrow-and-request" target="_blank" class="su-underline">
+                  <i class="bi bi-box-arrow-up-right"></i> Review borrow and request policies
+              </a>
+          </div>
+      </div>
+  </div>
+</div>

--- a/spec/features/archives_request_spec.rb
+++ b/spec/features/archives_request_spec.rb
@@ -151,4 +151,18 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(find('select[name="appointment"]').all('option').map(&:text)).to eq ['', 'Feb 19, 2026 ● 12:00 PM - 1:00 PM (1 item)']
     end
   end
+
+  context 'without a logged in user' do
+    let(:current_user) { CurrentUser.new({}) }
+    let(:eadxml) do
+      Nokogiri::XML(File.read('spec/fixtures/a0112.xml')).tap(&:remove_namespaces!)
+    end
+
+    it 'shows login page' do
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      expect(page).to have_content('Pehrson (Elmer Walter) Photograph Album')
+      expect(page).to have_content('Log in with SUNet ID')
+    end
+  end
 end


### PR DESCRIPTION
Right now you have to open a new tab because it is returning this page and it is annoying to have to open a new tab to get logged in
<img width="979" height="161" alt="Screenshot 2026-02-27 at 3 47 50 PM" src="https://github.com/user-attachments/assets/957bfde8-45dd-4a46-823d-e8f6ce677d12" />
<img width="828" height="786" alt="Screenshot 2026-02-27 at 3 48 15 PM" src="https://github.com/user-attachments/assets/81db65f3-23b3-462c-a6ee-96363f982708" />


