### PR TITLE
adding flex wrap to wrap lines

### DIFF
--- a/app/components/aeon/request_component.html.erb
+++ b/app/components/aeon/request_component.html.erb
@@ -58,7 +58,7 @@
   <div class="card-body d-flex justify-content-between">
     <div class="metadata">
       <h2 class="h3"><%= title %></h2>
-      <div class="d-flex gap-sm-3 flex-sm-row flex-column">
+      <div class="d-flex gap-sm-3 flex-sm-row flex-wrap flex-column">
         <div>
           <%= render Icons::DocumentBox1Component.new %><%= document_type %><% if date %> (<%= date %>)<% end %>
         </div>


### PR DESCRIPTION
Closes #2968

The figma shows that elements in the call number row can wrap to the next line across sizes.  Examples below:

In medium, putting elements on the next line
<img width="522" height="221" alt="Screenshot 2026-03-02 at 12 06 07 PM" src="https://github.com/user-attachments/assets/5be68aea-4030-496e-83c5-a8aa370e5e91" />

In medium, not putting elements on the next line
<img width="544" height="217" alt="Screenshot 2026-03-02 at 12 06 27 PM" src="https://github.com/user-attachments/assets/167b23ea-5cda-4f10-90bc-bcf74c6b4e6f" />

Screenshots after updating the code:

XS
<img width="572" height="629" alt="Screenshot 2026-03-02 at 12 09 25 PM" src="https://github.com/user-attachments/assets/8476209d-0547-4c7b-aa91-dbb7390b427f" />
---

Small

<img width="516" height="844" alt="Screenshot 2026-03-02 at 12 10 23 PM" src="https://github.com/user-attachments/assets/39a83179-6c96-4dbe-a674-452f920e14b1" />
---

Small showing elements wrapping to next line/moving elements to the next line
<img width="503" height="310" alt="Screenshot 2026-03-02 at 12 13 57 PM" src="https://github.com/user-attachments/assets/7ede8697-6a45-412c-8cb2-9156a8452232" />

---

Medium
<img width="817" height="818" alt="Screenshot 2026-03-02 at 12 10 43 PM" src="https://github.com/user-attachments/assets/f27ff1a4-dd09-4c33-a369-6b790c220223" />
---

Medium showing elements going to the next line when one element is too long
<img width="687" height="284" alt="Screenshot 2026-03-02 at 12 11 07 PM" src="https://github.com/user-attachments/assets/96806fae-842a-46b9-97e5-4aa5b1a10045" />