### PR TITLE
Provide a fallback redirect location for feedback form controller

### DIFF
--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -11,7 +11,7 @@ class FeedbackFormsController < ApplicationController
 
     respond_to do |format|
       format.json { render json: feedback_flash_messages }
-      format.html { redirect_to params[:url], flash: feedback_flash_messages }
+      format.html { redirect_to params[:url] || root_url, flash: feedback_flash_messages }
     end
   end
 


### PR DESCRIPTION
Closes #2878

Presumably when `params[:url]` is nil we were falling back to polymorphic routing? If we provide a fallback that shouldn't happen.