### PR TITLE
componentize reading room info with new appt button

### DIFF
--- a/app/components/aeon/reading_room_brief_component.html.erb
+++ b/app/components/aeon/reading_room_brief_component.html.erb
@@ -1,0 +1,14 @@
+<div class="d-flex flex-row justify-content-between align-items-start gap-2">
+  <div class="d-flex flex-column mb-2">
+    <span class="fw-semibold">
+      <i class="bi bi-geo-alt-fill"></i>
+      <%= reading_room.name %>
+    </span>
+    <span class="mb-2">
+      Hours: <%= reading_room.human_readable_hours %>
+    </span>
+  </div>
+  <%= link_to new_aeon_appointment_path(reading_room_id: reading_room.id ), class: 'btn btn-primary hide-when-1-item', data: { action: 'modal#open' } do %>
+    <i class="bi bi-calendar-plus me-1"></i>Create new appointment
+  <% end %>
+</div>

--- a/app/components/aeon/reading_room_brief_component.rb
+++ b/app/components/aeon/reading_room_brief_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Render an accordion item for a digitization form step.
+  class ReadingRoomBriefComponent < ViewComponent::Base
+    def initialize(reading_room:)
+      @reading_room = reading_room
+    end
+
+    attr_reader :reading_room
+  end
+end

--- a/app/views/archives_requests/new.html.erb
+++ b/app/views/archives_requests/new.html.erb
@@ -81,20 +81,7 @@
         <%= render AccordionStepComponent.new(request: f.object, id: 'pickup', submit: true, submit_text: 'Submit to Aeon', cancel: false, classes: [('d-none' if  f.object.request_type.blank? || f.object.request_type == 'scan')], form_id: f.id, step_index: (scan_or_pickup_step ||= step_enum.next), data: { 'patronrequest-forRequestType': 'pickup' }) do |c| %>
           <% c.with_title.with_content('Reading room use') %>
           <% c.with_body do %>
-            <div class="d-flex flex-row justify-content-between align-items-start gap-2">
-              <div class="d-flex flex-column mb-2">
-                <span class="fw-semibold">
-                  <i class="bi bi-geo-alt-fill"></i>
-                  <%= @ead_request.reading_room.name %>
-                </span>
-                <span class="mb-2">
-                  Hours: <%= @ead_request.reading_room.human_readable_hours %>
-                </span>
-              </div>
-              <%= link_to new_aeon_appointment_path(reading_room_id: @ead_request.reading_room.id ), class: 'btn btn-primary hide-when-1-item', data: { action: 'modal#open' } do %>
-                <i class="bi bi-calendar-plus me-1"></i>Create new appointment
-              <% end %>
-            </div>
+            <%= render Aeon::ReadingRoomBriefComponent.new(reading_room: @ead_request.reading_room) %>
 
             <div class="alert alert-warning alert-dismissible shadow-sm d-flex align-items-center">
               <div role="img" aria-label="Warning icon" class="bi bi-exclamation-triangle-fill text-warning fs-3 me-3"></div>

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -1,16 +1,5 @@
 <div class="row p-3 gap-3 flex-column flex-md-row">
-  <div class="d-flex flex-row justify-content-between align-items-start gap-2">
-    <div class="d-flex flex-column mb-2">
-      <span class="fw-semibold">
-        <i class="bi bi-geo-alt-fill"></i>
-        <%= f.object.aeon_reading_room_name %>
-      </span>
-    </div>
-    <%= link_to new_aeon_appointment_path(reading_room_id: f.object.aeon_reading_room.id ), class: 'btn btn-primary hide-when-1-item', data: { action: 'modal#open' } do %>
-      <i class="bi bi-calendar-plus me-1"></i>Create new appointment
-    <% end %>
-  </div>
-
+  <%= render Aeon::ReadingRoomBriefComponent.new(reading_room: f.object.aeon_reading_room) %>
 
   <% appointments = current_user.aeon.appointments.select { |appt| appt.reading_room.sites.include?(f.object.aeon_site) } %>
 


### PR DESCRIPTION
closes #3133 

https://github.com/sul-dlss/sul-requests/pull/3142 did all the work for 3133. This just makes it look pretty on the Folio side. Is working on the folio side.
<img width="710" height="636" alt="Screenshot 2026-03-03 at 10 31 50 AM" src="https://github.com/user-attachments/assets/c2a87405-476e-435e-9cb0-5fbc46b8a4bd" />
