### PR TITLE
move earliest avail out of label, wrap appt dropdown

### DIFF
--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="bg-light border rounded mb-2 p-2 d-flex gap-4 text-nowrap align-items-center" data-content-id="<%= dom_id %>">
+<div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="bg-light border rounded mb-2 p-2 d-flex gap-4 text-nowrap align-items-center flex-wrap" data-content-id="<%= dom_id %>">
   <div class="d-flex align-items-center">
     <i class="fs-4 bi bi-circle me-2" data-selected-item-form-target="status"></i>
     <span class="text-black fw-semibold"><%= title %></span>

--- a/app/views/patron_requests/_reading_or_digitization.html.erb
+++ b/app/views/patron_requests/_reading_or_digitization.html.erb
@@ -5,11 +5,11 @@
     <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input', :required => true, data: { action: 'patron-request#updateType' } %>
     <%= f.label :request_type_pickup, :class => 'form-check-label ms-1' do %>
       Reading room appointment
-      <span class="text-cardinal ms-2 mt-1">
-        Earliest appointment available:
-        <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_appointments_path(f.object.aeon_reading_room&.id, Date.today) %>
-      </span>
     <% end %>
+    <span class="text-cardinal ms-2 mt-1">
+      Earliest appointment available:
+      <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_appointments_path(f.object.aeon_reading_room&.id, Date.today) %>
+    </span>
 
   </div>
   <div class="mt-4">


### PR DESCRIPTION
Before:
<img width="524" height="698" alt="Screenshot 2026-03-03 at 10 53 50 AM" src="https://github.com/user-attachments/assets/3e41ffa9-151a-4c0f-9a76-73a54416d521" />
After:
<img width="524" height="774" alt="Screenshot 2026-03-03 at 10 54 09 AM" src="https://github.com/user-attachments/assets/305002a8-3720-4439-af36-89b4008ddb63" />

Before:
<img width="457" height="282" alt="Screenshot 2026-03-03 at 10 55 48 AM" src="https://github.com/user-attachments/assets/6d43f487-28bb-4fa3-b24e-683ab57095ae" />
After:
<img width="480" height="266" alt="Screenshot 2026-03-03 at 10 58 58 AM" src="https://github.com/user-attachments/assets/8a40f423-4775-4523-b63f-fd7c48b2a40b" />
