### PR TITLE
Extract request actions and item detail components

### DIFF
--- a/app/components/aeon/request_actions_component.html.erb
+++ b/app/components/aeon/request_actions_component.html.erb
@@ -1,0 +1,40 @@
+    <div class="d-flex text-nowrap align-items-baseline align-self-start">
+      <% if request.cancelled? %>
+        <form action="<%= resubmit_aeon_request_path(transaction_number) %>" method="PATCH">
+          <button type="submit" class="btn btn-link su-underline" aria-label="resubmit request"><i class="bi bi-arrow-clockwise"></i> Resubmit</button>
+        </form>
+      <% else %>
+        <% if appointment&.editable? %>
+          <a class="btn btn-link su-underline p-0 me-sm-2" href="#replace_me">
+            <i class="bi bi-pencil-fill me-1 align-middle"></i><span class="d-none d-sm-inline">Edit request</span>
+          </a>
+        <% end %>
+        <% if helpers.can? :destroy, request %>
+          <button class="btn btn-link su-underline p-0" type="submit" data-bs-toggle="modal" data-bs-target="#delete-<%= transaction_number %>">
+            <i class="bi bi-trash align-middle"></i><span class="visually-hidden">Delete <%= title %> request</span>
+          </button>
+        <% end %>
+      <% end %>
+      <!-- Delete modal -->
+      <div class="modal fade" id="delete-<%= transaction_number %>" tabindex="-1" aria-labelledby="title-<%= transaction_number %>" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h2 class="modal-title" id="title-<%= transaction_number %>">Delete request?</h2>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body fw-normal">
+              <div><span class="fw-bold">Title:</span> <%= title %></div>
+              <div><span class="fw-bold">Request:</span> <%= request_type %> <%= render Aeon::RequestItemDetailComponent.new(request:, variant: :text) %></div>
+              <div class="mt-2 fw-bold">This action cannot be undone.</div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">No</button>
+              <form action="<%= aeon_request_path(transaction_number) %>" method="DELETE">
+                <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Yes - Delete</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>

--- a/app/components/aeon/request_actions_component.rb
+++ b/app/components/aeon/request_actions_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Render request actions
+  class RequestActionsComponent < ViewComponent::Base
+    attr_reader :request
+
+    delegate :appointment, :digital?, :editable?, :title, :transaction_number, to: :request
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def request_type
+      if digital?
+        'Digitization'
+      else
+        'Reading room use'
+      end
+    end
+  end
+end

--- a/app/components/aeon/request_component.html.erb
+++ b/app/components/aeon/request_component.html.erb
@@ -14,46 +14,7 @@
       </span>
       <% end %>
     </div>
-    <div class="d-flex text-nowrap align-items-baseline align-self-start">
-      <% if request.cancelled? %>
-        <form action="<%= resubmit_aeon_request_path(transaction_number) %>" method="PATCH">
-          <button type="submit" class="btn btn-link su-underline" aria-label="resubmit request"><i class="bi bi-arrow-clockwise"></i> Resubmit</button>
-        </form>
-      <% else %>
-        <% if appointment&.editable? %>
-          <a class="btn btn-link su-underline p-0 me-sm-2" href="#replace_me">
-            <i class="bi bi-pencil-fill me-1 align-middle"></i><span class="d-none d-sm-inline">Edit request</span>
-          </a>
-        <% end %>
-        <% if helpers.can? :destroy, request %>
-          <button class="btn btn-link su-underline p-0" type="submit" data-bs-toggle="modal" data-bs-target="#delete-<%= transaction_number %>">
-            <i class="bi bi-trash align-middle"></i><span class="visually-hidden">Delete <%= title %> request</span>
-          </button>
-        <% end %>
-      <% end %>
-      <!-- Delete modal -->
-      <div class="modal fade" id="delete-<%= transaction_number %>" tabindex="-1" aria-labelledby="title-<%= transaction_number %>" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h2 class="modal-title" id="title-<%= transaction_number %>">Delete request?</h2>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body fw-normal">
-              <div><span class="fw-bold">Title:</span> <%= title %></div>
-              <div><span class="fw-bold">Request:</span> <%= status_text %><% if format_info %> (<%= format_info %>)<% end %></div>
-              <div class="mt-2 fw-bold">This action cannot be undone.</div>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">No</button>
-              <form action="<%= aeon_request_path(transaction_number) %>" method="DELETE">
-                <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Yes - Delete</button>
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <%= render Aeon::RequestActionsComponent.new(request:) %>
   </div>
   <div class="card-body d-flex justify-content-between">
     <div class="metadata">
@@ -67,13 +28,7 @@
           <div><a href="<%= searchworks_url %>" class="su-underline">View in SearchWorks<i class="ms-1 bi bi-arrow-up-right"></i></a></div>
         <% end %>
       </div>
-      <% if format_info %>
-        <div class="mt-2">
-          <span class="p-1 bg-stanford-10-black fw-semibold">
-            <%= format_info %>
-          </span>
-        </div>
-      <% end %>
+      <%= render Aeon::RequestItemDetailComponent.new(request:) %>
     </div>
     <% if thumbnail? %>
       <div>

--- a/app/components/aeon/request_component.rb
+++ b/app/components/aeon/request_component.rb
@@ -5,9 +5,9 @@ module Aeon
   class RequestComponent < ViewComponent::Base
     attr_reader :request
 
-    delegate :appointment?, :appointment, :item_url, :pages, :volume, :format, :title,
+    delegate :appointment?, :appointment, :item_url, :title,
              :date, :document_type, :call_number, :transaction_status, :transaction_date,
-             :transaction_number, :draft?, :editable?, :completed?, :submitted?, :digital?, :physical?, :scan_delivered?, to: :request
+             :transaction_number, :draft?, :completed?, :submitted?, :digital?, :physical?, :scan_delivered?, to: :request
 
     def initialize(request:)
       @request = request
@@ -17,14 +17,6 @@ module Aeon
       return unless item_url&.include?('searchworks')
 
       item_url
-    end
-
-    def format_info
-      return "Pages: #{pages}" if pages.present?
-      return "Item: #{volume}" if volume.present?
-      return "Format: #{format}" if format.present?
-
-      nil
     end
 
     def status_text

--- a/app/components/aeon/request_item_detail_component.html.erb
+++ b/app/components/aeon/request_item_detail_component.html.erb
@@ -1,0 +1,7 @@
+<% if @variant == :text %>
+(<%= format_info %>)
+<% else %>
+<div class="mt-2">
+  <span class="p-1 bg-stanford-10-black fw-semibold"><%= format_info %></span>
+</div>
+<% end %>

--- a/app/components/aeon/request_item_detail_component.rb
+++ b/app/components/aeon/request_item_detail_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Request item details
+  class RequestItemDetailComponent < ViewComponent::Base
+    attr_reader :request
+
+    delegate :pages, :volume, :format, to: :request
+
+    def initialize(request:, variant: :full)
+      @request = request
+      @variant = variant
+    end
+
+    def render?
+      format_info.present?
+    end
+
+    def format_info
+      return "Pages: #{pages}" if pages.present?
+      return "Item: #{volume}" if volume.present?
+      return "Format: #{format}" if format.present?
+
+      nil
+    end
+  end
+end


### PR DESCRIPTION
It seems like the new grouping behavior in https://github.com/sul-dlss/sul-requests/issues/2849 might be easier if we start breaking up the request component into smaller components.
