### PR TITLE
Remove feature flag check from handling submitted jobs

### DIFF
--- a/app/jobs/submit_patron_request_job.rb
+++ b/app/jobs/submit_patron_request_job.rb
@@ -7,7 +7,7 @@ class SubmitPatronRequestJob < ApplicationJob
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def perform(patron_request)
-    return SubmitAeonPatronRequestJob.perform_now(patron_request) if Settings.features.requests_redesign && patron_request.aeon_page?
+    return SubmitAeonPatronRequestJob.perform_now(patron_request) if patron_request.aeon_page?
     return convert_to_mediated_page(patron_request) if patron_request.mediateable?
     return place_title_hold(patron_request) if patron_request.selected_items.blank?
     return perform_scan_request(patron_request) if patron_request.scan?


### PR DESCRIPTION
If we got here in the first place, the flag was (presumably) set. It's just one less thing to stub for testing 🤷 