### PR TITLE
Don't apply flex-md-nowrap to single-item appointments display

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -580,6 +580,12 @@ label.btn-close {
   }
 }
 
+/* .flex-md-nowrap */
+@media (min-width: 768px) {
+  .appointments-container .appointments-item:not(:only-child) {
+    flex-wrap: nowrap;
+  }
+
 .appointments-container .appointments-item:only-child {
   .selected-item-status, .selected-item-remove {
     display: none;

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -1,4 +1,4 @@
-<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 p-2 d-flex column-gap-4 row-gap-2 text-nowrap align-items-center flex-wrap flex-md-nowrap" data-content-id="<%= dom_id %>">
+<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 p-2 d-flex column-gap-4 row-gap-2 text-nowrap align-items-center flex-wrap" data-content-id="<%= dom_id %>">
   <div class="d-flex align-items-center">
     <i class="fs-4 bi bi-circle me-2 selected-item-status" data-selected-item-form-target="status"></i>
     <span class="text-black fw-semibold selected-item-title"><%= title %></span>


### PR DESCRIPTION
I think we had a little regression when this class was explicitly added and ended up with a display like:
<img width="641" height="218" alt="Screenshot 2026-03-04 at 12 31 01" src="https://github.com/user-attachments/assets/ad1f49a0-57ad-4954-8bd6-029626abfd70" />

After:

<img width="662" height="408" alt="Screenshot 2026-03-04 at 12 30 28" src="https://github.com/user-attachments/assets/a518cba6-900c-4ba9-8656-4a72b6a9de9c" />
