### PR TITLE
Consolidate request type change handling into one controller

### DIFF
--- a/app/javascript/controllers/archives_request_controller.js
+++ b/app/javascript/controllers/archives_request_controller.js
@@ -29,10 +29,6 @@ export default class extends Controller {
     }
   }
 
-  updateRequestType(event) {
-    this.element.dataset.accordionFormTypeValue = event.target.value;
-  }
-
   showItemSelector() {
     const accordionController = this.application.getControllerForElementAndIdentifier(this.element, 'accordion-form');
     accordionController.goto('items-accordion');

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -44,3 +44,6 @@ application.register("modal", ModalController)
 
 import SelectedItemFormController from "./selected_item_form_controller"
 application.register("selected-item-form", SelectedItemFormController)
+
+import UpdateRequestTypeController from "./update_request_type_controller"
+application.register("update-request-type", UpdateRequestTypeController)

--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -45,16 +45,6 @@ export default class extends Controller {
     });
   }
 
-  updateType(event) {
-    const requestType = event.target.value;
-
-    const itemSelector = this.element.querySelector('[data-controller="item-selector"]');
-    if (itemSelector) itemSelector.dataset.itemSelectorRequestTypeValue = requestType;
-
-    this.element.dataset.accordionFormTypeValue = requestType;
-    this.element.dataset.itemSelectorItemLimitValue = this.typeValue != 'aeon' && requestType == 'scan' ? 1 : -1;
-  }
-
   updateProxy(event) {
     if (!this.hasProxyScanWarningTarget) return;
 

--- a/app/javascript/controllers/update_request_type_controller.js
+++ b/app/javascript/controllers/update_request_type_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  updateType(event) {
+    const requestType = event.target.value;
+
+    // this variable is null on the archives request page
+    const itemSelector = this.element.querySelector('[data-controller="item-selector"]');
+    if (itemSelector) itemSelector.dataset.itemSelectorRequestTypeValue = requestType;
+
+    this.element.dataset.accordionFormTypeValue = requestType;
+    // this was set in patron request controller earlier but not archives request controller
+    this.element.dataset.itemSelectorItemLimitValue = this.typeValue != 'aeon' && requestType == 'scan' ? 1 : -1;
+  }
+}

--- a/app/views/archives_requests/new.html.erb
+++ b/app/views/archives_requests/new.html.erb
@@ -29,15 +29,14 @@
           <% end %>
         </div>
       </div>
-      <%= form_with id: 'archives-request', model: @ead_request, url: archives_requests_path, class: 'accordion', html: { autocomplete: "off" }, data: { controller: 'accordion-form item-selector archives-request', action: 'item-selector:changed->archives-request#onSelectedItemsValueChanged item-selector:changed->accordion-form#typeValueChanged item-selector:changed->accordion-form#reenableNextButtons', turbo: false } do |f| %>
+      <%= form_with id: 'archives-request', model: @ead_request, url: archives_requests_path, class: 'accordion', html: { autocomplete: "off" }, data: { controller: 'accordion-form item-selector archives-request update-request-type', action: 'item-selector:changed->archives-request#onSelectedItemsValueChanged item-selector:changed->accordion-form#typeValueChanged item-selector:changed->accordion-form#reenableNextButtons', turbo: false } do |f| %>
         <%= f.hidden_field :ead_url %>
         <%= render AccordionStepComponent.new(id: 'request_type', step_index: step_enum.next, form_id: f.id) do |component| %>
           <% component.with_title.with_content('Request type') %>
           <% component.with_body do %>
             <fieldset class="ps-2">
               <div>
-                <!--TODO: refactor out #updateType in a new JS controller. Or pick one. This is wrong -->
-                <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input', :required => true, data: { action: 'archives-request#updateRequestType' } %>
+                <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input', :required => true, data: { action: 'update-request-type#updateType' } %>
                 <%= f.label :request_type_pickup, :class => 'form-check-label ms-1' do %>
                   Reading room appointment
                 <% end %>
@@ -47,7 +46,7 @@
                 </span>
               </div>
               <div class="mt-2">
-                <%= f.radio_button :request_type, 'scan', :class => 'form-check-input', data: { action: 'archives-request#updateRequestType' } %>
+                <%= f.radio_button :request_type, 'scan', :class => 'form-check-input', data: { action: 'update-request-type#updateType' } %>
                 <%= f.label :request_type_scan, :class => 'form-check-label ms-1' do %>
                   Digitization
                 <% end %>

--- a/app/views/patron_requests/_reading_or_digitization.html.erb
+++ b/app/views/patron_requests/_reading_or_digitization.html.erb
@@ -1,7 +1,7 @@
 
 <fieldset class="ps-2">
   <div>
-    <%= f.radio_button :request_type, 'pickup', class: 'form-check-input', required: true, data: { action: 'patron-request#updateType' } %>
+    <%= f.radio_button :request_type, 'pickup', class: 'form-check-input', required: true, data: { action: 'update-request-type#updateType' } %>
     <%= f.label :request_type_pickup, class: 'form-check-label ms-1' do %>
       Reading room appointment
     <% end %>
@@ -12,7 +12,7 @@
 
   </div>
   <div class="mt-2">
-    <%= f.radio_button :request_type, 'scan', class: 'form-check-input', data: { action: 'patron-request#updateType' } %>
+    <%= f.radio_button :request_type, 'scan', class: 'form-check-input', data: { action: 'update-request-type#updateType' } %>
     <%= f.label :request_type_scan, class: 'form-check-label ms-1' do %>
       Digitization
     <% end %>

--- a/app/views/patron_requests/_scan_or_pickup.html.erb
+++ b/app/views/patron_requests/_scan_or_pickup.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
   <div>
-    <%= f.radio_button :request_type, 'scan', :class => 'form-check-input', :required => true, data: { action: 'patron-request#updateType' } %>
+    <%= f.radio_button :request_type, 'scan', :class => 'form-check-input', :required => true, data: { action: 'update-request-type#updateType' } %>
     <%= f.label :request_type_scan, :class => 'form-check-label ms-1' do %>
       Email digital scan
     <% end %>
@@ -25,7 +25,7 @@
     </div>
   </div>
   <div class="mt-4">
-    <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input', data: { action: 'patron-request#updateType' } %>
+    <%= f.radio_button :request_type, 'pickup', :class => 'form-check-input', data: { action: 'update-request-type#updateType' } %>
     <%= f.label :request_type_pickup, :class => 'form-check-label ms-1' do %>
       Pickup physical item
     <% end %>

--- a/app/views/patron_requests/new.html+aeon.erb
+++ b/app/views/patron_requests/new.html+aeon.erb
@@ -46,7 +46,7 @@
 <% end %>
 
 <%= form_for(@patron_request,
-             data: { controller: 'patron-request accordion-form item-selector', action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->patron-request#showHideItemGroups item-selector:changed->accordion-form#typeValueChanged' },
+             data: { controller: 'patron-request accordion-form item-selector update-request-type', action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->patron-request#showHideItemGroups item-selector:changed->accordion-form#typeValueChanged' },
              html: { class: 'col-lg-8 accordion' },
              url: @patron_request.aeon_form_target,
              method: @patron_request.finding_aid? ? 'GET' : 'POST') do |f| %>

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -35,7 +35,7 @@
 
 <%= form_for(@patron_request,
             data: {
-              controller: 'patron-request accordion-form item-selector',
+              controller: 'patron-request accordion-form item-selector update-request-type',
               action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->accordion-form#typeValueChanged',
               'patron-request-type-value': 'aeon',
             },

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -46,7 +46,7 @@
 <% end %>
 
 <%= form_for(@patron_request,
-             data: { controller: 'patron-request accordion-form item-selector', action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->patron-request#showHideItemGroups item-selector:changed->accordion-form#typeValueChanged item-selector:changed->accordion-form#reenableNextButtons' },
+             data: { controller: 'patron-request accordion-form item-selector update-request-type', action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->patron-request#showHideItemGroups item-selector:changed->accordion-form#typeValueChanged item-selector:changed->accordion-form#reenableNextButtons' },
              html: { class: 'col-lg-8 accordion' },
              url: patron_requests_path,
              method: 'POST') do |f| %>


### PR DESCRIPTION
As part of work for #3059 , consolidating the handling for request type changes so we can handle digitization terms appearing across types of requests.