### PR TITLE
Default to a darker form check border color

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -102,6 +102,10 @@ input[type="radio"] {
   --bs-border-color: var(--stanford-50-black);
 }
 
+.form-check-input {
+  --bs-border-color: var(--stanford-50-black);
+}
+
 /* This selector/rule can be removed after https://github.com/twbs/bootstrap/pull/39098 is released */
 a {
   text-decoration: var(--bs-link-decoration);


### PR DESCRIPTION
Before:
<img width="160" height="45" alt="Screenshot 2026-03-04 at 2 09 48 PM" src="https://github.com/user-attachments/assets/bb670981-9aa4-40ba-8a5c-c1844173dad8" />

After:
<img width="185" height="47" alt="Screenshot 2026-03-04 at 2 18 55 PM" src="https://github.com/user-attachments/assets/8e36619c-332d-4087-be43-e80e6ea5d8c7" />
