### PR TITLE
add back in check for cancelled requests

### DIFF
--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -44,7 +44,7 @@ module Aeon
 
     def appointments
       @appointments ||= self.class.aeon_client.appointments_for(username:).sort_by(&:sort_key).reject(&:cancelled?).each do |appointment|
-        appointment.requests = requests.select { |request| request.appointment_id == appointment.id }
+        appointment.requests = requests.select { |request| !request.cancelled? && request.appointment_id == appointment.id }
       end
     end
 


### PR DESCRIPTION
This was removed in https://github.com/sul-dlss/sul-requests/pull/3171. It shouldn't have been. 3171 was checking to see if the appointment was cancelled. This line ties requests to appointments and we shouldn't be tying cancelled requests to existing appointments which is possible if someone cancelled a request and didn't cancel the appointment.