### PR TITLE
The transaction queue will move out of draft before digitization

### DIFF
--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -104,11 +104,7 @@ module Aeon
     end
 
     def draft?
-      if digital?
-        photoduplication_queue.nil? || photoduplication_queue&.draft?
-      else
-        transaction_queue.nil? || transaction_queue&.draft?
-      end
+      transaction_queue.nil? || transaction_queue&.draft?
     end
 
     def submitted?

--- a/spec/models/aeon/request_spec.rb
+++ b/spec/models/aeon/request_spec.rb
@@ -53,18 +53,6 @@ RSpec.describe Aeon::Request do
       request = build(:aeon_request, transaction_status: 8)
       expect(request).not_to be_draft
     end
-
-    context 'with a digitization request' do
-      it 'returns false when the digitization process has been initiated' do
-        draft_tranaction_queue = Aeon::Queue.new(id: 5, queue_name: 'Awaiting User Review', queue_type: 'Transaction')
-        in_progress_digital_queue = Aeon::Queue.new(id: 9, queue_name: 'Awaiting Order Processing', queue_type: 'Photoduplication')
-        allow(aeon_client).to receive(:find_queue).with(id: 5, type: :transaction).and_return(draft_tranaction_queue)
-        allow(aeon_client).to receive(:find_queue).with(id: 9, type: :photoduplication).and_return(in_progress_digital_queue)
-
-        request = build(:aeon_request, :digitized, transaction_status: 5, photoduplication_status: 9)
-        expect(request).not_to be_draft
-      end
-    end
   end
 
   describe '#completed?' do


### PR DESCRIPTION
Against the `req-digital` branch.

I believe modeled this incorrectly in the beginning.

For our workflows, the transaction queue is all we care about for draft status. The request will be moved to a non-draft transaction queue prior to the start of digitization.

<img width="633" height="746" alt="Screenshot 2026-03-05 at 11 09 14 AM" src="https://github.com/user-attachments/assets/cdfefc73-c87d-4582-b7c3-17e9f345fbd0" />
