### PR TITLE
Set Aeon webRequestForm based on item selector usage

### DIFF
--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -46,7 +46,8 @@ class SubmitAeonPatronRequestJob < ApplicationJob
       shipping_option: patron_request.request_type == 'scan' ? 'Electronic Delivery' : nil,
       site: patron_request.aeon_site,
       special_request: volume_params['additional_information'],
-      username: patron_request.user.email_address
+      username: patron_request.user.email_address,
+      web_request_form: 'multiple'
     )
   end
 
@@ -64,7 +65,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
       item_date: patron_request.folio_instance&.pub_date,
       item_title: patron_request.item_title,
       location: patron_request.origin_location_code,
-      web_request_form: 'GenericRequestMonograph',
+      web_request_form: patron_request.selectable_items.many? ? 'multiple' : 'single',
       username: patron_request.user.aeon.username,
       item_info1: patron_request.view_url,
       special_request: volume_params['additional_information'] || patron_request.aeon_reading_special,

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -136,6 +136,11 @@ module Aeon
       @reading_room ||= AeonClient.new.reading_rooms.find { |rr| rr.sites.include?(site) }
     end
 
+    def multi_item_selector?
+      # Assuming multi-item selection for legacy Aeon requests seems a better default.
+      @web_request_form != 'single'
+    end
+
     private
 
     def within_persist_completed_request_as_submitted_period?

--- a/spec/jobs/submit_aeon_patron_request_job_spec.rb
+++ b/spec/jobs/submit_aeon_patron_request_job_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SubmitAeonPatronRequestJob do
                                                                           shipping_option: 'Electronic Delivery',
                                                                           special_request: 'info',
                                                                           username: 'aeon_user',
-                                                                          web_request_form: 'GenericRequestMonograph'
+                                                                          web_request_form: 'single'
                                                                         ))
       end
     end


### PR DESCRIPTION
Re-use the `webRequestForm` Aeon field to remember if we displayed the multiple item selector form to the user. We need that information to display the request in the correct format later.

From Chris, on the cases:
>a) a monograph where the user has no choice of item at all
b) a multi-item thing where the user selected one item
c) a multi-item thing where the user selected multiple items
d) a single-item EAD where the user still has to select the one box anyway (i think we decided EADs they always have to pick, right?)
and i think the decision here is b-d all get the same treatment post-submission