### PR TITLE
Omit empty item title parts

### DIFF
--- a/app/javascript/controllers/item_selector_controller.js
+++ b/app/javascript/controllers/item_selector_controller.js
@@ -96,7 +96,10 @@ export default class extends Controller {
   formatItemTitle(item) {
     if (!item.titleParts) return item.label;
 
-    return item.titleParts.map(e => DOMPurify.sanitize(e)).join('<i class="bi bi-chevron-right mx-1"></i>');
+    return item.titleParts
+      .filter(e => e?.trim())
+      .map(e => DOMPurify.sanitize(e))
+      .join('<i class="bi bi-chevron-right mx-1"></i>');
   }
 
   selectedItemsValueChanged(value, previousValue) {


### PR DESCRIPTION
Closes #3223 

No more leading chevron:
<img width="684" height="241" alt="Screenshot 2026-03-10 at 11 01 28 AM" src="https://github.com/user-attachments/assets/3ddc4f63-b691-4269-af6e-16056e83b730" />

Still works with multiple parts:
<img width="806" height="152" alt="Screenshot 2026-03-10 at 11 02 26 AM" src="https://github.com/user-attachments/assets/11d20d29-7cc5-47d6-80b1-1328bc645065" />
