### PR TITLE
Extract a request appointment time component and add to group items

### DIFF
--- a/app/components/aeon/request_appointment_time_component.html.erb
+++ b/app/components/aeon/request_appointment_time_component.html.erb
@@ -1,0 +1,5 @@
+<span class="appointment-details ms-1">
+  <span class="fw-bold text-green"><%= appointment_date %></span>
+  <span class="fw-normal text-nowrap text-green"><%= appointment_time_range %></span>
+  <% if @with_reading_room %><span class="fw-normal text-nowrap text-green"><%= appointment_reading_room_name %></span><% end %>
+</span>

--- a/app/components/aeon/request_appointment_time_component.rb
+++ b/app/components/aeon/request_appointment_time_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Render a request's appointment time
+  class RequestAppointmentTimeComponent < ViewComponent::Base
+    attr_reader :request
+
+    delegate :appointment, :appointment?, :draft?, to: :request
+
+    def initialize(request:, with_reading_room: true)
+      @request = request
+      @with_reading_room = with_reading_room
+    end
+
+    def render?
+      appointment? && !draft?
+    end
+
+    def appointment_date
+      appointment.start_time.strftime('%b %-d, %Y') if appointment?
+    end
+
+    def appointment_time_range
+      return unless appointment?
+
+      format = '%-l:%M %P'
+      start = appointment.start_time.strftime(format).sub(':00', '')
+      stop = appointment.stop_time.strftime(format).sub(':00', '')
+
+      "#{start} - #{stop} (#{appointment.start_time.zone})"
+    end
+
+    def appointment_reading_room_name
+      appointment.reading_room&.name if appointment?
+    end
+  end
+end

--- a/app/components/aeon/request_component.html.erb
+++ b/app/components/aeon/request_component.html.erb
@@ -4,13 +4,7 @@
       <div class="d-flex flex-wrap gap-1 align-items-center">
         <%= render Aeon::RequestStatusPillComponent.new(request:) %>
         <%= render Aeon::RequestStatusMessageComponent.new(request:) %>
-        <% if show_appointment? %>
-        <span class="appointment-details ms-1">
-          <span class="fw-bold text-green"><%= appointment_date %></span>
-          <span class="fw-normal text-nowrap text-green"><%= appointment_time_range %></span>
-          <span class="fw-normal text-nowrap text-green"><%= appointment_reading_room_name %></span>
-        </span>
-        <% end %>
+        <%= render Aeon::RequestAppointmentTimeComponent.new(request:) %>
       </div>
       <%= render Aeon::RequestActionsComponent.new(request:) %>
     </div>

--- a/app/components/aeon/request_component.rb
+++ b/app/components/aeon/request_component.rb
@@ -5,33 +5,11 @@ module Aeon
   class RequestComponent < ViewComponent::Base
     attr_reader :request
 
-    delegate :appointment, :appointment?, :call_number, :date, :document_type,
-             :draft?, :title, :transaction_date, :transaction_number, :transaction_status, to: :request
+    delegate :call_number, :date, :document_type, :title,
+             :transaction_date, :transaction_number, :transaction_status, to: :request
 
     def initialize(request:)
       @request = request
-    end
-
-    def appointment_date
-      appointment.start_time.strftime('%b %-d, %Y') if appointment?
-    end
-
-    def show_appointment?
-      appointment? && !draft?
-    end
-
-    def appointment_time_range
-      return unless appointment?
-
-      format = '%-l:%M %P'
-      start = appointment.start_time.strftime(format).sub(':00', '')
-      stop = appointment.stop_time.strftime(format).sub(':00', '')
-
-      "#{start} - #{stop} (#{appointment.start_time.zone})"
-    end
-
-    def appointment_reading_room_name
-      appointment.reading_room&.name if appointment?
     end
 
     def thumbnail?

--- a/app/components/aeon/request_group_item_component.html.erb
+++ b/app/components/aeon/request_group_item_component.html.erb
@@ -4,7 +4,10 @@
       <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
       <%= render Aeon::RequestItemDetailComponent.new(request:) %>
     </div>
-    <%= render Aeon::RequestActionsComponent.new(request:) %>
+    <div class="d-flex align-items-center gap-5 justify-content-between">
+      <%= render Aeon::RequestAppointmentTimeComponent.new(request:, with_reading_room: false) %>
+      <%= render Aeon::RequestActionsComponent.new(request:) %>
+    </div>
   </div>
   <div class="pt-2 fs-14 d-flex gap-sm-3 flex-sm-row flex-column">
     <div>Request #<%= transaction_number %></div>

--- a/spec/components/aeon/request_group_component_spec.rb
+++ b/spec/components/aeon/request_group_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Aeon::RequestGroupComponent, type: :component do
     end
   end
 
-  context 'with ead requests' do
+  context 'with submitted ead requests' do
     let(:first_request) do
       build(:aeon_request, call_number: 'SC0097 The Art of Computer Programming', ead_number: 'SC0097',
                            title: 'Donald E. Knuth papers', transaction_number: 100, volume: 'Box 1', web_request_form:)
@@ -44,14 +44,16 @@ RSpec.describe Aeon::RequestGroupComponent, type: :component do
     let(:request_group) { Aeon::RequestGrouping.new([first_request, second_request]) }
 
     before do
-      allow(first_request).to receive_messages(draft?: true)
-      allow(second_request).to receive_messages(draft?: true)
+      allow(first_request).to receive_messages(cancelled?: false, completed?: false, draft?: false, submitted?: true)
+      allow(second_request).to receive_messages(cancelled?: false, completed?: false, draft?: false, submitted?: true)
       render_inline(described_class.new(request_group:))
     end
 
     it 'renders information about each request' do
       expect(page).to have_css 'h2', text: 'Donald E. Knuth papers', count: 1
       expect(page).to have_content 'The Art of Computer Programming', count: 2
+      expect(page).to have_content 'Mar 11, 2024', count: 2
+      expect(page).to have_content '1 pm - 1:15 pm (PDT)', count: 2
       expect(page).to have_content 'SC0097', count: 1
       expect(page).to have_content 'Box 1'
       expect(page).to have_content 'Box 2'


### PR DESCRIPTION
Shows the appointment time for each grouped request. I missed it in https://github.com/sul-dlss/sul-requests/issues/3177.

Doesn't look great at small sizes but we'll cross that bridge when we do responsive design?

<img width="952" height="335" alt="Screenshot 2026-03-10 at 4 09 03 PM" src="https://github.com/user-attachments/assets/9ed8e18b-a7dc-4115-b96a-5e2b68367edb" />
