### PR TITLE
Send series and subseries data for ItemWithoutContainer EAD

### DIFF
--- a/app/views/patron_requests/_ead_series_contents.html.erb
+++ b/app/views/patron_requests/_ead_series_contents.html.erb
@@ -64,6 +64,7 @@
     <%# Individual item without container - gets its own checkbox %>
     <% 
       checkbox_id = volume_checkbox_id(series_title: series_title || display_group.title, subseries_name: display_group.title)
+      checked = f.object.selected_items.any? { |item| (series_title || display_group.title) == item[:series] && display_group.title == item[:subseries] }
     %>
     <div class="mb-2 d-flex align-items-start gap-2">
       <% if nested %>
@@ -73,15 +74,14 @@
         </span>
       <% end %>
       <%= f.check_box :barcodes,
-            { multiple: true, class: "form-check-input mt-1 #{'ms-2' unless nested}", id: checkbox_id, 
+            { multiple: true, class: "form-check-input mt-1 #{'ms-2' unless nested}", id: checkbox_id, checked: checked,
               data: { action: 'item-selector#change', 'item-selector-target': 'item', 'item-selector-title-parts-param': [series_title || display_group.title, display_group.title], 'item-selector-id-param': checkbox_id } },
               volume_value(series_title: series_title || display_group.title, subseries_name: display_group.title),
             nil %>
-
-      <%= tag.div class: 'd-none', data: { contentId: checkbox_id, toggleDisabled: true } do %>
+      <%= tag.div class: 'd-none', data: { 'content-id': checkbox_id, 'toggle-disabled': true } do %>
         <%= fields_for "patron_request[aeon_item][#{checkbox_id}]" do |f| %>
           <%= f.hidden_field :id, disabled: !checked, value: checkbox_id, data: { toggle: true } %>
-          <%= f.hidden_field :series, disabled: !checked, value: series_title || container_name, data: { toggle: true } %>
+          <%= f.hidden_field :series, disabled: !checked, value: series_title || display_group.title, data: { toggle: true } %>
           <%= f.hidden_field :subseries, disabled: !checked, value: display_group.title, data: { toggle: true } %>
         <% end %>
       <% end %>


### PR DESCRIPTION
Fixes #3202

`checked` was undefined and the camelCase attributes may have caused issues

This results in submitted requests with the proper data:
<img width="884" height="504" alt="Screenshot 2026-03-12 at 2 47 51 PM" src="https://github.com/user-attachments/assets/ad416b0f-869e-44dd-a861-161462eb56c2" />

To answer the ticket's question directly (Should ItemWithoutContainer's have checkboxes/exist?) -- yes.

These are part of the collection but happen not to be in a containing box. In this case the "Photos of the exhibit in Penticton" is filed alone as a sibling to containing boxes. Maybe it's a thumb drive filed next to the box; who knows.
<img width="878" height="418" alt="Screenshot 2026-03-12 at 2 53 38 PM" src="https://github.com/user-attachments/assets/4a46268e-5302-4f86-999f-510095eb603b" />

This is not digital content online (see https://archives.stanford.edu/catalog/sc0399_aspace_ref233_oze) -- in this case see note "Access to digital content is restricted to the Special Collections Reading Room." Patrons can ask to learn more rather than shut down the option. If it's published in the EAD then communication about it/requests are expected.

Here is another example: https://archives.stanford.edu/catalog/sc0097_aspace_ref677_njc
"The 35mm slides used in Lecture 4, converted to digital form, appear on this conpact disk in several sizes."
So the CD is just sitting in the archive next to Box 2.
