### PR TITLE
add view for aeon request page when library_id user doesn't have an email address

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -14,6 +14,7 @@ class PatronRequestsController < ApplicationController
 
   load_resource
   before_action :assign_new_attributes, only: [:new]
+  before_action :aeon_email_present, only: [:new]
   before_action :authorize_new_request, only: [:new]
   authorize_resource
 
@@ -57,12 +58,18 @@ class PatronRequestsController < ApplicationController
     @patron_request.assign_attributes(**new_params)
   end
 
+  def aeon_email_present
+    return unless @patron_request.aeon_page? && current_user.library_id?
+
+    render 'no_email' if current_user.email_address.blank? && Settings.features.requests_redesign
+  end
+
   # SSO or library-id users don't need to re-login, but name/email users always need to provide their information
   # for each request.
   #
   # Aeon pages never need authentication, because Aeon will handle that as part of its request flow.
   def authorize_new_request # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-    return if @patron_request.aeon_page? && (current_user.email_address || !Settings.features.requests_redesign)
+    return if @patron_request.aeon_page? && (current_user.email_address.present? || !Settings.features.requests_redesign)
 
     return if current_user.patron.present? || (params[:step].present? && current_user.patron.email.present?)
 

--- a/app/views/patron_requests/no_email.html.erb
+++ b/app/views/patron_requests/no_email.html.erb
@@ -1,0 +1,10 @@
+<div role="alert" class="alert alert-danger d-flex shadow-sm align-items-center">
+  <div role="img" aria-label="Danger icon" class="bi bi-exclamation-triangle-fill fs-3 me-3 align-self-center d-flex justify-content-center"></div>
+  <div class="text-body">
+    <div class="fw-semibold">Action required</div>
+    <div>
+      Your library account does not include an email address, which is required to complete this request.
+      Please email <%= mail_to "sul-privileges@stanford.edu" %> or call (650) 723-1492 to update your account.
+    </div>
+  </div>
+</div>

--- a/spec/factories/patrons.rb
+++ b/spec/factories/patrons.rb
@@ -76,6 +76,12 @@ FactoryBot.define do
     active { false }
   end
 
+  factory :no_email_patron, parent: :patron do
+    display_name { 'No email' }
+    id { 'no-email-uuid' }
+    email { '' }
+  end
+
   factory :visitor_patron, class: 'Folio::NullPatron' do
     display_name { 'Visitor' }
     email { 'visitor@example.com' }

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -167,4 +167,20 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(page).to have_content('Log in with SUNet ID')
     end
   end
+
+  context 'when user does not have an email address' do
+    let(:user) { create(:library_id_user) }
+    let(:eadxml) do
+      Nokogiri::XML(File.read('spec/fixtures/a0112.xml')).tap(&:remove_namespaces!)
+    end
+
+    before do
+      allow(Folio::Patron).to receive(:find_by).with(library_id: user.library_id).and_return(build(:no_email_patron))
+    end
+
+    it 'identifies the library of the item' do
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+      expect(page).to have_content 'Your library account does not include an email address, which is required to complete this request.'
+    end
+  end
 end


### PR DESCRIPTION
closes #2865
<img width="1148" height="891" alt="Screenshot 2026-03-13 at 2 07 33 PM" src="https://github.com/user-attachments/assets/f3ee0b16-fb71-450c-8e37-376e9b824fc0" />
