### PR TITLE
Filter and constrain available appointments based on a user's existing appointments

### DIFF
--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -6,7 +6,7 @@
 class AeonAppointmentsController < ApplicationController
   include AeonController
 
-  before_action :load_appointments, except: [:available]
+  before_action :load_appointments
   before_action :load_appointment, only: [:edit, :update, :destroy]
   before_action :create_appointment, only: [:create]
   before_action :load_reading_rooms, only: [:new, :available]
@@ -29,8 +29,7 @@ class AeonAppointmentsController < ApplicationController
     @selected_time = params[:selected]
     @date = Date.parse(params.expect(:date))
 
-    @available_appointments = AeonClient.new.available_appointments(reading_room_id: params.expect(:reading_room_id),
-                                                                    date: @date, include_next_available: true)
+    @available_appointments = filtered_available_appointments
     @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
     respond_to do |format|
       format.html
@@ -70,6 +69,13 @@ class AeonAppointmentsController < ApplicationController
   end
 
   private
+
+  def filtered_available_appointments
+    slots = AeonClient.new.available_appointments(reading_room_id: params.expect(:reading_room_id),
+                                                  date: @date, include_next_available: true)
+    existing = @appointments.reject { |appt| appt.id == params[:appointment_id]&.to_i }
+    Aeon::AvailableAppointmentFilter.new(available_appointments: slots, existing_appointments: existing).filter
+  end
 
   def load_reading_rooms
     @reading_rooms = Aeon::ReadingRoom.all

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -59,7 +59,10 @@ export default class extends Controller {
 
     if (!date || !readingRoomId) return;
 
-    this.availabilityTarget.src = `/aeon_appointments/available/${readingRoomId}/${date}?selected=${startTime}&duration=${apptDuration}`
+    const appointmentId = this.availabilityTarget.dataset.appointmentId;
+    let src = `/aeon_appointments/available/${readingRoomId}/${date}?selected=${startTime}&duration=${apptDuration}`;
+    if (appointmentId) src += `&appointment_id=${appointmentId}`;
+    this.availabilityTarget.src = src;
   }
 
   resetFields() {

--- a/app/models/aeon/available_appointment_filter.rb
+++ b/app/models/aeon/available_appointment_filter.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Filters available appointment slots against a user's existing appointments
+  # to prevent double-booking. Slots that conflict are either removed entirely
+  # or have their maximum length reduced so the new appointment ends before the
+  # existing one starts.
+  class AvailableAppointmentFilter
+    MIN_APPOINTMENT_LENGTH = 30.minutes
+
+    def initialize(available_appointments:, existing_appointments:)
+      @available_appointments = available_appointments
+      @existing_appointments = existing_appointments
+    end
+
+    def filter
+      @available_appointments.filter_map { |slot| adjust_slot(slot) }
+    end
+
+    private
+
+    def adjust_slot(slot)
+      effective_max = effective_max_length(slot)
+
+      return nil if effective_max.nil? || effective_max < MIN_APPOINTMENT_LENGTH
+
+      return slot if effective_max == slot.maximum_appointment_length
+
+      AvailableAppointment.new(start_time: slot.start_time, maximum_appointment_length: effective_max)
+    end
+
+    def effective_max_length(slot)
+      slot_start = slot.start_time
+      slot_end = slot_start + slot.maximum_appointment_length
+      effective_max = slot.maximum_appointment_length
+
+      @existing_appointments.each do |existing|
+        next unless conflicts?(slot_start, slot_end, existing)
+
+        # Existing appointment covers the slot's start time
+        return nil if existing.start_time <= slot_start
+
+        # Existing appointment starts during the slot's range
+        capped = ((existing.start_time - slot_start) / 60).minutes
+        effective_max = [effective_max, capped].min
+      end
+
+      effective_max
+    end
+
+    def conflicts?(slot_start, slot_end, existing)
+      existing.start_time < slot_end && existing.stop_time > slot_start
+    end
+  end
+end

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -18,7 +18,7 @@
 
     <% if @appointment&.reading_room&.day_only_appointments? %>
       <%# if it's a day-only appointment, we still use the turboframe to check if the reading room is open at all, but we don't need any of the other controls. %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_appointments_url(@appointment.reading_room_id, @appointment.date || Time.zone.now.iso8601) %>">
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_appointments_url(@appointment.reading_room_id, @appointment.date || Time.zone.now.iso8601, appointment_id: @appointment.id) %>">
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
       </turbo-frame>
     <% elsif @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
@@ -31,7 +31,7 @@
         <%= f.time_field :stop_time, required: true %>
       </div>
     <% else %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_appointments_url(@appointment.reading_room_id, @appointment.date || Time.zone.now.iso8601, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" data-appointment-id="<%= @appointment.id %>" src="<%= available_aeon_appointments_url(@appointment.reading_room_id, @appointment.date || Time.zone.now.iso8601, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time), appointment_id: @appointment.id) if @appointment.reading_room_id %>">
         <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, selected: (@appointment.start_time && @appointment.stop_time ? (@appointment.stop_time - @appointment.start_time).to_i : '')) %>
 
         <fieldset class="mb-3">

--- a/spec/models/aeon/available_appointment_filter_spec.rb
+++ b/spec/models/aeon/available_appointment_filter_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::AvailableAppointmentFilter do
+  subject(:filtered) { described_class.new(available_appointments: available_slots, existing_appointments:).filter }
+
+  let(:date) { Time.zone.parse('2026-03-30T16:00:00Z') }
+
+  def slot(hour, minute, max_minutes)
+    Aeon::AvailableAppointment.new(
+      start_time: date.change(hour:, min: minute),
+      maximum_appointment_length: max_minutes.minutes
+    )
+  end
+
+  def appointment(start, stop)
+    build(:aeon_appointment,
+          start_time: date.change(hour: start[0], min: start[1]),
+          stop_time: date.change(hour: stop[0], min: stop[1]))
+  end
+
+  context 'with no existing appointments' do
+    let(:existing_appointments) { [] }
+    let(:available_slots) { [slot(9, 0, 180), slot(10, 0, 180)] }
+
+    it 'returns all slots unchanged' do
+      expect(filtered).to eq(available_slots)
+    end
+  end
+
+  context 'when an existing appointment covers the slot start time' do
+    let(:existing_appointments) { [appointment([9, 0], [11, 0])] }
+    let(:available_slots) { [slot(9, 0, 180), slot(10, 0, 180), slot(11, 0, 180)] }
+
+    it 'removes slots whose start time falls within the existing appointment' do
+      expect(filtered.map(&:start_time)).to eq([date.change(hour: 11, min: 0)])
+    end
+  end
+
+  context 'when an existing appointment starts during a slot range' do
+    let(:existing_appointments) { [appointment([11, 0], [12, 0])] }
+    let(:available_slots) { [slot(9, 0, 180), slot(10, 30, 180)] }
+
+    it 'reduces maximum_appointment_length so the new appointment ends before the existing one starts' do
+      expect(filtered.map { |s| [s.start_time.strftime('%H:%M'), s.maximum_appointment_length] }).to eq([
+                                                                                                          ['09:00', 120.minutes],
+                                                                                                          ['10:30', 30.minutes]
+                                                                                                        ])
+    end
+  end
+
+  context 'when reduced max length falls below the minimum (30 minutes)' do
+    let(:existing_appointments) { [appointment([10, 15], [11, 0])] }
+    let(:available_slots) { [slot(10, 0, 180)] }
+
+    it 'removes the slot when the gap is less than the minimum appointment length' do
+      expect(filtered).to be_empty
+    end
+
+    context 'when the gap is exactly 30 minutes' do
+      let(:existing_appointments) { [appointment([10, 30], [11, 0])] }
+
+      it 'keeps the slot with reduced max length' do
+        expect(filtered.length).to eq(1)
+        expect(filtered.first.maximum_appointment_length).to eq(30.minutes)
+      end
+    end
+  end
+
+  context 'with multiple existing appointments' do
+    let(:existing_appointments) { [appointment([10, 0], [11, 0]), appointment([14, 0], [15, 0])] }
+    let(:available_slots) do
+      [slot(9, 0, 180), slot(10, 0, 180), slot(12, 0, 180), slot(15, 0, 180)]
+    end
+
+    it 'filters considering all existing appointments' do
+      expect(filtered.map { |s| [s.start_time.strftime('%H:%M'), s.maximum_appointment_length] }).to eq([
+                                                                                                          ['09:00', 60.minutes],
+                                                                                                          ['12:00', 120.minutes],
+                                                                                                          ['15:00', 180.minutes]
+                                                                                                        ])
+    end
+  end
+
+  context 'with no overlap' do
+    let(:existing_appointments) { [appointment([6, 0], [8, 0])] }
+    let(:available_slots) { [slot(9, 0, 180), slot(10, 0, 180)] }
+
+    it 'returns all slots unchanged' do
+      expect(filtered).to eq(available_slots)
+    end
+  end
+end


### PR DESCRIPTION
Closes #3166 

I'm still noodling on this one. It is a bummer needing to load the user's Aeon appointments on every hit to `available`...