### PR TITLE
Allow updating an appointment without sending a new name

### DIFF
--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -94,10 +94,10 @@ class AeonClient
 
   def update_appointment(appointment_id, name:, start_time:, stop_time:)
     json_patch = [
-      { op: 'replace', path: '/name', value: name },
+      ({ op: 'replace', path: '/name', value: name } if name),
       { op: 'replace', path: '/startTime', value: start_time.iso8601 },
       { op: 'replace', path: '/stopTime', value: stop_time.iso8601 }
-    ]
+    ].compact
 
     response = patch("Appointments/#{appointment_id}", json_patch)
 


### PR DESCRIPTION
Maybe we want to fix this upstream, but right now if you update an appointment without a name specified, Aeon throws a 500.