### PR TITLE
Add one-time key authentication for name/email users

### DIFF
--- a/app/models/current_user.rb
+++ b/app/models/current_user.rb
@@ -59,7 +59,7 @@ class CurrentUser
 
   def name_email_user
     if Settings.features.authenticate_name_email_users && data['otp_authenticated']
-      User.find_or_create_by(email: data['email']) do |user|
+      User.find_or_create_by(email: data['email']).tap do |user|
         update_session_attributes(user)
       end
     else
@@ -87,8 +87,10 @@ class CurrentUser
   end
 
   def update_session_attributes(user)
-    user.name = data['name']
+    user.name ||= data['name']
     user.otp_authenticated = data['otp_authenticated']
+
+    user.save if user.changed?
   end
 
   def ldap_attributes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ApplicationRecord
   end
 
   def authenticated?
-    sso_user? || (library_id_user? && email_from_folio) || @otp_authenticated
+    sso_user? || (library_id_user? && email_from_folio) || @otp_authenticated.present?
   end
 
   def student_type

--- a/app/views/shared/_sul_header_redesign.erb
+++ b/app/views/shared/_sul_header_redesign.erb
@@ -7,10 +7,10 @@
     </button>
     <div class="d-md-block d-none">
       <ul class="navbar-nav">
-        <% if current_user.sso_user? || current_user.library_id_user? %>
+        <% if current_user.authenticated? %>
           <% logout_path = current_user.site_admin? ? root_path : request.url %>
           <li class="nav-item">
-            <%= link_to t('shared.sul_header.logout', sunetid: current_user.sunetid || current_user.library_id), logout_path(referrer: logout_path), class: 'nav-link' %>
+            <%= link_to t('shared.sul_header.logout', sunetid: current_user.sunetid || current_user.library_id || current_user.email), logout_path(referrer: logout_path), class: 'nav-link' %>
           </li>
         <% else %>
           <li class="nav-item">

--- a/spec/features/new_aeon_user_spec.rb
+++ b/spec/features/new_aeon_user_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating new accounts for patrons', :js do
   before do
-    allow(Settings.features).to receive(:requests_redesign).and_return(true)
+    allow(Settings.features).to receive_messages(requests_redesign: true, authenticate_name_email_users: true)
     allow(EadClient).to receive(:fetch).and_return(Ead::Document.new(eadxml, url: 'whatever'))
 
     allow(AeonClient).to receive(:new).and_return(stub_aeon_client)
@@ -64,7 +64,13 @@ RSpec.describe 'Creating new accounts for patrons', :js do
 
       click_button 'Continue'
 
-      expect(page).to have_content('Terms')
+      expect(page).to have_content('Verify email address')
+      fill_in 'code', with: '000000'
+      click_button 'Continue'
+
+      expect(page).to have_content('Account information')
+      expect(page).to have_field('Name', with: 'Test User')
+      expect(page).to have_field('Email address', with: 'test@localhost')
     end
   end
 end


### PR DESCRIPTION
Builds on #3292 to prompt for a one-time key (that's  just a static `000000`).
(Unfortunately, a first stab at this already came in with dd48ea1b26a4bba6f72a7e782257ea272199c108, so this is just some cleanup that should have been in that commit)