### PR TITLE
Add an input control for OTP inputs.

### DIFF
--- a/app/components/otp_input_component.html.erb
+++ b/app/components/otp_input_component.html.erb
@@ -1,0 +1,13 @@
+<div class="vstack gap-2" data-controller="otp-input" data-action="paste->otp-input#paste">
+  <label class="form-label" id="otpLabel" data-action="click->otp-input#focus">Verification code</label>
+
+  <div class="otp d-flex gap-1" aria-labelledby="otpLabel" aria-describedby="otpHelp">
+    <% length.times do |i| %>
+      <%= text_field_tag :digit, nil, class: 'form-control w-auto', size: 1, minlength: 1, maxlength: 1, inputmode: 'numeric', pattern: "\d*", autocomplete: i == 0 ? 'one-time-code' : 'off', aria: { label: "Digit #{i}" }, data: otp_digit_data %>
+    <% end %>
+
+    <%= form.hidden_field name, data: { 'otp-input-target': 'field' }, value: value %>
+  </div>
+
+  <div id="otpHelp" class="form-text">Enter the <%= length %>-digit code sent to your email.</div>
+</div>

--- a/app/components/otp_input_component.rb
+++ b/app/components/otp_input_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Render a OTP code input field.
+class OtpInputComponent < ViewComponent::Base
+  attr_reader :name, :form, :length, :value
+
+  def initialize(name:, form: nil, length: 6, value: nil)
+    @name = name
+    @form = form || ActionView::Helpers::FormBuilder.new(nil, nil, self, {})
+    @length = length
+    @value = value
+  end
+
+  def otp_digit_data
+    { 'otp-input-target': 'digit',
+      action: 'input->otp-input#shift input->otp-input#focus focus->otp-input#focus input->otp-input#update keydown->otp-input#keydown' }
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -40,6 +40,9 @@ application.register("appointment", AppointmentController)
 import AppointmentSelectController from "./appointment_select_controller"
 application.register("appointment-select", AppointmentSelectController)
 
+import OtpInput from "./otp_input_controller"
+application.register("otp-input", OtpInput)
+
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 

--- a/app/javascript/controllers/otp_input_controller.js
+++ b/app/javascript/controllers/otp_input_controller.js
@@ -1,0 +1,90 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["digit", "field"]
+
+  connect() {
+  }
+
+  fieldTargetConnected() {
+    if (this.fieldTarget.value) {
+      this.digitTargets.forEach((el, index) => el.value = this.fieldTarget.value[index] || "")
+    }
+  }
+
+  update() {
+    this.fieldTarget.value = this.digitTargets.map(el => el.value).join("")
+  }
+
+  paste(event) {
+    event.preventDefault()
+    const paste = (event.clipboardData || window.clipboardData).getData('text');
+    const digits = paste.split("").filter(char => char.match(/\d/)).slice(0, this.digitTargets.length)
+
+    this.digitTargets.forEach((el, index) => el.value = digits[index] || "")
+
+    const firstEmptyDigit = this.digitTargets.find(el => el.value === "");
+
+    (firstEmptyDigit || this.digitTargets[this.digitTargets.length - 1]).focus();
+  }
+
+  shift(event) {
+    const firstEmptyDigitIndex = this.digitTargets.findIndex(el => el.value === "");
+    const thisIndex = this.digitTargets.findIndex(el => el === event.currentTarget);
+
+    if (firstEmptyDigitIndex > 0 && firstEmptyDigitIndex < thisIndex) {
+      this.digitTargets[firstEmptyDigitIndex].value = event.currentTarget.value
+      event.currentTarget.value = ""
+    }
+  }
+
+  focus() {
+    const firstEmptyDigit = this.digitTargets.find(el => el.value === "");
+    const focusedDigit = this.element.querySelector(':focus-within');
+    
+    // already focused on an empty digit, do not change focus
+    if (!firstEmptyDigit && focusedDigit) {
+      return
+    }
+
+    const lastDigit = this.digitTargets[this.digitTargets.length - 1];
+
+    (firstEmptyDigit || lastDigit).focus()
+  }
+
+  keydown(event) {
+    if (event.key === "Backspace" || event.key === "Delete") {
+      this.erase(event)
+    }
+
+    if (event.key == "ArrowLeft") {
+      const thisIndex = this.digitTargets.findIndex(el => el === event.currentTarget);
+      if (thisIndex > 0) {
+        this.digitTargets[thisIndex - 1].focus()
+      }
+    }
+    
+    if (event.key == "ArrowRight") {
+      const thisIndex = this.digitTargets.findIndex(el => el === event.currentTarget);
+      if (thisIndex < this.digitTargets.length - 1) {
+        this.digitTargets[thisIndex + 1].focus()
+      }
+    }
+  }
+
+  erase(event) {
+    const thisIndex = this.digitTargets.findIndex(el => el === event.currentTarget);
+
+    if (thisIndex === 0) return;
+
+    if (event.currentTarget.value === "") {
+      this.digitTargets[thisIndex - 1].value = ""
+      this.digitTargets[thisIndex - 1].focus()
+    } else {
+      event.currentTarget.value = ""
+      this.digitTargets[thisIndex - 1].focus()
+    }
+
+    this.update();
+  }
+}

--- a/spec/component_previews/otp_input_component_preview.rb
+++ b/spec/component_previews/otp_input_component_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class OtpInputComponentPreview < ViewComponent::Preview
+  layout 'lookbook'
+
+  def default
+    render OtpInputComponent.new(name: 'otp_code', form: nil)
+  end
+end


### PR DESCRIPTION
Inspired by the functionality described by https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/forms/otp-input/... hopefully we'll be able to just adopt the upstream controls when it's available 🤷 

<img width="552" height="197" alt="Screenshot 2026-03-17 at 14 36 06" src="https://github.com/user-attachments/assets/5ae1b7dc-909e-4d5d-a111-8a35b3bd2754" />
