### PR TITLE
Wait for all submitted Aeon requests to be available for display

### DIFF
--- a/app/javascript/controllers/aeon_confirmation_poll_controller.js
+++ b/app/javascript/controllers/aeon_confirmation_poll_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Polls the confirmation page turbo frame until all expected Aeon requests
+// have appeared, or max attempts are reached.
+export default class extends Controller {
+  static values = {
+    attempts: Number,
+    interval: { type: Number, default: 1000 },
+    maxAttempts: { type: Number, default: 20 }
+  }
+
+  static targets = ["frame", "loading"]
+
+  loadingTargetConnected() {
+    this.scheduleNext()
+  }
+
+  disconnect() {
+    clearTimeout(this.timer)
+  }
+
+  scheduleNext() {
+    this.timer = setTimeout(() => this.refresh(), this.intervalValue)
+  }
+
+  refresh() {
+    this.attemptsValue++
+
+    if (this.attemptsValue >= this.maxAttemptsValue) return
+
+    const url = new URL(window.location.href)
+    url.searchParams.set("_poll", Date.now())
+    this.frameTarget.src = url.toString()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("form", FormController)
 import RememberController from "./remember_controller"
 application.register("remember", RememberController)
 
+import AeonConfirmationPollController from "./aeon_confirmation_poll_controller"
+application.register("aeon-confirmation-poll", AeonConfirmationPollController)
+
 import ArchivesSeriesController from "./archives_series_controller"
 application.register("archives-series", ArchivesSeriesController)
 

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -134,6 +134,14 @@ class PatronRequest < ApplicationRecord
     aeon_page? && scan?
   end
 
+  def expected_aeon_item_count
+    if ead_url.present?
+      aeon_item&.count || 0
+    else
+      selected_items.count
+    end
+  end
+
   def item_mediation_data
     super || {}
   end

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -8,38 +8,51 @@
       <div class="bg-light p-2 fs-5 mb-4">Please review Reading room policies before arriving for your appointment.</div>
     <% end %>
     <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'mt-4 mb-4') %>
-    <div class="confirmation">
-      <% if @aeon_requests.any? %>
-        <% if @aeon_requests.appointment_reading_room.present? %>
-          <div class="mb-4">
-            <h2><%= @aeon_requests.appointment_reading_room.name %></h2>
-            <i class="bi bi-geo-alt-fill me-1"></i><span><%= @aeon_requests.appointment_reading_room.directions %></span>
+    <div data-controller="aeon-confirmation-poll" data-aeon-confirmation-poll-attempts-value="0">
+      <turbo-frame id="aeon-confirmation" data-aeon-confirmation-poll-target="frame">
+        <% if @aeon_requests.count < @patron_request.expected_aeon_item_count %>
+          <div class="d-flex align-items-center my-3" data-aeon-confirmation-poll-target="loading">
+            <div class="spinner-border spinner-border-sm me-2" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+            <span>Confirming your requests. You can navigate away from this page.</span>
+          </div>
+        <% else %>
+          <div class="confirmation">
+            <% if @aeon_requests.any? %>
+              <% if @aeon_requests.appointment_reading_room.present? %>
+                <div class="mb-4">
+                  <h2><%= @aeon_requests.appointment_reading_room.name %></h2>
+                  <i class="bi bi-geo-alt-fill me-1"></i><span><%= @aeon_requests.appointment_reading_room.directions %></span>
+                </div>
+              <% end %>
+              <% if @aeon_requests.first&.multi_item_selector? %>
+                <%= render Aeon::ConfirmationRequestListComponent.new(requests: @aeon_requests.submitted_requests, digitization: @aeon_requests.digital? ) %>
+                <%= render Aeon::ConfirmationSavedForLaterComponent.new(request_group: @aeon_requests) %>
+              <% else %>
+                <% request = @aeon_requests.first %>
+                <% if request.appointment %>
+                  <div class="mb-3">
+                    <h2>Appointment</h2>
+                    <i class="bi bi-calendar me-2"></i><%= render AppointmentTimeRangeComponent.new(appointment: request.appointment) %>
+                  </div>
+                <% elsif request.requested_pages.present? %>
+                  <div class="mb-3">
+                    <h2>Pages</h2>
+                    <i class="bi bi-file-earmark me-2"></i><%= request.requested_pages %>
+                  </div>
+                <% end %>
+                <% if request.special_request %>
+                  <div class="mb-3">
+                    <h2>Additional Information</h2>
+                    <%= request.special_request %>
+                  </div>
+                <% end %>
+              <% end %>
+            <% end %>
           </div>
         <% end %>
-        <% if @aeon_requests.first&.multi_item_selector? %>
-          <%= render Aeon::ConfirmationRequestListComponent.new(requests: @aeon_requests.submitted_requests, digitization: @aeon_requests.digital? ) %>
-          <%= render Aeon::ConfirmationSavedForLaterComponent.new(request_group: @aeon_requests) %>
-        <% else %>
-          <% request = @aeon_requests.first %>
-          <% if request.appointment %>
-            <div class="mb-3">
-              <h2>Appointment</h2>
-              <i class="bi bi-calendar me-2"></i><%= render AppointmentTimeRangeComponent.new(appointment: request.appointment) %>
-            </div>
-          <% elsif request.requested_pages.present? %>
-            <div class="mb-3">
-              <h2>Pages</h2>
-              <i class="bi bi-file-earmark me-2"></i><%= request.requested_pages %>
-            </div>
-          <% end %>
-          <% if request.special_request %>
-            <div class="mb-3">
-              <h2>Additional Information</h2>
-              <%= request.special_request %>
-            </div>
-          <% end %>
-        <% end %>
-      <% end %>
+      </turbo-frame>
     </div>
     <% if can? :debug, @patron_request %>
       <hr>


### PR DESCRIPTION
Nobody asked for this but it's been bugging me in the demos. Opinions welcome 😄 

This opts for polling until we see the Aeon request count we expect for a given patron request. I found this preferable to updating over time. This is because Aeon requests start as "Awaiting Request Processing" (queue 8), but we send a subsequent API call to move them to "Awaiting User Review" (queue 5) if the request is a draft. When displaying in real time, the user sees each draft request first as a real "submitted" request, then sees it move to draft.

I added a loading icon and placeholder text: 
<img width="752" height="128" alt="Screenshot 2026-03-18 at 8 11 01 AM" src="https://github.com/user-attachments/assets/749e286d-60f8-46f6-9a80-4212d98c61e8" />
