### PR TITLE
Hide ready requests on the draft requests page.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -649,3 +649,9 @@ label.btn-close {
 .modal-location .hide-when-1-item {
   display: none;
 }
+
+#draft-requests {
+  .request:has(.ready) {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -392,7 +392,7 @@ label.btn-close {
  transform: rotate(90deg);
 }
 
-.request.card {
+.request.card, .request-group.card {
   --bs-card-cap-bg: white;
   --bs-border-radius: 0.25rem;
   --bs-card-border-color: var(--stanford-10-black);

--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,4 +1,4 @@
-<div class="request-group request card mb-4" data-controller="empty-remove">
+<div class="request-group card mb-4" data-controller="empty-remove">
   <div class="card-header fw-semibold p-3 ps-2 d-flex gap-1 flex-row align-items-md-center justify-content-between">
     <div class="d-flex flex-wrap gap-1 align-items-center">
       <%= render Aeon::RequestStatusPillComponent.new(request: request_group.status_request) %>

--- a/app/views/aeon_requests/drafts.html.erb
+++ b/app/views/aeon_requests/drafts.html.erb
@@ -1,4 +1,4 @@
-<div class="container" data-controller="draft-request">
+<div id="draft-requests" class="container" data-controller="draft-request">
   <div class="row">
     <div class="col-8 pe-5">
       <div class="d-flex flex-wrap gap-2 justify-content-between mb-3">


### PR DESCRIPTION
At least now draft requests that become ready don't end up looking all funny. I suspect we'll end up refactoring the update action's turbo stream to provide the right stuff at some point (if we can figure out how to do that without needing all the patron's requests ever)