### PR TITLE
Push more of our logic behind `base_callnumber`

### DIFF
--- a/app/components/aeon/request_group_brief_component.html.erb
+++ b/app/components/aeon/request_group_brief_component.html.erb
@@ -4,8 +4,8 @@
       <div class="mb-2 text-dark-emphasis"><%= requests.first.reading_room&.name %></div>
       <h2 class="h3"><%= title %></h2>
       <div class="d-flex gap-sm-3 flex-sm-row flex-wrap flex-column">
-        <% if ead_number %>
-          <div>Call number: <%= ead_number %></div>
+        <% if base_callnumber.present? %>
+          <div>Call number: <%= base_callnumber %></div>
         <% end %>
       </div>
       <ul class="list-group list-group-flush">

--- a/app/components/aeon/request_group_compact_component.html.erb
+++ b/app/components/aeon/request_group_compact_component.html.erb
@@ -5,10 +5,8 @@
       <span class="text-digital-red"><%= request_group.digital? ? 'Digitization' : 'Reading room use' %></span>
       <h3 class="h4 my-1"><%= title %></h3>
       <div class="d-flex gap-sm-3 flex-sm-row flex-wrap flex-column">
-        <% if ead_number %>
-          <div>Call number: <%= ead_number %></div>
-        <% elsif call_number.present? %>
-          <div>Call number: <%= call_number %></div>
+        <% if base_callnumber.present? %>
+          <div>Call number: <%= base_callnumber %></div>
         <% end %>
       </div>
       <% if request_group.multi_item_selector? %>

--- a/app/components/aeon/request_group_component.rb
+++ b/app/components/aeon/request_group_component.rb
@@ -5,7 +5,7 @@ module Aeon
   class RequestGroupComponent < ViewComponent::Base
     attr_reader :request_group
 
-    delegate :appointment?, :title, :call_number, :document_type, :date, :ead_number, :reading_room_name, :requests,
+    delegate :appointment?, :title, :base_callnumber, :call_number, :document_type, :date, :ead_number, :reading_room_name, :requests,
              :submitted?, to: :request_group
 
     def initialize(request_group:)

--- a/app/components/record_header_component.rb
+++ b/app/components/record_header_component.rb
@@ -21,20 +21,10 @@ class RecordHeaderComponent < ViewComponent::Base
   end
 
   def call_number
-    return aeon_request_callnumber if record.is_a?(Aeon::Request)
-
-    record.call_number.presence
+    record.base_callnumber.presence
   end
 
   def brief?
     @brief
-  end
-
-  private
-
-  def aeon_request_callnumber
-    return record.ead_number if record.ead_number
-
-    record.call_number unless record.multi_item_selector?
   end
 end

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -86,6 +86,10 @@ module Aeon
       end
     end
 
+    def base_callnumber
+      ead_number || (call_number unless multi_item_selector?)
+    end
+
     def completed?
       return false unless in_completed_queue?
       return false if within_persist_completed_request_as_submitted_period?

--- a/app/models/aeon/request_grouping.rb
+++ b/app/models/aeon/request_grouping.rb
@@ -9,7 +9,7 @@ module Aeon
 
     delegate :each, to: :requests
 
-    delegate :appointment?, :submitted?, :appointment, :call_number, :date, :digital?,
+    delegate :appointment?, :submitted?, :appointment, :base_callnumber, :call_number, :date, :digital?,
              :document_type, :ead_number, :multi_item_selector?, :title, to: :first
 
     def self.from_requests(requests)

--- a/app/models/ead/document.rb
+++ b/app/models/ead/document.rb
@@ -24,6 +24,7 @@ module Ead
       @identifier ||= doc.xpath('//unitid[not(@type)]').first&.text&.strip
     end
 
+    alias base_callnumber identifier
     alias call_number identifier
 
     def document_type

--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -83,6 +83,8 @@ module Folio
       single_item&.base_callnumber
     end
 
+    alias base_callnumber call_number
+
     def document_type
       format.presence&.first || single_item&.type
     end

--- a/spec/components/aeon/request_group_compact_component_spec.rb
+++ b/spec/components/aeon/request_group_compact_component_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Aeon::RequestGroupCompactComponent, type: :component do
   context 'with multi-item requests' do
     let(:web_request_form) { 'multiple' }
     let(:first_request) do
-      build(:aeon_request, call_number: 'SC0097', title: 'Donald E. Knuth papers',
+      build(:aeon_request, ead_number: 'SC0097', title: 'Donald E. Knuth papers',
                            transaction_number: 100, web_request_form:)
     end
     let(:second_request) do
-      build(:aeon_request, call_number: 'SC0097', title: 'Donald E. Knuth papers',
+      build(:aeon_request, ead_number: 'SC0097', title: 'Donald E. Knuth papers',
                            transaction_number: 101, web_request_form:)
     end
     let(:request_group) { Aeon::RequestGrouping.new([first_request, second_request]) }


### PR DESCRIPTION
At least for base call number display, this pushes our `multi_item_selector?` check behind the scenes and gets rid of the type checking in `RecordHeaderComponent`