### PR TITLE
Prefer 'requested_pages' over 'pages' for Aeon requests

### DIFF
--- a/app/components/aeon/confirmation_request_list_component.html.erb
+++ b/app/components/aeon/confirmation_request_list_component.html.erb
@@ -15,8 +15,8 @@
             <div>
               <% if request.appointment %>
                 <%= render AppointmentTimeRangeComponent.new(appointment: request.appointment) %>
-              <% elsif request.pages.present? %>
-                Pages <%= request.pages %>
+              <% elsif request.requested_pages.present? %>
+                Pages <%= request.requested_pages %>
               <% end %>
             </div>
           </div>

--- a/app/components/aeon/request_item_detail_component.rb
+++ b/app/components/aeon/request_item_detail_component.rb
@@ -5,7 +5,7 @@ module Aeon
   class RequestItemDetailComponent < ViewComponent::Base
     attr_reader :request
 
-    delegate :ead?, :pages, :volume, :format, to: :request
+    delegate :ead?, :requested_pages, :volume, :format, to: :request
 
     def initialize(request:, variant: :full)
       @request = request
@@ -17,7 +17,7 @@ module Aeon
     end
 
     def format_info
-      return "Pages: #{pages}" if pages.present?
+      return "Pages: #{requested_pages}" if requested_pages.present?
       return "Item: #{volume}" if volume.present? && !ead?
       return "Format: #{format}" if format.present?
 

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -61,7 +61,6 @@ module Aeon
     alias_attribute :id, :transaction_number
     alias_attribute :item_url, :item_info1
     alias_attribute :access_restrictions, :item_info4
-    alias_attribute :pages, :item_info5
     alias_attribute :requested_pages, :item_info5
     alias_attribute :author, :item_author
     alias_attribute :date, :item_date

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -25,10 +25,10 @@
               <h2>Appointment</h2>
               <i class="bi bi-calendar me-2"></i><%= render AppointmentTimeRangeComponent.new(appointment: request.appointment) %>
             </div>
-          <% elsif request.pages.present? %>
+          <% elsif request.requested_pages.present? %>
             <div class="mb-3">
               <h2>Pages</h2>
-              <i class="bi bi-file-earmark me-2"></i><%= request.pages %>
+              <i class="bi bi-file-earmark me-2"></i><%= request.requested_pages %>
             </div>
           <% end %>
           <% if request.special_request %>


### PR DESCRIPTION
I noticed we have two aliases for `item_info5`. Any reason not to standardize on one?