### PR TITLE
Use the normal font weight for request bulk action label

### DIFF
--- a/app/components/aeon/request_actions_component.html.erb
+++ b/app/components/aeon/request_actions_component.html.erb
@@ -8,7 +8,7 @@
           <input type="checkbox" class="form-check-input" id="delete-bulk-<%= request.id %>"
             data-action="change->draft-request#updateDeleteButton draft-request#updateSelectAll"
             data-draft-request-target="select" data-id="<%= request.id %>" />
-          <%= label_tag "delete-bulk-#{request.id}", 'Select', class: 'ms-2 me-3 form-check-label' %>
+          <%= label_tag "delete-bulk-#{request.id}", 'Select', class: 'ms-2 me-3 form-check-label fw-normal' %>
         <% end %>
         <% if helpers.can? :edit, request %>
           <%= link_to edit_aeon_request_path(request), class: 'btn btn-link su-underline p-0 me-sm-2', data: { action: 'modal#open' } do %>


### PR DESCRIPTION
Before:
<img width="712" height="168" alt="Screenshot 2026-03-23 at 4 50 03 PM" src="https://github.com/user-attachments/assets/8cbaa3f1-015a-402f-9f49-25a5a8560400" />

After:
<img width="702" height="86" alt="Screenshot 2026-03-23 at 4 51 58 PM" src="https://github.com/user-attachments/assets/25b5c81f-88d7-4a99-9ccc-76b7c09dcc98" />
