### PR TITLE
Use digital green dark instead of digital green

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -43,7 +43,7 @@ layer(components);
 }
 
 .text-green {
-  color: var(--stanford-digital-green);
+  color: rgba(var(--stanford-digital-green-dark-rgb), 1);
 }
 
 .text-jungle-green {
@@ -422,7 +422,7 @@ label.btn-close {
   }
 
   .ready {
-    color: var(--stanford-digital-green);
+    color: rgba(var(--stanford-digital-green-dark-rgb), 1);
     background-color: rgba(var(--stanford-digital-green-rgb), 0.1);
   }
 


### PR DESCRIPTION
The designs specify digital green dark for these elements. This solves our color contrast issue (which is why Darcy used dark).