### PR TITLE
switch item_id to text field

### DIFF
--- a/db/migrate/20260325145334_update_item_id.rb
+++ b/db/migrate/20260325145334_update_item_id.rb
@@ -1,0 +1,6 @@
+class UpdateItemId < ActiveRecord::Migration[8.1]
+  def change
+    change_column :api_responses, :item_id, :text
+    change_column :api_responses, :patron_request_id, :bigint, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_17_164328) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_145334) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "comment"
     t.string "commenter"
@@ -23,7 +23,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_17_164328) do
 
   create_table "api_responses", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "item_id"
+    t.text "item_id"
     t.bigint "patron_request_id", null: false
     t.binary "request_data"
     t.binary "response_data"


### PR DESCRIPTION
should? close #3348 

The reason patron_request_id is defined in this as well is the migration without kept updating the row from bigint to int.