### PR TITLE
Use the item identification component on the confirmation screen

### DIFF
--- a/app/components/aeon/confirmation_request_list_component.html.erb
+++ b/app/components/aeon/confirmation_request_list_component.html.erb
@@ -7,9 +7,7 @@
         <div class="accordion-item">
           <div class="accordion-header bg-white accordion-button px-0 collapsed d-flex align-items-center justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#<%= accordion_name(index) %>" aria-expanded="false" aria-controls="<%= accordion_name(index) %>" id="<%= accordion_name(index) %>Heading">
             <div>
-              <span class="px-2 bg-fog-light fw-semibold">
-                <%= request.call_number %><i class="bi bi-chevron-right"></i><%= request.volume %>
-              </span>
+              <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
               <span class="ms-2 fs-14">Request #<%= request.transaction_number %></span>
             </div>
             <div>


### PR DESCRIPTION
It has logic to avoid displaying unneeded separators.

Before:
<img width="487" height="173" alt="Screenshot 2026-03-27 at 8 14 27 AM" src="https://github.com/user-attachments/assets/3a24093e-ae93-4a78-b658-e47ecb008b6b" />

After:
<img width="748" height="118" alt="Screenshot 2026-03-27 at 1 00 46 PM" src="https://github.com/user-attachments/assets/6cf3717a-7cef-4e42-b295-c988a692728f" />
