### PR TITLE
Omit the bottom border on the last request in the confirmation group

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -618,8 +618,11 @@ label.btn-close {
     --bs-accordion-border-radius: 0;
   }
   
-  .accordion-item {
-    border-bottom: 1px solid var(--stanford-20-black)!important;
+  .request {
+    border-bottom: 1px solid var(--stanford-20-black);
+    &:last-child {
+      border-bottom: none;
+    }
   }
 }
 

--- a/app/components/aeon/confirmation_request_list_component.html.erb
+++ b/app/components/aeon/confirmation_request_list_component.html.erb
@@ -1,9 +1,9 @@
 
 <div class="border rounded p-3 mb-2">
-  <h2 class="h3 mb-3"><%= title %></h2>
-  <ul class="list-unstyled">
+  <h2 class="h3"><%= title %></h2>
+  <ul class="list-unstyled mb-0">
     <% requests.each_with_index do |request, index| %>
-      <li class="accordion accordion-flush">
+      <li class="request accordion accordion-flush">
         <div class="accordion-item">
           <div class="accordion-header bg-white accordion-button px-0 collapsed d-flex align-items-center justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#<%= accordion_name(index) %>" aria-expanded="false" aria-controls="<%= accordion_name(index) %>" id="<%= accordion_name(index) %>Heading">
             <div>


### PR DESCRIPTION
Prepping for when not all of these will be accordions.

Before:
<img width="638" height="508" alt="Screenshot 2026-03-27 at 1 27 02 PM" src="https://github.com/user-attachments/assets/e546c563-1843-477b-be27-8dbbc1002151" />

After:
<img width="895" height="443" alt="Screenshot 2026-03-27 at 1 37 07 PM" src="https://github.com/user-attachments/assets/06f00a28-2f81-4a6e-b6ce-7102a344b3d1" />
