### PR TITLE
Move `status_request` out of the group model into the group component

### DIFF
--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,8 +1,8 @@
 <div class="request-group card mb-4" data-controller="empty-remove">
   <div class="card-header fw-semibold p-3 ps-2 d-flex gap-1 flex-row align-items-md-center justify-content-between">
     <div class="d-flex flex-wrap gap-1 align-items-center">
-      <%= render Aeon::RequestStatusPillComponent.new(request: status_request) %>
-      <%= render Aeon::RequestStatusMessageComponent.new(request: status_request) %>
+      <%= render Aeon::RequestStatusPillComponent.new(request: request_for_status_display) %>
+      <%= render Aeon::RequestStatusMessageComponent.new(request: request_for_status_display) %>
       <% if appointment_reading_room.present? %>
       <span class="appointment-details ms-1">
         <span class="ms-2 fw-semibold text-nowrap text-green"><%= appointment_reading_room.name %></span>

--- a/app/components/aeon/request_group_component.rb
+++ b/app/components/aeon/request_group_component.rb
@@ -5,7 +5,7 @@ module Aeon
   class RequestGroupComponent < ViewComponent::Base
     attr_reader :request_group
 
-    delegate :appointment_reading_room, :base_callnumber, :requests, :status_request, :title, to: :request_group
+    delegate :appointment_reading_room, :base_callnumber, :requests, :title, to: :request_group
 
     def initialize(request_group:)
       @request_group = request_group
@@ -13,6 +13,10 @@ module Aeon
 
     def render?
       requests.present?
+    end
+
+    def request_for_status_display
+      requests.find { |r| r.status != :completed } || requests.first
     end
   end
 end

--- a/app/models/aeon/request_grouping.rb
+++ b/app/models/aeon/request_grouping.rb
@@ -33,15 +33,7 @@ module Aeon
     def appointment_reading_room
       return if digital?
 
-      submitted_requests&.first&.reading_room
-    end
-
-    # For status display, prefer a pending request over a ready one
-    # so the group shows as pending if any request is still pending.
-    def status_request
-      return first unless digital? && requests.any?(&:submitted?)
-
-      requests.find { |r| !r.scan_delivered? } || first
+      @appointment_reading_room ||= submitted_requests&.first&.reading_room
     end
   end
 end

--- a/spec/components/aeon/request_group_component_spec.rb
+++ b/spec/components/aeon/request_group_component_spec.rb
@@ -61,4 +61,20 @@ RSpec.describe Aeon::RequestGroupComponent, type: :component do
       expect(page).to have_content 'Request #101'
     end
   end
+
+  context 'with a mix of completed and not-completed digital requests' do
+    let(:first_request) { build(:aeon_request, :digitized) }
+    let(:second_request) { build(:aeon_request, :digitized) }
+    let(:request_group) { Aeon::RequestGrouping.new([first_request, second_request]) }
+
+    before do
+      allow(first_request).to receive_messages(cancelled?: false, completed?: true, draft?: false, scan_delivered?: true)
+      allow(second_request).to receive_messages(cancelled?: false, completed?: false, draft?: false, scan_delivered?: false)
+      render_inline(described_class.new(request_group:))
+    end
+
+    it 'displays the status of the group as pending' do
+      expect(page).to have_content 'Digitization pending'
+    end
+  end
 end

--- a/spec/models/aeon/request_grouping_spec.rb
+++ b/spec/models/aeon/request_grouping_spec.rb
@@ -58,30 +58,4 @@ RSpec.describe Aeon::RequestGrouping do
       end
     end
   end
-
-  describe '#status_request' do
-    context 'when the group is not digital' do
-      let(:request) { build(:aeon_request) }
-      let(:grouping) { described_class.new([request]) }
-
-      it 'returns the first request' do
-        expect(grouping.status_request).to eq(request)
-      end
-    end
-
-    context 'when the group is digital and submitted with a mix of ready and pending' do
-      let(:delivered) { build(:aeon_request, :digitized) }
-      let(:pending) { build(:aeon_request, :digitized) }
-      let(:grouping) { described_class.new([delivered, pending]) }
-
-      before do
-        allow(delivered).to receive_messages(submitted?: true, scan_delivered?: true)
-        allow(pending).to receive_messages(submitted?: true, scan_delivered?: false)
-      end
-
-      it 'returns the pending request' do
-        expect(grouping.status_request).to eq(pending)
-      end
-    end
-  end
 end


### PR DESCRIPTION
People find `status_request` confusing and so far we haven't had another need for it outside of the group component.
