### PR TITLE
Remove text decoration on appointment edit pencil icon

### DIFF
--- a/app/components/aeon/appointment_component.html.erb
+++ b/app/components/aeon/appointment_component.html.erb
@@ -6,7 +6,7 @@
       <span><i class="bi bi-geo-alt-fill me-1"></i><%= appointment.reading_room.name %></span>
     </h2>
     <div>
-      <%= link_to edit_aeon_appointment_path(appointment.id), data: { action: 'modal#open' } do %>
+      <%= link_to edit_aeon_appointment_path(appointment.id), class: 'text-decoration-none', data: { action: 'modal#open' } do %>
         <i class="bi bi-pencil-fill me-1"></i><span class="visually-hidden">Edit appointment</span>
       <% end %>
       <% if helpers.can? :destroy, appointment %>


### PR DESCRIPTION
Removes this little underline on hover:

<img width="68" height="42" alt="Screenshot 2026-03-30 at 9 28 47 AM" src="https://github.com/user-attachments/assets/11047d8c-6147-4e9d-8293-4d32830527d1" />
