### PR TITLE
Increase gap and spacing on appointment header

### DIFF
--- a/app/components/aeon/appointment_component.html.erb
+++ b/app/components/aeon/appointment_component.html.erb
@@ -1,9 +1,9 @@
 <div class="card border-light mb-4">
   <div class="card-header d-flex border-light d-flex justify-content-between align-items-center bg-white">
-    <h2 class="card-title mb-0 h4 d-flex gap-2">
-      <span><i class="bi bi-calendar me-1"></i><%= appointment_date %></span>
-      <span><i class="bi bi-clock me-1"></i><%= appointment_time_range %></span>
-      <span><i class="bi bi-geo-alt-fill me-1"></i><%= appointment.reading_room.name %></span>
+    <h2 class="card-title mb-0 h4 d-flex gap-3">
+      <span><i class="bi bi-calendar me-2"></i><%= appointment_date %></span>
+      <span><i class="bi bi-clock me-2"></i><%= appointment_time_range %></span>
+      <span><i class="bi bi-geo-alt-fill me-2"></i><%= appointment.reading_room.name %></span>
     </h2>
     <div>
       <%= link_to edit_aeon_appointment_path(appointment.id), data: { action: 'modal#open' } do %>


### PR DESCRIPTION
This uses the spacing from the design. Because it's so important to do this now 😄 


Before:
<img width="579" height="61" alt="Screenshot 2026-03-30 at 10 00 53 AM" src="https://github.com/user-attachments/assets/798b0b8b-aab0-42fe-85a8-f0a16ba7e238" />

After:
<img width="575" height="55" alt="Screenshot 2026-03-30 at 10 01 07 AM" src="https://github.com/user-attachments/assets/5a61aa71-9b63-4e6b-8ed5-fc698c870aad" />
