### PR TITLE
Set the mailer host from settings.

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,6 +4,6 @@
 #  Top-level mailer class to allow us to set defaults like from and layout.
 ###
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@requests.stanford.edu'
+  default from: "no-reply@#{Settings.mailer_host}"
   layout 'mailer'
 end


### PR DESCRIPTION
Maybe this will stop the Stanford SMTP server (or gmail?) from blocking our OTP mail?