### PR TITLE
Disable accordion button for single pre-rendered digitization items

### DIFF
--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,23 +1,21 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative">
-    <button class="accordion-button d-inline-flex w-auto align-items-center position-static" type="button" data-bs-toggle="collapse" data-bs-target="#content_<%= dom_id %>" aria-expanded="<%= collapsed? ? 'false' : 'true' %>" aria-controls="content_<%= dom_id %>">
+    <%= tag.button(**button_attributes) do %>
       <i class="bi bi-check2 selected-item-status"></i>
       <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
-    </button>
+    <% end %>
     <button class="btn btn-link p-0 ps-1 z-3 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
       <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
     </button>
-
     <i class="bi bi-chevron-right disclosure-icon ms-auto px-4"></i>
   </div>
-  <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' if collapsed? %>">
+  <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' unless single_item? %>">
     <%= fields_for base_name, object do |f| %>
       <div class="accordion-body">
         <div class="mb-3">
           <%= f.label :requested_pages, class: 'form-label fw-semibold redesign-required-label' %>
           <%= f.text_field :requested_pages, placeholder: 'e.g. 100-150, 167, 170-180 or Chapter 5', class: 'form-control', data: { 'required-for-submit': true } %>
         </div>
-
         <div class="mb-3">
           <fieldset>
             <legend class="form-label fs-6 mb-1 fw-semibold">Is this for publication?</legend>
@@ -25,12 +23,10 @@
               <%= f.radio_button :for_publication, true %>
               <%= f.label :for_publication_true, 'Yes' %>
             </span>
-
             <%= f.radio_button :for_publication, false %>
             <%= f.label :for_publication_false, 'No' %>
           </fieldset>
         </div>
-
         <div class="mb-3" data-controller="char-counter">
           <%= f.label :additional_information, class: 'form-label fw-semibold' %>
           <%= f.text_area :additional_information, class: 'form-control', maxlength: 255, data: { action: "input->char-counter#updateCharCounter"} %>
@@ -39,7 +35,6 @@
             <span data-char-counter-target="counter"></span>
           </p>
         </div>
-
         <div class="d-flex justify-content-end">
           <button class="next-item btn btn-sm btn-primary" data-selected-item-form-target="nextButton" data-action="selected-item-form#nextItem">Next item</button>
         </div>

--- a/app/components/aeon/digitization_form_item_component.rb
+++ b/app/components/aeon/digitization_form_item_component.rb
@@ -5,16 +5,29 @@ module Aeon
   class DigitizationFormItemComponent < ViewComponent::Base
     attr_reader :title, :dom_id, :object, :base_name
 
-    def initialize(title:, dom_id:, object: nil, base_name: nil, collapsed: true)
+    def initialize(title:, dom_id:, object: nil, base_name: nil, single_item: false)
       @title = title
       @dom_id = dom_id
       @object = object
       @base_name = base_name || "item[#{dom_id}]"
-      @collapsed = collapsed
+      @single_item = single_item
     end
 
-    def collapsed?
-      @collapsed
+    def single_item?
+      @single_item
+    end
+
+    def button_attributes
+      attrs = {
+        class: 'accordion-button d-inline-flex w-auto align-items-center position-static',
+        type: 'button',
+        'data-bs-toggle': 'collapse',
+        'data-bs-target': "#content_#{dom_id}",
+        'aria-expanded': single_item? ? 'true' : 'false',
+        'aria-controls': "content_#{dom_id}"
+      }
+      attrs[:disabled] = true if single_item?
+      attrs
     end
   end
 end

--- a/app/javascript/controllers/item_selector_controller.js
+++ b/app/javascript/controllers/item_selector_controller.js
@@ -148,7 +148,7 @@ export default class extends Controller {
       if (accordionButton) {
         if (value.length === 1) {
           accordionButton.setAttribute('disabled', '');
-        } else {
+        } else if (value.length > 0) {
           accordionButton.removeAttribute('disabled');
         }
       }

--- a/app/views/patron_requests/_digitization_options.html.erb
+++ b/app/views/patron_requests/_digitization_options.html.erb
@@ -3,7 +3,7 @@
 
   <div class="accordion digitization-accordion selected-items-container" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
     <% if f.object.selectable_items.one? %>
-      <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", collapsed: false) %>
+      <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", single_item: true) %>
     <% end %>
   </div>
 


### PR DESCRIPTION
(again) closes https://github.com/sul-dlss/sul-requests/issues/3313

I wasn't sure the right place to test this.

Herb required that I set button attributes in the .rb file because of `disabled`