### PR TITLE
Serve the JS sourcemap for development debugging

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Serve sourcemap files for debugging
+  config.assets.precompile += %w[*.js.map]
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
We build but don't serve, so it's broken in devtools