### PR TITLE
add radio form for cancelled appointments

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -110,6 +110,7 @@ body {
 
 input[type="radio"] {
   --bs-border-color: var(--stanford-50-black);
+  accent-color: var(--stanford-digital-blue);
 }
 
 .form-check-input {

--- a/app/components/aeon/appointment_component.html.erb
+++ b/app/components/aeon/appointment_component.html.erb
@@ -53,18 +53,24 @@
   </div>
   <!-- Delete modal -->
   <%= render ModalComponent.new(id: "delete-appointment-#{appointment.id}",
-                                cancel_text: 'No',
-                                submit_text: 'Yes - Delete') do |component| %>
+                                submit_text: 'Yes, cancel appointment') do |component| %>
     <% component.with_title.with_content('Cancel appointment?') %>
     <% component.with_body do %>
-      <%= form_with url: aeon_appointment_path(appointment.id), id: "form-delete-appointment-#{appointment.id}", method: 'delete' do %>
-        <div class="fw-semibold"><i class="bi bi-calendar me-2"></i><%= appointment_date %><i class="bi bi-clock mx-2"></i><%= appointment_time_range %></div>
-        <div class="mt-1 fw-semibold"><i class="bi bi-geo-alt-fill me-1"></i><%= appointment.reading_room.name %></div>
+      <div class="fw-semibold"><i class="bi bi-calendar me-2"></i><%= appointment_date %><i class="bi bi-clock mx-2"></i><%= appointment_time_range %></div>
+      <div class="mt-1 fw-semibold"><i class="bi bi-geo-alt-fill me-1"></i><%= appointment.reading_room.name %></div>
+      <%= form_with url: aeon_appointment_path(appointment.id), id: "form-delete-appointment-#{appointment.id}", method: 'delete' do |f| %>
         <% if appointment.requests.any? %>
-          <p class="mb-0">
-            <%= pluralize(appointment.requests.length, 'requested item') %> are assigned to this appointment. If you cancel or delete the appointment, the items will not be deleted.
-            Instead, they will be moved to <strong>Draft requests</strong>.
-          </p>
+          <div class="mb-0 mt-2 alert alert-info">
+            <strong><%= pluralize(appointment.requests.length, 'item') %></strong> are assigned to this appointment.
+            <div class="d-flex gap-1">
+              <%= f.radio_button :cancel_items, false %>
+              <%= f.label 'save_items', 'Save items and schedule later' %>
+            </div>
+            <div class="d-flex gap-1">
+              <%= f.radio_button :cancel_items, true %>
+              <%= f.label 'save_items', 'Delete requested items' %>
+            </div>
+          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -64,7 +64,7 @@ class AeonAppointmentsController < ApplicationController
   def destroy
     authorize! :delete, @appointment
 
-    CancelAeonAppointmentJob.perform_now(@appointment)
+    CancelAeonAppointmentJob.perform_now(@appointment, cancel_requests: params['cancel_items'] == 'true')
 
     redirect_to aeon_appointments_path, notice: 'Appointment cancelled successfully'
   end

--- a/app/jobs/cancel_aeon_appointment_job.rb
+++ b/app/jobs/cancel_aeon_appointment_job.rb
@@ -5,19 +5,25 @@
 class CancelAeonAppointmentJob < ApplicationJob
   queue_as :default
 
-  def perform(appointment)
+  def perform(appointment, cancel_requests: false)
+    status = request_status(cancel_requests)
     appointment.requests.each do |request|
-      move_request_to_draft(request)
+      move_request(request, status:)
     end
     aeon_client.cancel_appointment(appointment.id)
   end
 
+  def request_status(cancel)
+    return Settings.aeon.queue_names.draft.transaction.first unless cancel
+    Settings.aeon.queue_names.cancelled.transaction.first
+  end
+
   # When an appointment is cancelled, Aeon cancels the requests by default. We want to move them to draft
   # and dis-associated the appointment instead.
-  def move_request_to_draft(request)
+  def move_request(request, status:)
     aeon_client.update_request(request.transaction_number, AeonClient::DeleteAppointmentRequestData.new)
     aeon_client.update_request_route(transaction_number: request.transaction_number,
-                                     status: Settings.aeon.queue_names.draft.transaction.first)
+                                     status:)
   end
 
   def aeon_client


### PR DESCRIPTION
closes https://github.com/sul-dlss/sul-requests/issues/3396

We should probably do something about the fact for 1 item the grammar isn't correct. @dbranchini could we refactor the language to be agnostic? 1 item assigned to this appointment. 2 items assigned to this appointment. 
<img width="525" height="363" alt="Screenshot 2026-04-06 at 4 52 57 PM" src="https://github.com/user-attachments/assets/0da41656-a470-42c0-a86c-44847d505141" />
