### PR TITLE
Add "Save for later" behavior for requests

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -552,6 +552,11 @@ label.btn-close {
 
 .appointments-item {
   flex-wrap: wrap;
+
+  .spinner-grow-sm {
+    --bs-spinner-width: 0.375rem;
+    --bs-spinner-height: 0.375rem;
+  }
 }
 
 #reading:has(.appointments-item:only-child),
@@ -690,6 +695,30 @@ label.btn-close {
     &:last-child {
       border-bottom: none;
     }
+  }
+}
+
+@layer framework {
+  .saved-item:last-child {
+    border-bottom: none !important;
+  }
+}
+
+.save-for-later-container {
+  opacity: 1;
+  transition: opacity 0.3s ease, display 0.3s allow-discrete;
+
+  @starting-style {
+    opacity: 0;
+  }
+}
+
+.saved-item {
+  opacity: 1;
+  transition: opacity 0.3s ease;
+
+  @starting-style {
+    opacity: 0;
   }
 }
 

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -3,12 +3,14 @@
     <i class="bi bi-check2 selected-item-status"></i>
     <div class="d-flex flex-column">
       <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
-      <div>
-        <a href="#" class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
-        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
-        </button>
-      </div>
+      <% if new_item? %>
+        <div>
+          <a href="#" class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+          <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+            <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+          </button>
+        </div>
+      <% end %>
     </div>
   </div>
   <%= fields_for base_name, object do |f| %>

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -1,15 +1,20 @@
-<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 p-2 d-flex row-gap-2 text-nowrap align-items-center" data-content-id="<%= dom_id %>">
+<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 p-2 d-flex row-gap-2 justify-content-between text-nowrap align-items-center" data-content-id="<%= dom_id %>">
   <div class="d-flex align-items-center">
     <i class="bi bi-check2 selected-item-status"></i>
-    <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
-    <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-      <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
-    </button>
+    <div class="d-flex flex-column">
+      <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
+      <div>
+        <a href="#" class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+        </button>
+      </div>
+    </div>
   </div>
   <%= fields_for base_name, object do |f| %>
     <div class="fs-6 mb-0 w-100 form-label fw-semibold redesign-required-label possibly-visually-hidden-appointments-label">Appointment</div>
 
-    <div class="dropdown custom-select" data-controller="appointment-select" data-action="change->appointment-select#updateSelected appointment-select:change@document->appointment-select#updateItemCounts">
+    <div class="dropdown custom-select" data-controller="appointment-select" data-action="change->appointment-select#updateSelected input->appointment-select#updateSelected appointment-select:change@document->appointment-select#updateItemCounts save-for-later:changed@document->appointment-select#updateItemCounts">
       <%= f.hidden_field :appointment_id, class: 'visually-hidden', data: { 'appointment-select-target': :input, 'required-for-submit': true } %>
       <button class="py-1 btn border bg-white dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-appointment-select-target="button">
         Select existing appointment

--- a/app/components/aeon/appointment_form_item_component.rb
+++ b/app/components/aeon/appointment_form_item_component.rb
@@ -14,6 +14,10 @@ module Aeon
       @reading_room_id = reading_room_id
     end
 
+    def new_item?
+      object.nil?
+    end
+
     def new_appointment_path
       new_aeon_appointment_path(reading_room_id: @reading_room_id)
     end

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -5,12 +5,14 @@
         <i class="bi bi-check2 selected-item-status"></i>
         <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
       </button>
-      <div class="d-flex position-relative z-3">
-        <a href="#" class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
-        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
-        </button>
-      </div>
+      <% if new_item? %>
+        <div class="d-flex position-relative z-3">
+          <a href="#" class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+          <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+            <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+          </button>
+        </div>
+      <% end %>
     </div>
 
     <i class="bi bi-chevron-down accordion-header-icon ms-auto px-4"></i>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,12 +1,17 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative">
-    <button class="accordion-button d-inline-flex w-auto align-items-center position-static" type="button" data-bs-toggle="collapse" data-bs-target="#content_<%= dom_id %>" aria-expanded="<%= collapsed? ? 'false' : 'true' %>" aria-controls="content_<%= dom_id %>">
-      <i class="bi bi-check2 selected-item-status"></i>
-      <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
-    </button>
-    <button class="btn btn-link p-0 ps-1 z-3 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-      <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
-    </button>
+    <div class="d-flex align-items-center flex-grow-1 justify-content-between">
+      <button class="accordion-button d-inline-flex w-auto align-items-center position-static" type="button" data-bs-toggle="collapse" data-bs-target="#content_<%= dom_id %>" aria-expanded="<%= collapsed? ? 'false' : 'true' %>" aria-controls="content_<%= dom_id %>">
+        <i class="bi bi-check2 selected-item-status"></i>
+        <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
+      </button>
+      <div class="d-flex position-relative z-3">
+        <a href="#" class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+        </button>
+      </div>
+    </div>
 
     <i class="bi bi-chevron-down accordion-header-icon ms-auto px-4"></i>
   </div>

--- a/app/components/aeon/digitization_form_item_component.rb
+++ b/app/components/aeon/digitization_form_item_component.rb
@@ -16,5 +16,9 @@ module Aeon
     def collapsed?
       @collapsed
     end
+
+    def new_item?
+      object.nil?
+    end
   end
 end

--- a/app/components/aeon/request_item_identifier_component.html.erb
+++ b/app/components/aeon/request_item_identifier_component.html.erb
@@ -1,4 +1,4 @@
-<span class="p-1 bg-fog-light fw-semibold">
+<span class="<%= classes %>">
   <%= call_number %>
   <% if separator? %><i class="bi bi-chevron-right"></i><% end %>
   <%= container %>

--- a/app/components/aeon/request_item_identifier_component.rb
+++ b/app/components/aeon/request_item_identifier_component.rb
@@ -3,12 +3,13 @@
 module Aeon
   # Request item identifier
   class RequestItemIdentifierComponent < ViewComponent::Base
-    attr_reader :request
+    attr_reader :classes, :request
 
     delegate :ead?, :volume, to: :request
 
-    def initialize(request:)
+    def initialize(request:, classes: 'p-1 bg-fog-light fw-semibold')
       @request = request
+      @classes = classes
     end
 
     def call_number

--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -12,13 +12,13 @@ class PatronRequestsController < ApplicationController
 
   bot_challenge only: [:new]
 
-  load_resource
+  load_resource new: [:new, :save_for_later]
   before_action :assign_new_attributes, only: [:new]
   before_action :aeon_email_present, only: [:new]
-  before_action :authorize_new_request, only: [:new]
+  before_action :authorize_new_request, only: [:new, :save_for_later]
   authorize_resource
 
-  before_action :associate_request_with_patron, only: [:new, :create]
+  before_action :associate_request_with_patron, only: [:new, :create, :save_for_later]
   before_action :redirect_aeon_pages, only: [:create]
   before_action :require_aeon_terms, only: [:new, :create]
   before_action :redirect_finding_aid_pages, if: lambda {
@@ -50,6 +50,19 @@ class PatronRequestsController < ApplicationController
       redirect_to @patron_request
     else
       render 'new'
+    end
+  end
+
+  def save_for_later
+    return unless Settings.features.requests_redesign && @patron_request.aeon_page?
+
+    scope_to_save_for_later_item
+
+    if @patron_request.save
+      create_draft_aeon_request
+      respond_to { |format| format.turbo_stream }
+    else
+      head :unprocessable_content
     end
   end
 
@@ -90,6 +103,20 @@ class PatronRequestsController < ApplicationController
     flash.now[:error] = t('sessions.login_by_sunetid.error_html') if sunetid_without_folio_account? && !@patron_request.aeon_page?
 
     render 'login'
+  end
+
+  def create_draft_aeon_request
+    @aeon_request = SubmitAeonPatronRequestJob.perform_now(@patron_request)&.first
+    @dom_id = @patron_request.aeon_item.keys.first
+    @request_type = @patron_request.request_type == 'scan' ? 'scan' : 'pickup'
+  end
+
+  def scope_to_save_for_later_item
+    item_id = params[:save_for_later_item_id]
+    return unless item_id
+
+    @patron_request.barcodes = [item_id]
+    @patron_request.aeon_item = @patron_request.aeon_item&.slice(item_id) || {}
   end
 
   def redirect_aeon_pages
@@ -138,6 +165,7 @@ class PatronRequestsController < ApplicationController
                                    :fulfillment_type, :request_type,
                                    :scan_page_range, :scan_authors, :scan_title,
                                    :aeon_reading_special, :aeon_terms, :ead_url,
+                                   :saved_for_later_count,
                                    { barcodes: [] }, { aeon_item: aeon_term_params }])
   end
 

--- a/app/javascript/controllers/accordion_form_controller.js
+++ b/app/javascript/controllers/accordion_form_controller.js
@@ -33,7 +33,17 @@ export default class extends Controller {
   emptyFields(accordion) {
     const formData = new FormData(accordion.closest('form'));
 
-    return Array.from(accordion.querySelectorAll('[required],input[name="patron_request[barcodes][]"]')).find(x => formData.getAll(x.name).every(x => !x))
+    const requiredEmpty = Array.from(accordion.querySelectorAll('[required],input[name="patron_request[barcodes][]"]')).find(x => formData.getAll(x.name).every(x => !x))
+    if (requiredEmpty) return requiredEmpty;
+
+    // Check data-required-for-submit fields on visible items
+    const visibleRequired = Array.from(accordion.querySelectorAll('[data-required-for-submit]'))
+      .filter(x => x.closest('[data-content-id]')?.offsetParent)
+
+    // If items exist with required-for-submit fields but none are visible, nothing to submit
+    if (visibleRequired.length === 0 && accordion.querySelectorAll('[data-required-for-submit]').length > 0) return true
+
+    return visibleRequired.find(x => formData.getAll(x.name).every(x => !x))
   }
 
   enableAnyNextButtons(event) {

--- a/app/javascript/controllers/appointment_select_controller.js
+++ b/app/javascript/controllers/appointment_select_controller.js
@@ -21,7 +21,7 @@ export default class extends Controller {
     this.element.querySelectorAll('[data-count]').forEach(option => {
       const baseCount = parseInt(option.dataset.count);
 
-      const formCount = this.element.closest('#reading-accordion').querySelectorAll("input[value='" + option.dataset.appointmentId + "']:not(:disabled)").length;
+      const formCount = document.getElementById('reading-accordion').querySelectorAll("input[value='" + option.dataset.appointmentId + "']:not(:disabled)").length;
 
       const newCount = baseCount + formCount;
 

--- a/app/javascript/controllers/appointment_select_controller.js
+++ b/app/javascript/controllers/appointment_select_controller.js
@@ -21,7 +21,7 @@ export default class extends Controller {
     this.element.querySelectorAll('[data-count]').forEach(option => {
       const baseCount = parseInt(option.dataset.count);
 
-      const formCount = this.element.closest('#reading-accordion').querySelectorAll("input[value='" + option.dataset.appointmentId + "']").length;
+      const formCount = this.element.closest('#reading-accordion').querySelectorAll("input[value='" + option.dataset.appointmentId + "']:not(:disabled)").length;
 
       const newCount = baseCount + formCount;
 
@@ -45,6 +45,10 @@ export default class extends Controller {
     const selectedOption = this.element.querySelector(`[data-value="${this.inputTarget.value}"]`);
     if (selectedOption) {
       this.buttonTarget.innerHTML = selectedOption.querySelector('.label-value').innerHTML;
+    } else {
+      this.element.querySelector('.selected')?.classList?.remove('selected');
+      this.buttonTarget.textContent = 'Select existing appointment';
+      this.dispatch('change', { detail: { value: '' } });
     }
   }
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -46,6 +46,9 @@ application.register("otp-input", OtpInput)
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 
+import SaveForLaterController from "./save_for_later_controller"
+application.register("save-for-later", SaveForLaterController)
+
 import SelectedItemFormController from "./selected_item_form_controller"
 application.register("selected-item-form", SelectedItemFormController)
 

--- a/app/javascript/controllers/save_for_later_controller.js
+++ b/app/javascript/controllers/save_for_later_controller.js
@@ -1,0 +1,127 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['container', 'items', 'savedItem']
+
+  connect() {
+    this.update()
+  }
+
+  savedItemTargetConnected() {
+    this.update()
+  }
+
+  savedItemTargetDisconnected() {
+    this.update()
+  }
+
+  save(event) {
+    event.preventDefault()
+
+    const { id } = event.params
+    const formItem = this.formItemFor(id)
+    if (!formItem) return
+
+    this.submitSaveForLater(id)
+    this.setItemInputsDisabled(id, true)
+    this.replaceWithSpinner(formItem, id)
+    this.containerTarget.hidden = false
+    this.dispatch('changed')
+  }
+
+  undo(event) {
+    this.removeSavedItem(event, (id) => this.restoreFormItem(id))
+  }
+
+  delete(event) {
+    this.removeSavedItem(event, (id) => this.removeFormItem(id))
+  }
+
+  // Private
+
+  removeSavedItem(event, callback) {
+    const li = event.target.closest('[data-content-id]')
+    const id = li.dataset.contentId
+
+    li.remove()
+    callback(id)
+    this.dispatch('changed')
+  }
+
+  formItemFor(id) {
+    return this.element.querySelector(`[data-content-id="${id}"]:not(.saved-item)`)
+  }
+
+  replaceWithSpinner(formItem, id) {
+    const titleEl = formItem.querySelector('.selected-item-title').cloneNode(true)
+    const spinner = document.getElementById('save-for-later-spinner-template').content.firstElementChild.cloneNode(true)
+    spinner.id = `save-for-later-spinner-${id}`
+    spinner.dataset.contentId = id
+    spinner.prepend(titleEl)
+    formItem.insertAdjacentElement('afterend', spinner)
+    formItem.classList.add('d-none')
+  }
+
+  restoreFormItem(id) {
+    const formItem = this.formItemFor(id)
+    if (!formItem) return
+
+    formItem.classList.remove('d-none')
+    this.setItemInputsDisabled(id, false)
+    formItem.querySelectorAll('[data-required-for-submit]').forEach(input => {
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  removeFormItem(id) {
+    const formItem = this.formItemFor(id)
+    if (formItem) formItem.remove()
+  }
+
+  setItemInputsDisabled(id, disabled) {
+    const form = this.element.closest('form')
+
+    const checkbox = form.querySelector(`[data-item-selector-id-param="${id}"]`)
+    if (checkbox) checkbox.disabled = disabled
+
+    form.querySelectorAll(`[name^="patron_request[aeon_item][${id}]"]`).forEach(input => {
+      input.disabled = disabled
+    })
+  }
+
+  async submitSaveForLater(itemId) {
+    const form = this.element.closest('form')
+    const formData = new FormData(form)
+    formData.set('save_for_later_item_id', itemId)
+
+    const response = await fetch('/patron_requests/save_for_later', {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content,
+        'Accept': 'text/vnd.turbo-stream.html'
+      },
+      body: formData
+    })
+
+    if (response.ok) {
+      const html = await response.text()
+      Turbo.renderStreamMessage(html)
+    }
+  }
+
+  update() {
+    if (!this.hasItemsTarget) return
+
+    this.containerTarget.hidden = this.itemsTarget.children.length === 0
+    this.updateCount()
+  }
+
+  updateCount() {
+    const form = this.element.closest('form')
+    const countInput = form?.querySelector('[name="patron_request[saved_for_later_count]"]')
+    if (countInput) {
+      const total = form.querySelectorAll('[data-save-for-later-target="items"] .saved-item').length
+      countInput.value = total
+    }
+  }
+}

--- a/app/javascript/controllers/selected_item_form_controller.js
+++ b/app/javascript/controllers/selected_item_form_controller.js
@@ -34,7 +34,10 @@ export default class extends Controller {
     event.stopPropagation();
 
     const currentItem = event.target.closest('[data-content-id]');
-    const nextItem = currentItem.nextElementSibling;
+    let nextItem = currentItem.nextElementSibling;
+    while (nextItem && !nextItem.offsetParent) {
+      nextItem = nextItem.nextElementSibling;
+    }
 
     const currentCollapse = currentItem.querySelector('.accordion-collapse');
     const nextCollapse = nextItem?.querySelector('.accordion-collapse');

--- a/app/javascript/controllers/status_counter_controller.js
+++ b/app/javascript/controllers/status_counter_controller.js
@@ -8,9 +8,10 @@ export default class extends Controller {
   }
 
   update(event) {
-    const completeCount = this.element.querySelectorAll('[data-selected-item-form-status-value="complete"]').length;
-    const draftCount =this.element.querySelectorAll('[data-selected-item-form-status-value="incomplete"]').length;
+    const completeCount = [...this.element.querySelectorAll('[data-selected-item-form-status-value="complete"]')]
+      .filter(el => el.offsetParent).length;
+    const noun = completeCount === 1 ? 'item' : 'items';
 
-    this.counterTarget.innerHTML = `${completeCount} complete · ${draftCount} drafts`;
+    this.counterTarget.innerHTML = `${completeCount} ${noun} ready to submit`;
   }
 }

--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -10,17 +10,18 @@ class SubmitAeonPatronRequestJob < ApplicationJob
     return unless patron_request.aeon_page?
     return perform_ead_request(patron_request) if patron_request.ead_url.present?
 
-    patron_request.selected_items.each do |folio_item|
+    patron_request.selected_items.each.map do |folio_item|
       request = as_aeon_create_request_data(patron_request, folio_item, patron_request.aeon_item&.dig(folio_item.id) || {})
       response = submit_aeon_request(request)
 
       patron_request.aeon_api_responses.where(item_id: folio_item.id).delete_all
       patron_request.aeon_api_responses.create(item_id: folio_item.id, request_data: request.as_json, response_data: response.as_json)
+      response
     end
   end
 
   def perform_ead_request(patron_request)
-    patron_request.aeon_item.each_value do |volume_params|
+    patron_request.aeon_item.each_value.map do |volume_params|
       request = as_aeon_create_ead_request_data(patron_request, volume_params)
       response = submit_aeon_request(request)
 
@@ -28,6 +29,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
 
       patron_request.aeon_api_responses.where(item_id: item_id).delete_all
       patron_request.aeon_api_responses.create(item_id: item_id, request_data: request.as_json, response_data: response.as_json)
+      response
     end
   end
 

--- a/app/models/abilities/patron_ability.rb
+++ b/app/models/abilities/patron_ability.rb
@@ -22,6 +22,7 @@ class PatronAbility
     clear_aliased_actions
     alias_action :index, :show, to: :read
     alias_action :edit, to: :update
+    alias_action :save_for_later, to: :create
 
     can :new, PatronRequest do |request|
       can?(:request_pickup, request) || can?(:request_scan, request)

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -13,7 +13,8 @@ class PatronRequest < ApplicationRecord
   store :data, accessors: [
     :barcodes, :folio_responses, :illiad_response_data, :scan_page_range, :scan_authors, :scan_title,
     :proxy, :for_sponsor, :for_sponsor_id, :estimated_delivery, :patron_name, :item_title, :requested_barcodes, :item_mediation_data,
-    :aeon_reading_special, :aeon_item, :aeon_terms, :ead_url
+    :aeon_reading_special, :aeon_item, :aeon_terms, :ead_url,
+    :saved_for_later_count
   ], coder: JSON
 
   delegate :instance_id, :finding_aid, :finding_aid?, to: :folio_instance

--- a/app/views/patron_requests/_digitization_options.html.erb
+++ b/app/views/patron_requests/_digitization_options.html.erb
@@ -1,7 +1,8 @@
 <div class="row p-3 gap-3 flex-column flex-md-row">
   <%= render 'digitization_notice' %>
 
-  <div class="accordion digitization-accordion selected-items-container" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
+  <%= render 'save_for_later', request_type: 'scan' %>
+  <div class="accordion digitization-accordion selected-items-container px-0" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
     <% if f.object.selectable_items.one? %>
       <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", collapsed: false) %>
     <% end %>

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -12,6 +12,7 @@
   <% appointments = current_user.aeon.appointments_for(site: f.object.aeon_site) %>
 
   <div class="mt-3">
+    <%= render 'save_for_later', request_type: 'pickup' %>
     <ul class="appointments-container list-unstyled selected-items-container" data-item-selector-target="selectedItems" data-template="#appointmentTemplate">
       <% if f.object.selectable_items.one? %>
         <%= render Aeon::AppointmentFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", appointments: appointments) %>

--- a/app/views/patron_requests/_save_for_later.html.erb
+++ b/app/views/patron_requests/_save_for_later.html.erb
@@ -1,0 +1,15 @@
+<div class="save-for-later-container border rounded p-3 mb-3" data-save-for-later-target="container" hidden>
+  <h3 class="h4 text-cardinal"><i class="bi bi-pin-angle-fill me-2 text-digital-red"></i>Saved for later</h3>
+  <ul id="save-for-later-items-<%= request_type %>" class="list-unstyled" data-save-for-later-target="items"></ul>
+</div>
+
+<template id="save-for-later-spinner-template">
+  <li class="appointments-item rounded mb-2 p-2 d-flex row-gap-2 justify-content-between text-nowrap align-items-center">
+    <span class="d-flex gap-1 align-items-center text-digital-red">
+      <i class="bi bi-pin-angle-fill me-1"></i>Saving
+      <span class="spinner-grow spinner-grow-sm ms-1"></span>
+      <span class="spinner-grow spinner-grow-sm"></span>
+      <span class="spinner-grow spinner-grow-sm"></span>
+    </span>
+  </li>
+</template>

--- a/app/views/patron_requests/_saved_item.html.erb
+++ b/app/views/patron_requests/_saved_item.html.erb
@@ -1,0 +1,11 @@
+<li id="save-for-later-spinner-<%= @dom_id %>" class="d-flex justify-content-between saved-item border-bottom py-1" data-content-id="<%= @dom_id %>" data-save-for-later-target="savedItem">
+  <%= render Aeon::RequestItemIdentifierComponent.new(request:, classes: nil) %>
+  <div>
+    <%= link_to aeon_request_path(request),
+          data: { turbo_method: :delete, action: 'save-for-later#undo' },
+          class: 'su-underline me-1 fs-14' do %>Undo<% end %>
+    <%= link_to aeon_request_path(request),
+          data: { turbo_method: :delete, action: 'save-for-later#delete' },
+          class: 'btn btn-link p-0 ps-1' do %><i class="bi bi-trash"></i><% end %>
+  </div>
+</li>

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -29,6 +29,7 @@
 <% scan_or_pickup_step = nil %>
 <%= f.hidden_field :instance_hrid %>
 <%= f.hidden_field :origin_location_code %>
+<%= f.hidden_field :saved_for_later_count, value: 0 %>
 <% if f.object.selectable_items.one? || f.object.barcodes&.one? %>
   <% single_item = f.object.selectable_items.first %>
   <% single_barcode = f.object.barcodes&.first || (single_item&.barcode || single_item&.id) %>
@@ -92,30 +93,28 @@
 
 <!-- aeon reading room request -->
 <!-- removed any 'can do this' part for both -->
-<%= render AccordionStepComponent.new(request: f.object, id: 'reading', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update', 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
+<%= render AccordionStepComponent.new(request: f.object, id: 'reading', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter save-for-later', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update save-for-later:changed->status-counter#update save-for-later:changed->accordion-form#reenableNextButtons', 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
   <% c.with_title.with_content('Reading room') %>
   <% c.with_body do %>
     <%= render 'reading_options', f: %>
   <% end %>
   <% c.with_footer do %>
     <span class="px-2 py-1" data-status-counter-target="counter">
-      0 complete
-      0 drafts
+      0 items ready to submit
     </span>
   <% end %>
 <% end %>
 
 <!-- aeon digitization request -->
 
-<%= render AccordionStepComponent.new(request: f.object, id: 'digitization', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update', 'patronrequest-forRequestType': 'scan' }, submit: true) do |c| %>
+<%= render AccordionStepComponent.new(request: f.object, id: 'digitization', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter save-for-later', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update save-for-later:changed->status-counter#update save-for-later:changed->accordion-form#reenableNextButtons', 'patronrequest-forRequestType': 'scan' }, submit: true) do |c| %>
   <% c.with_title.with_content('Digitization') %>
   <% c.with_body do %>
     <%= render 'digitization_options', f: %>
   <% end %>
   <% c.with_footer do %>
     <span class="px-2 py-1" data-status-counter-target="counter">
-      0 complete
-      0 drafts
+      0 items ready to submit
     </span>
   <% end %>
 <% end %>

--- a/app/views/patron_requests/save_for_later.turbo_stream.erb
+++ b/app/views/patron_requests/save_for_later.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.remove "save-for-later-spinner-#{@dom_id}" %>
+<%= turbo_stream.append "save-for-later-items-#{@request_type}" do %>
+  <%= render 'saved_item', request: @aeon_request %>
+<% end %>

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -18,7 +18,11 @@
         <% end %>
         <% if @aeon_requests.first&.multi_item_selector? %>
           <%= render Aeon::ConfirmationRequestListComponent.new(requests: @aeon_requests.submitted_requests, digitization: @aeon_requests.digital? ) %>
-          <%= render Aeon::ConfirmationRequestListComponent.new(requests: @aeon_requests.draft_requests, digitization: @aeon_requests.digital?, drafts: true) %>
+          <% if @patron_request.saved_for_later_count.to_i > 0 %>
+            <div class="mt-3">
+              <p><%= @patron_request.saved_for_later_count %> <%= 'item'.pluralize(@patron_request.saved_for_later_count.to_i) %> saved for later</p>
+            </div>
+          <% end %>
         <% else %>
           <% request = @aeon_requests.first %>
           <% if request.appointment %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Rails.application.routes.draw do
   post 'change_pin', to: 'reset_pins#change'
 
   resources :patron_requests, only: [:new, :show, :create] do
+    collection do
+      post :save_for_later
+    end
     resource :needed_date, only: [:edit, :update, :show]
     resources :admin_comments
   end

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -39,9 +39,11 @@ RSpec.describe 'Requesting an item from an EAD', :js do
   let(:aeon_user) { Aeon::User.new(username: user.email_address, auth_type: 'Default') }
 
   let(:stub_aeon_client) do
-    instance_double(AeonClient, find_user: aeon_user, create_request: created_request, reading_rooms:, available_appointments:)
+    instance_double(AeonClient, find_user: aeon_user, create_request: created_request, update_request_route: draft_request,
+                                reading_rooms:, available_appointments:)
   end
-  let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, draft?: false, valid?: true) }
+  let(:created_request) { Aeon::Request.new(transaction_number: 123, call_number: 'SC0097', web_request_form: 'multiple', item_info1: '') }
+  let(:draft_request) { Aeon::Request.new(transaction_number: 123, call_number: 'SC0097', web_request_form: 'multiple', item_info1: '', transaction_status: 5) }
 
   let(:available_appointments) do
     [instance_double(Aeon::AvailableAppointment,
@@ -91,6 +93,54 @@ RSpec.describe 'Requesting an item from an EAD', :js do
                                                                         item_volume: 'Box 12',
                                                                         site: 'SPECUA'
                                                                       ))
+    end
+
+    it 'allows the user to save reading room items for later' do # rubocop:disable RSpec/ExampleLength
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Reading room appointment'
+      click_button 'Continue'
+
+      click_link 'Computers and Typesetting'
+      click_link 'Legal size documents'
+      check 'Box 12'
+      click_link 'Volume A, The TeXbook'
+      check 'Box 13'
+      click_button 'Continue'
+
+      # Submit disabled: no items have appointments
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Assign appointment to first item
+      within('[data-content-id]', text: 'Box 12', match: :first) do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+
+      # Submit disabled: second item has no appointment
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Save second item for later
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      expect(page).to have_css('.saved-item')
+
+      # Submit enabled: one with appointment, one saved
+      expect(page).to have_button('Submit request', disabled: false)
+
+      # Undo restores the item
+      click_link 'Undo'
+      expect(page).to have_no_css('.saved-item')
+
+      # Submit disabled: restored item has no appointment
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Save both items for later
+      first('[data-content-id]', text: 'Box 12').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      expect(page).to have_css('.saved-item', count: 2)
+
+      # Submit disabled: all items saved, nothing to submit
+      expect(page).to have_button('Submit request', disabled: true)
     end
 
     it 'allows the user to submit a request with details about the portion of the item to be digitized' do # rubocop:disable RSpec/ExampleLength

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
         click_button 'Select existing appointment'
         click_button 'Feb 19'
       end
+      expect(page).to have_css '.badge', text: '2 items'
 
       # Submit disabled: second item has no appointment
       expect(page).to have_button('Submit request', disabled: true)
@@ -134,8 +135,19 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       # Submit disabled: restored item has no appointment
       expect(page).to have_button('Submit request', disabled: true)
 
-      # Save both items for later
+      # Assign appointment to the second item
+      within('[data-content-id]', text: 'Box 13', match: :first) do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+      expect(page).to have_css '.badge', text: '3 items'
+      expect(page).to have_button('Submit request', disabled: false)
+
       first('[data-content-id]', text: 'Box 12').click_link('Save for later')
+
+      # Appointment item limit should show that the saved item relinquished the appointment
+      expect(page).to have_css '.badge', text: '2 items'
+
       first('[data-content-id]', text: 'Box 13').click_link('Save for later')
       expect(page).to have_css('.saved-item', count: 2)
 

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -181,6 +181,9 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       fill_in 'Requested pages', with: 'Pages 1-10'
       fill_in 'Additional information', with: 'Testing only'
 
+      click_button 'Next item'
+      fill_in 'Requested pages', with: 'Pages 6-8'
+
       click_button 'Submit request'
 
       expect(page).to have_css('.confirmation')
@@ -191,6 +194,13 @@ RSpec.describe 'Requesting an item from an EAD', :js do
                                                                         item_info5: 'Pages 1-10',
                                                                         item_volume: 'Box 12',
                                                                         special_request: 'Testing only',
+                                                                        call_number: 'SC0097 Computers and Typesetting',
+                                                                        site: 'SPECUA'
+                                                                      ))
+      expect(stub_aeon_client).to have_received(:create_request).with(an_object_having_attributes(
+                                                                        username: user.email_address,
+                                                                        item_info5: 'Pages 6-8',
+                                                                        item_volume: 'Box 14',
                                                                         call_number: 'SC0097 Computers and Typesetting',
                                                                         site: 'SPECUA'
                                                                       ))

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -16,9 +16,12 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   let(:reading_rooms) { JSON.load_file('spec/fixtures/reading_rooms.json').map { |room| Aeon::ReadingRoom.from_dynamic(room) } }
   let(:aeon_user) { Aeon::User.new(username: user.email_address, auth_type: 'Default') }
   let(:stub_aeon_client) do
-    instance_double(AeonClient, find_user: aeon_user, create_request: created_request, reading_rooms:, available_appointments:)
+    instance_double(AeonClient, find_user: aeon_user, create_request: created_request, update_request_route: draft_request,
+                                reading_rooms:, available_appointments:)
   end
-  let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, draft?: false, valid?: true) }
+  let(:created_request) { Aeon::Request.new(transaction_number: 123, call_number: 'ABC 123', web_request_form: 'multiple', item_info1: '') }
+  let(:draft_request) { Aeon::Request.new(transaction_number: 123, call_number: 'ABC 123', web_request_form: 'multiple', item_info1: '', transaction_status: 5) }
+
   let(:available_appointments) do
     [instance_double(Aeon::AvailableAppointment,
                      start_time: DateTime.new(2026, 2, 19),
@@ -158,5 +161,50 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
                                                                       ))
     end
     # rubocop:enable RSpec/ExampleLength
+
+    it 'allows the user to save items for later' do # rubocop:disable RSpec/ExampleLength
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+
+      check 'ABC 123'
+      check 'ABC 321'
+      click_button 'Continue'
+
+      # Submit disabled: no items complete
+      expect(page).to have_button('Submit request', disabled: true)
+
+      fill_in 'Requested pages', with: 'Pages 1-10'
+      choose 'Yes'
+      click_button 'Next item'
+
+      # Submit disabled: second item incomplete
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Save second item for later
+      find('[data-content-id]', text: 'ABC 321').click_link('Save for later')
+      expect(page).to have_css('.saved-item')
+
+      # Submit enabled: one complete, one saved
+      expect(page).to have_button('Submit request', disabled: false)
+
+      # Undo restores the form item
+      click_link 'Undo'
+      expect(page).to have_no_css('.saved-item')
+      within('.digitization-accordion') do
+        expect(page).to have_content('ABC 321')
+      end
+
+      # Submit disabled again: restored item is incomplete
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Save both items for later
+      find('[data-content-id]', text: 'ABC 123').click_link('Save for later')
+      find('[data-content-id]', text: 'ABC 321').click_link('Save for later')
+      expect(page).to have_css('.saved-item', count: 2)
+
+      # Submit disabled: all items saved, nothing to submit
+      expect(page).to have_button('Submit request', disabled: true)
+    end
   end
 end


### PR DESCRIPTION
Part of #3397

Saved for later items are saved immediately in Aeon, as requested.

<img width="705" height="659" alt="Screenshot 2026-04-06 at 5 36 36 PM" src="https://github.com/user-attachments/assets/6aee41e3-4161-40fd-a3c9-c7738d4f3b40" />

TODO:
- [x] Showing up in the edit request modal view that uses the selected item accordion 👎
- [x] Fix item count badge (turbo + timing issue?) 
- [ ] Be more intentional with "Save for later" -> "Edit request request" type flow
