### PR TITLE
Disable uses of single accordion buttons for item forms

### DIFF
--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,9 +1,15 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative">
-    <button class="accordion-button d-inline-flex w-auto align-items-center position-static" type="button" data-bs-toggle="collapse" data-bs-target="#content_<%= dom_id %>" aria-expanded="<%= collapsed? ? 'false' : 'true' %>" aria-controls="content_<%= dom_id %>">
+    <%= button_tag(
+        type: "button",
+        class: "accordion-button d-inline-flex w-auto align-items-center position-static",
+        data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
+        aria: { expanded: !collapsed?, controls: "content_#{dom_id}" },
+        disabled: !new_item?
+        ) do %>
       <i class="bi bi-check2 selected-item-status"></i>
       <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
-    </button>
+    <% end %>
     <button class="btn btn-link p-0 ps-1 z-3 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
       <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
     </button>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -4,8 +4,8 @@
         type: "button",
         class: "accordion-button d-inline-flex w-auto align-items-center position-static",
         data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
-        aria: { expanded: !collapsed?, controls: "content_#{dom_id}" },
-        disabled: !new_item?
+        aria: { expanded: !accordion?, controls: "content_#{dom_id}" },
+        disabled: !accordion?
         ) do %>
       <i class="bi bi-check2 selected-item-status"></i>
       <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
@@ -16,7 +16,7 @@
 
     <i class="bi bi-chevron-down accordion-header-icon ms-auto px-4"></i>
   </div>
-  <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' if collapsed? %>">
+  <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' if accordion? %>">
     <%= fields_for base_name, object do |f| %>
       <div class="accordion-body">
         <div class="mb-3">

--- a/app/components/aeon/digitization_form_item_component.rb
+++ b/app/components/aeon/digitization_form_item_component.rb
@@ -5,20 +5,16 @@ module Aeon
   class DigitizationFormItemComponent < ViewComponent::Base
     attr_reader :title, :dom_id, :object, :base_name
 
-    def initialize(title:, dom_id:, object: nil, base_name: nil, collapsed: true)
+    def initialize(title:, dom_id:, object: nil, base_name: nil, accordion: true)
       @title = title
       @dom_id = dom_id
       @object = object
       @base_name = base_name || "item[#{dom_id}]"
-      @collapsed = collapsed
+      @accordion = accordion
     end
 
-    def collapsed?
-      @collapsed
-    end
-
-    def new_item?
-      object.nil?
+    def accordion?
+      @accordion
     end
   end
 end

--- a/app/components/aeon/digitization_form_item_component.rb
+++ b/app/components/aeon/digitization_form_item_component.rb
@@ -16,5 +16,9 @@ module Aeon
     def collapsed?
       @collapsed
     end
+
+    def new_item?
+      object.nil?
+    end
   end
 end

--- a/app/views/aeon_requests/_form.html.erb
+++ b/app/views/aeon_requests/_form.html.erb
@@ -3,7 +3,7 @@
     <% if f.object.digital? %>
       <%= render 'patron_requests/digitization_notice' %>
       <div class="selected-items-container">
-        <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.volume, dom_id: 'edit_aeon_item_request', object: f.object, base_name: 'aeon_request', collapsed: false) %>
+        <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.volume, dom_id: 'edit_aeon_item_request', object: f.object, base_name: 'aeon_request', accordion: false) %>
       </div>
     <% else %>
       <div class="mt-2 p-2 modal-location">

--- a/app/views/patron_requests/_digitization_options.html.erb
+++ b/app/views/patron_requests/_digitization_options.html.erb
@@ -3,7 +3,7 @@
 
   <div class="accordion digitization-accordion selected-items-container" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
     <% if f.object.selectable_items.one? %>
-      <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", collapsed: false) %>
+      <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", accordion: false) %>
     <% end %>
   </div>
 


### PR DESCRIPTION
I needed to take a stab at #3313 in order to understand https://github.com/sul-dlss/sul-requests/pull/3407 and https://github.com/sul-dlss/sul-requests/pull/3412

I'm reasonably confident 54d3c25a1b0465f3add831663e7983813d1db399 is on the right track.

731e5169ee9c3a401ceea52e26ca7d75443a27f1 makes an assumption that only holds true if we do not intend to render sets of existing requests to edit. I use this pattern in 'Save for later' too.