### PR TITLE
Return the response in the Aeon patron request job

### DIFF
--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -10,17 +10,18 @@ class SubmitAeonPatronRequestJob < ApplicationJob
     return unless patron_request.aeon_page?
     return perform_ead_request(patron_request) if patron_request.ead_url.present?
 
-    patron_request.selected_items.each do |folio_item|
+    patron_request.selected_items.each.map do |folio_item|
       request = as_aeon_create_request_data(patron_request, folio_item, patron_request.aeon_item&.dig(folio_item.id) || {})
       response = submit_aeon_request(request)
 
       patron_request.aeon_api_responses.where(item_id: folio_item.id).delete_all
       patron_request.aeon_api_responses.create(item_id: folio_item.id, request_data: request.as_json, response_data: response.as_json)
+      response
     end
   end
 
   def perform_ead_request(patron_request)
-    patron_request.aeon_item.each_value do |volume_params|
+    patron_request.aeon_item.each_value.map do |volume_params|
       request = as_aeon_create_ead_request_data(patron_request, volume_params)
       response = submit_aeon_request(request)
 
@@ -28,6 +29,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
 
       patron_request.aeon_api_responses.where(item_id: item_id).delete_all
       patron_request.aeon_api_responses.create(item_id: item_id, request_data: request.as_json, response_data: response.as_json)
+      response
     end
   end
 


### PR DESCRIPTION
Save for later (https://github.com/sul-dlss/sul-requests/pull/3419) needs this response (using `perform_now`).

To me this could be a bit of a smell, I'm somewhat tempted to extract a service object and use that for the synchronous call. As written, this doesn't interfere with the other open PRs and I think we may still get the Faraday retry behavior. Curious how people feel about this in isolation from the larger PR.