### PR TITLE
Use the EAD document as the source of truth if available

### DIFF
--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -266,7 +266,7 @@ class PatronRequest < ApplicationRecord
   end
 
   def bib_record
-    folio_instance.presence || ead_doc
+    ead_doc || folio_instance.presence
   end
 
   # @return [String] the title of the item


### PR DESCRIPTION
... if there's both FOLIO + EAD parameters in the URL, things get a little funky.