### PR TITLE
Add support for bouncing EAD requests over to Aeon (for non-redesign environments)

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -12,6 +12,10 @@ class PatronRequestsController < ApplicationController
 
   bot_challenge only: [:new]
 
+  before_action :redirect_aeon_finding_aid_requests, only: [:new], if: lambda {
+    !Settings.features.requests_redesign && (params[:Value].present? || params[:value].present?)
+  }
+
   load_resource
   before_action :assign_new_attributes, only: [:new]
   before_action :aeon_email_present, only: [:new]
@@ -90,6 +94,14 @@ class PatronRequestsController < ApplicationController
     flash.now[:error] = t('sessions.login_by_sunetid.error_html') if sunetid_without_folio_account? && !@patron_request.aeon_page?
 
     render 'login'
+  end
+
+  def redirect_aeon_finding_aid_requests
+    ead_url = params[:Value].presence || params[:value].presence || params[:ead_url].presence
+
+    return if ead_url.blank?
+
+    redirect_to Settings.aeon_archives_url + "&Value=#{ead_url}", allow_other_host: true
   end
 
   def redirect_aeon_pages

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -377,6 +377,7 @@ scan_destinations:
 
 # Aeon external request endpoint (ERE)
 aeon_ere_url: https://stanford.aeon.atlas-sys.com/logon?Action=11&Type=200
+aeon_archives_url: https://stanford.aeon.atlas-sys.com/logon?Action=10&Form=31
 
 # Aeon API settings. `api_key` is also required.
 aeon:

--- a/spec/features/archives_patron_request_spec.rb
+++ b/spec/features/archives_patron_request_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Requesting an item from an EAD' do
+  context 'when the redesign feature flag is disabled' do
+    it 'redirects the user to Aeon' do
+      begin
+        visit new_archives_request_path(value: 'http://example.com/ead.xml')
+      rescue ActionController::RoutingError
+        # Capybara can't find the external Aeon route.
+      end
+
+      expect(page.current_url).to start_with(Settings.aeon_archives_url)
+      expect(page.current_url).to include('Value=http://example.com/ead.xml')
+    end
+  end
+end


### PR DESCRIPTION
This should allow us to point archives-prod at requests (matching the -stage configuration), and giving us a seam to do a soft-launch from that environment too.