### PR TITLE
Add "Save for later" behavior for requests

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -746,6 +746,26 @@ label.btn-close {
   }
 }
 
+@layer framework {
+  .saved-item:last-child {
+    border-bottom: none !important;
+  }
+}
+
+@keyframes save-for-later-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.save-for-later:not(:has(.saved-item)) {
+  display: none;
+}
+
+.save-for-later,
+.saved-item {
+  animation: save-for-later-fade-in 0.3s ease;
+}
+
 .custom-select {
   button {
     --bs-btn-bg: white;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -209,7 +209,7 @@ summary .disclosure-icon::before {
   box-shadow: none !important;
 }
 
-.accordion-button[disabled]  ~ .accordion-header-icon {
+.accordion-header:has(.accordion-button[disabled]) .accordion-header-icon {
   display: none;
 }
 

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -4,7 +4,7 @@
     <div class="d-flex flex-column">
       <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
       <div>
-        <a href="#" class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+        <button class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</button>
         <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
           <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
         </button>

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -1,14 +1,19 @@
-<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 p-2 d-flex row-gap-2 text-nowrap align-items-center" data-content-id="<%= dom_id %>">
+<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 p-2 d-flex row-gap-2 justify-content-between text-nowrap align-items-center" data-content-id="<%= dom_id %>">
   <div class="d-flex align-items-center">
     <i class="bi bi-check2 selected-item-status"></i>
-    <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
-    <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-      <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
-    </button>
+    <div class="d-flex flex-column">
+      <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
+      <div>
+        <a href="#" class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+        </button>
+      </div>
+    </div>
   </div>
   <%= fields_for base_name, object do |f| %>
     <div class="fs-6 mb-0 w-100 form-label fw-semibold redesign-required-label possibly-visually-hidden-appointments-label">Appointment</div>
-    <div class="dropdown custom-select" data-controller="appointment-select" data-action="change->appointment-select#updateSelected appointment-select:change@document->appointment-select#updateItemCounts">
+    <div class="dropdown custom-select" data-controller="appointment-select" data-action="change->appointment-select#updateSelected input->appointment-select#updateSelected appointment-select:change@document->appointment-select#updateItemCounts">
       <%= f.hidden_field :appointment_id, class: 'visually-hidden', data: { 'appointment-select-target': :input, 'required-for-submit': true } %>
       <%= button_tag 'Select existing appointment', class: 'py-1 btn border dropdown-toggle', type: 'button', data: { bs_toggle: 'dropdown', appointment_select_target: 'button' }, aria: { expanded: false }, disabled: selectable_appointments.blank? %>
       <menu class="dropdown-menu appt-dropdown">
@@ -17,7 +22,7 @@
       </menu>
     </div>
 
-    <span class="create-appointment-section">
+    <span class="create-appointment-section me-auto">
       <span class="fw-semibold mx-2">OR</span>
       <%= link_to new_appointment_path, class: 'btn btn-primary btn-sm', data: { action: 'modal#open', 'turbo-prefetch': false } do %>
         <i class="bi bi-calendar-plus me-1"></i>Create new appointment

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -4,7 +4,11 @@
     <div class="d-flex flex-column">
       <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %></span>
       <div>
-        <button class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</button>
+        <% if save_for_later? %>  
+        <button class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>">
+          <i class="bi bi-pin-angle-fill me-1"></i>Save for later
+        </button>
+        <% end %>
         <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
           <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
         </button>

--- a/app/components/aeon/appointment_form_item_component.rb
+++ b/app/components/aeon/appointment_form_item_component.rb
@@ -21,5 +21,9 @@ module Aeon
     def selectable_appointments
       appointments.select(&:editable?).sort_by(&:sort_key)
     end
+
+    def save_for_later?
+      object.nil?
+    end
   end
 end

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -12,7 +12,11 @@
         <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
       <% end %>
       <div class="d-flex position-relative z-3">
-        <button class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</button>
+        <% if save_for_later? %>
+        <button class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>">
+          <i class="bi bi-pin-angle-fill me-1"></i>Save for later
+        </button>
+        <% end %>
         <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
           <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
         </button>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,18 +1,23 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative">
-    <%= button_tag(
-        type: "button",
-        class: "accordion-button d-inline-flex w-auto align-items-center position-static",
-        data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
-        aria: { expanded: !accordion?, controls: "content_#{dom_id}" },
-        disabled: !accordion?
-        ) do %>
-      <i class="bi bi-check2 selected-item-status"></i>
-      <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
-    <% end %>
-    <button class="btn btn-link p-0 ps-1 z-3 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-      <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
-    </button>
+    <div class="d-flex align-items-center flex-grow-1 justify-content-between">
+      <%= button_tag(
+          type: "button",
+          class: "accordion-button d-inline-flex w-auto align-items-center position-static",
+          data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
+          aria: { expanded: !accordion?, controls: "content_#{dom_id}" },
+          disabled: !accordion?
+          ) do %>
+        <i class="bi bi-check2 selected-item-status"></i>
+        <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
+      <% end %>
+      <div class="d-flex position-relative z-3">
+        <a href="#" class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+        </button>
+      </div>
+    </div>
 
     <i class="bi bi-chevron-down accordion-header-icon ms-auto px-4"></i>
   </div>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -12,7 +12,7 @@
         <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
       <% end %>
       <div class="d-flex position-relative z-3">
-        <a href="#" class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</a>
+        <button class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>"><i class="bi bi-pin-angle-fill me-1"></i>Save for later</button>
         <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
           <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
         </button>

--- a/app/components/aeon/digitization_form_item_component.rb
+++ b/app/components/aeon/digitization_form_item_component.rb
@@ -16,5 +16,9 @@ module Aeon
     def accordion?
       @accordion
     end
+
+    def save_for_later?
+      object.nil?
+    end
   end
 end

--- a/app/javascript/controllers/accordion_form_controller.js
+++ b/app/javascript/controllers/accordion_form_controller.js
@@ -33,7 +33,14 @@ export default class extends Controller {
   emptyFields(accordion) {
     const formData = new FormData(accordion.closest('form'));
 
-    return Array.from(accordion.querySelectorAll('[required],input[name="patron_request[barcodes][]"]')).find(x => formData.getAll(x.name).every(x => !x))
+    const requiredEmpty = Array.from(accordion.querySelectorAll('[required],input[name="patron_request[barcodes][]"]')).find(x => formData.getAll(x.name).every(x => !x))
+    if (requiredEmpty) return requiredEmpty;
+
+    // Per-item soft requirements: gated here (not via `required`) so save-
+    // for-later can submit with empty fields to trigger Aeon draft routing.
+    return Array.from(accordion.querySelectorAll('[data-required-for-submit]'))
+      .filter(x => x.closest('[data-content-id]')?.offsetParent)
+      .find(x => formData.getAll(x.name).every(x => !x))
   }
 
   enableAnyNextButtons(event) {

--- a/app/javascript/controllers/appointment_select_controller.js
+++ b/app/javascript/controllers/appointment_select_controller.js
@@ -45,6 +45,10 @@ export default class extends Controller {
     const selectedOption = this.element.querySelector(`[data-value="${this.inputTarget.value}"]`);
     if (selectedOption) {
       this.buttonTarget.innerHTML = selectedOption.querySelector('.label-value').innerHTML;
+    } else {
+      this.element.querySelector('.selected')?.classList?.remove('selected');
+      this.buttonTarget.textContent = 'Select existing appointment';
+      this.dispatch('change', { detail: { value: '' } });
     }
   }
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -46,6 +46,9 @@ application.register("otp-input", OtpInput)
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 
+import SaveForLaterController from "./save_for_later_controller"
+application.register("save-for-later", SaveForLaterController)
+
 import SelectedItemFormController from "./selected_item_form_controller"
 application.register("selected-item-form", SelectedItemFormController)
 

--- a/app/javascript/controllers/save_for_later_controller.js
+++ b/app/javascript/controllers/save_for_later_controller.js
@@ -1,0 +1,81 @@
+import { Controller } from "@hotwired/stimulus"
+import { Collapse } from "bootstrap"
+
+export default class extends Controller {
+  static targets = ['list', 'savedItemTemplate', 'section']
+
+  save(event) {
+    event.preventDefault()
+
+    const formItem = event.target.closest('[data-content-id]')
+    if (!formItem) return
+
+    const id = formItem.dataset.contentId
+    const originSection = this.sectionTargets.find(section => section.contains(formItem))
+    if (originSection) this.clearRequiredInputs(originSection, id)
+
+    this.formItemsFor(id).forEach(item => {
+      item.classList.add('d-none')
+      item.setAttribute('data-saved-for-later', '')
+    })
+
+    this.listTargets.forEach(list => list.appendChild(this.makeSavedItem(formItem)))
+
+    // Auto-expand the next visible sibling if this section uses expand/collapse
+    let nextItem = formItem.nextElementSibling
+    while (nextItem && !nextItem.offsetParent) nextItem = nextItem.nextElementSibling
+    const nextCollapse = nextItem?.querySelector('.accordion-collapse')
+    if (nextCollapse) Collapse.getOrCreateInstance(nextCollapse).show()
+
+    this.dispatch('changed')
+  }
+
+  restore(event) {
+    event.preventDefault()
+
+    const savedClone = event.target.closest('[data-content-id]')
+    if (!savedClone) return
+
+    const id = savedClone.dataset.contentId
+
+    this.formItemsFor(id).forEach(item => {
+      item.classList.remove('d-none')
+      item.removeAttribute('data-saved-for-later')
+      // Re-run selected-item-form validation now that the item is visible again.
+      item.querySelectorAll('[data-required-for-submit]').forEach(input => {
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+    })
+
+    this.listTargets.forEach(list => {
+      list.querySelectorAll(`[data-content-id="${id}"]`).forEach(el => el.remove())
+    })
+
+    this.dispatch('changed')
+  }
+
+  clearRequiredInputs(section, id) {
+    section.querySelectorAll(`[data-content-id="${id}"] [data-required-for-submit]`).forEach(input => {
+      input.value = ''
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  formItemsFor(id) {
+    return Array.from(this.element.querySelectorAll(`[data-content-id="${id}"]:not([data-toggle-disabled])`))
+      .filter(el => !this.listTargets.some(list => list.contains(el)))
+  }
+
+  makeSavedItem(formItem) {
+    const id = formItem.dataset.contentId
+    const title = formItem.querySelector('.selected-item-title')
+    const clone = this.savedItemTemplateTarget.content.cloneNode(true)
+    const li = clone.querySelector('li')
+
+    li.dataset.contentId = id
+    li.querySelector('[data-role="title"]').innerHTML = title.innerHTML
+    li.querySelector('button').dataset.itemSelectorIdParam = id
+
+    return li
+  }
+}

--- a/app/javascript/controllers/selected_item_form_controller.js
+++ b/app/javascript/controllers/selected_item_form_controller.js
@@ -34,7 +34,10 @@ export default class extends Controller {
     event.stopPropagation();
 
     const currentItem = event.target.closest('[data-content-id]');
-    const nextItem = currentItem.nextElementSibling;
+    let nextItem = currentItem.nextElementSibling;
+    while (nextItem && !nextItem.offsetParent) {
+      nextItem = nextItem.nextElementSibling;
+    }
 
     const currentCollapse = currentItem.querySelector('.accordion-collapse');
     const nextCollapse = nextItem?.querySelector('.accordion-collapse');

--- a/app/javascript/controllers/status_counter_controller.js
+++ b/app/javascript/controllers/status_counter_controller.js
@@ -9,8 +9,13 @@ export default class extends Controller {
 
   update(event) {
     const completeCount = this.element.querySelectorAll('[data-selected-item-form-status-value="complete"]').length;
-    const draftCount =this.element.querySelectorAll('[data-selected-item-form-status-value="incomplete"]').length;
+    const savedCount = this.element.querySelectorAll('[data-saved-for-later]').length;
 
-    this.counterTarget.innerHTML = `${completeCount} complete · ${draftCount} drafts`;
+    let text = `${completeCount} ready to submit`;
+    if (savedCount > 0) {
+      text += ` · ${savedCount} saving for later`;
+    }
+
+    this.counterTarget.innerHTML = text;
   }
 }

--- a/app/views/patron_requests/_digitization_options.html.erb
+++ b/app/views/patron_requests/_digitization_options.html.erb
@@ -1,7 +1,8 @@
 <div class="row p-3 gap-3 flex-column flex-md-row">
   <%= render 'digitization_notice' %>
 
-  <div class="accordion digitization-accordion selected-items-container" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
+  <%= render 'save_for_later' %>
+  <div class="accordion digitization-accordion selected-items-container px-0" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
     <% if f.object.selectable_items.one? %>
       <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", accordion: false) %>
     <% end %>

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -15,6 +15,7 @@
   <%= render Aeon::ReadingRoomBriefComponent.new(reading_room: f.object.aeon_reading_room) %>
 
   <div class="mt-3">
+    <%= render 'save_for_later' %>
     <ul class="appointments-container list-unstyled selected-items-container" data-item-selector-target="selectedItems" data-template="#appointmentTemplate">
       <% if f.object.selectable_items.one? %>
         <%= render Aeon::AppointmentFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", appointments: appointments) %>

--- a/app/views/patron_requests/_save_for_later.html.erb
+++ b/app/views/patron_requests/_save_for_later.html.erb
@@ -1,0 +1,4 @@
+<div class="save-for-later border rounded p-3 mb-3">
+  <h3 class="h4 text-cardinal"><i class="bi bi-pin-angle-fill me-2 text-digital-red"></i>Save for later</h3>
+  <ul class="list-unstyled" data-save-for-later-target="list"></ul>
+</div>

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -18,7 +18,7 @@
 
 <%= form_for(@patron_request,
             data: {
-              controller: 'patron-request accordion-form item-selector',
+              controller: 'patron-request accordion-form item-selector save-for-later',
               action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->accordion-form#typeValueChanged',
               'patron-request-type-value': 'aeon',
             },
@@ -150,33 +150,43 @@
 
 <!-- aeon reading room request -->
 <!-- removed any 'can do this' part for both -->
-<%= render AccordionStepComponent.new(request: f.object, id: 'reading', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update', 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
+<%= render AccordionStepComponent.new(request: f.object, id: 'reading', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update save-for-later:changed@document->status-counter#update save-for-later:changed@document->accordion-form#reenableNextButtons', 'save-for-later-target': 'section', 'patronrequest-forRequestType': 'pickup' }, submit: true) do |c| %>
   <% c.with_title.with_content('Reading room') %>
   <% c.with_body do %>
     <%= render 'reading_options', f: %>
   <% end %>
   <% c.with_footer do %>
     <span class="px-2 py-1" data-status-counter-target="counter">
-      0 complete
-      0 drafts
+      0 items ready to submit
     </span>
   <% end %>
 <% end %>
 
 <!-- aeon digitization request -->
 
-<%= render AccordionStepComponent.new(request: f.object, id: 'digitization', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update', 'patronrequest-forRequestType': 'scan' }, submit: true) do |c| %>
+<%= render AccordionStepComponent.new(request: f.object, id: 'digitization', classes: ['d-none'], step_index: (scan_or_pickup_step ||= step_enum.next), form_id: f.id, data: { controller: 'status-counter', action: 'selected-item-form:status-changed->status-counter#update item-selector:changed@document->status-counter#update save-for-later:changed@document->status-counter#update save-for-later:changed@document->accordion-form#reenableNextButtons', 'save-for-later-target': 'section', 'patronrequest-forRequestType': 'scan' }, submit: true) do |c| %>
   <% c.with_title.with_content('Digitization') %>
   <% c.with_body do %>
     <%= render 'digitization_options', f: %>
   <% end %>
   <% c.with_footer do %>
     <span class="px-2 py-1" data-status-counter-target="counter">
-      0 complete
-      0 drafts
+      0 items ready to submit
     </span>
   <% end %>
 <% end %>
+
+<template data-save-for-later-target="savedItemTemplate">
+  <li class="d-flex justify-content-between saved-item border-bottom py-1">
+    <span data-role="title"></span>
+    <div>
+      <a href="#" class="su-underline me-1 fs-14" data-action="save-for-later#restore">Undo</a>
+      <button class="btn btn-link p-0 ps-1" data-action="item-selector#remove">
+        <i class="bi bi-trash"></i>
+      </button>
+    </div>
+  </li>
+</template>
 
 <% end %>
 </div>

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -180,7 +180,7 @@
   <li class="d-flex justify-content-between saved-item border-bottom py-1">
     <span data-role="title"></span>
     <div>
-      <a href="#" class="su-underline me-1 fs-14" data-action="save-for-later#restore">Undo</a>
+      <button class="su-underline btn btn-link fs-14" data-action="save-for-later#restore">Undo</button>
       <button class="btn btn-link p-0 ps-1" data-action="item-selector#remove">
         <i class="bi bi-trash"></i>
       </button>

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -159,14 +159,14 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(page).to have_button('Submit request', disabled: true)
 
       # Save second item for later
-      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 13').click_button('Save for later')
       expect(page).to have_css('.saved-item')
 
       # Submit enabled: one with appointment, one saved
       expect(page).to have_button('Submit request', disabled: false)
 
       # Undo restores the item
-      click_link 'Undo'
+      click_button 'Undo'
       expect(page).to have_no_css('.saved-item')
 
       # Save-for-later must not unhide the EAD series tree's `data-toggle-disabled` wrappers.
@@ -183,12 +183,12 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(page).to have_css '.badge', text: '3 items'
       expect(page).to have_button('Submit request', disabled: false)
 
-      first('[data-content-id]', text: 'Box 12').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 12').click_button('Save for later')
 
       # Appointment item limit should show that the saved item relinquished the appointment
       expect(page).to have_css '.badge', text: '2 items'
 
-      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 13').click_button('Save for later')
       expect(page).to have_css('.saved-item', count: 2)
 
       expect(page).to have_button('Submit request', disabled: false)
@@ -213,7 +213,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       end
 
       # Save Box 13 for later in the reading-room flow
-      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 13').click_button('Save for later')
       expect(page).to have_css('.saved-item', text: 'Box 13')
 
       # Switch request type to digitization
@@ -256,7 +256,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'Box 13'
       click_button 'Continue'
 
-      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 13').click_button('Save for later')
       expect(page).to have_css('.saved-item', text: 'Box 13')
 
       # The Edit button on request-type must still be clickable. A regression test
@@ -285,7 +285,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
         click_button 'Select existing appointment'
         click_button 'Feb 19'
       end
-      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      first('[data-content-id]', text: 'Box 13').click_button('Save for later')
 
       expect(page).to have_button('Submit request', disabled: false)
 

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -132,6 +132,174 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(page).to have_no_css '[data-ead-search-target="countPill"]'
     end
 
+    it 'allows the user to save reading room items for later' do # rubocop:disable RSpec/ExampleLength
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Reading room appointment'
+      click_button 'Continue'
+
+      click_link 'Computers and Typesetting'
+      click_link 'Legal size documents'
+      check 'Box 12'
+      click_link 'Volume A, The TeXbook'
+      check 'Box 13'
+      click_button 'Continue'
+
+      # Submit disabled: no items have appointments
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Assign appointment to first item
+      within('[data-content-id]', text: 'Box 12') do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+      expect(page).to have_css '.badge', text: '2 items'
+
+      # Submit disabled: second item has no appointment
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Save second item for later
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      expect(page).to have_css('.saved-item')
+
+      # Submit enabled: one with appointment, one saved
+      expect(page).to have_button('Submit request', disabled: false)
+
+      # Undo restores the item
+      click_link 'Undo'
+      expect(page).to have_no_css('.saved-item')
+
+      # Save-for-later must not unhide the EAD series tree's `data-toggle-disabled` wrappers.
+      expect(page).to have_no_css('.series-contents-container [data-content-id][data-toggle-disabled]:not(.d-none)', visible: :all)
+
+      # Submit disabled: restored item has no appointment
+      expect(page).to have_button('Submit request', disabled: true)
+
+      # Assign appointment to the second item
+      within('[data-content-id]', text: 'Box 13') do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+      expect(page).to have_css '.badge', text: '3 items'
+      expect(page).to have_button('Submit request', disabled: false)
+
+      first('[data-content-id]', text: 'Box 12').click_link('Save for later')
+
+      # Appointment item limit should show that the saved item relinquished the appointment
+      expect(page).to have_css '.badge', text: '2 items'
+
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      expect(page).to have_css('.saved-item', count: 2)
+
+      expect(page).to have_button('Submit request', disabled: false)
+    end
+
+    it 'preserves saved-for-later items across a request-type round trip' do # rubocop:disable RSpec/ExampleLength
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Reading room appointment'
+      click_button 'Continue'
+
+      click_link 'Computers and Typesetting'
+      click_link 'Legal size documents'
+      check 'Box 12'
+      click_link 'Volume A, The TeXbook'
+      check 'Box 13'
+      click_button 'Continue'
+
+      within('[data-content-id]', text: 'Box 12') do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+
+      # Save Box 13 for later in the reading-room flow
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      expect(page).to have_css('.saved-item', text: 'Box 13')
+
+      # Switch request type to digitization
+      within('#request-type-accordion') { click_button 'Edit' }
+      expect(page).to have_css('#request-type.accordion-collapse.show')
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+      expect(page).to have_css('#items-accordion .accordion-collapse.show')
+      click_button 'Continue'
+
+      # Saved item is mirrored into the digitization save-for-later list
+      expect(page).to have_css('.digitization-accordion')
+      expect(page).to have_css('.saved-item', text: 'Box 13')
+
+      # Switch back to reading room; saved item is still there
+      within('#request-type-accordion') { click_button 'Edit' }
+      expect(page).to have_css('#request-type.accordion-collapse.show')
+      choose 'Reading room appointment'
+      click_button 'Continue'
+      expect(page).to have_css('#items-accordion .accordion-collapse.show')
+      click_button 'Continue'
+      expect(page).to have_css('.saved-item', text: 'Box 13')
+
+      # Submit is enabled because Box 12 has an appointment and Box 13 is saved
+      expect(page).to have_button('Submit request', disabled: false)
+    end
+
+    it 'shows the request-type Edit button when save-for-later is triggered from the digitization flow' do
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+
+      click_link 'Computers and Typesetting'
+      click_link 'Legal size documents'
+      check 'Box 12'
+      click_link 'Volume A, The TeXbook'
+      check 'Box 13'
+      click_button 'Continue'
+
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+      expect(page).to have_css('.saved-item', text: 'Box 13')
+
+      # The Edit button on request-type must still be clickable. A regression test
+      # for a `stretched-link` class that was being cloned from the form item's
+      # title span into the saved-item clone, where its ::after overlay ended up
+      # covering the entire page because the saved clone had no positioned
+      # ancestor to constrain it.
+      within('#request-type-accordion') { click_button 'Edit' }
+      expect(page).to have_css('#request-type.accordion-collapse.show')
+    end
+
+    it 'keeps Submit enabled after editing request type with items saved for later' do # rubocop:disable RSpec/ExampleLength
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Reading room appointment'
+      click_button 'Continue'
+
+      click_link 'Computers and Typesetting'
+      click_link 'Legal size documents'
+      check 'Box 12'
+      click_link 'Volume A, The TeXbook'
+      check 'Box 13'
+      click_button 'Continue'
+
+      within('[data-content-id]', text: 'Box 12') do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+      first('[data-content-id]', text: 'Box 13').click_link('Save for later')
+
+      expect(page).to have_button('Submit request', disabled: false)
+
+      # Click Edit on request type, then Continue without changing anything
+      within('#request-type-accordion') { click_button 'Edit' }
+      expect(page).to have_css('#request-type.accordion-collapse.show')
+      click_button 'Continue'
+      expect(page).to have_css('#items-accordion .accordion-collapse.show')
+      click_button 'Continue'
+      expect(page).to have_css('#reading.accordion-collapse.show')
+
+      expect(page).to have_button('Submit request', disabled: false)
+    end
+
     it 'allows the user to submit a request with details about the portion of the item to be digitized' do # rubocop:disable RSpec/ExampleLength
       visit new_archives_request_path(value: 'http://example.com/ead.xml')
 
@@ -170,6 +338,9 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       fill_in 'Requested pages', with: 'Pages 1-10'
       fill_in 'Additional information', with: 'Testing only'
 
+      click_button 'Next item'
+      fill_in 'Requested pages', with: 'Pages 6-8'
+
       click_button 'Submit request'
 
       expect(page).to have_css('.confirmation')
@@ -180,6 +351,13 @@ RSpec.describe 'Requesting an item from an EAD', :js do
                                                                         item_info5: 'Pages 1-10',
                                                                         item_volume: 'Box 12',
                                                                         special_request: 'Testing only',
+                                                                        call_number: 'SC0097 Computers and Typesetting',
+                                                                        site: 'SPECUA'
+                                                                      ))
+      expect(stub_aeon_client).to have_received(:create_request).with(an_object_having_attributes(
+                                                                        username: user.email_address,
+                                                                        item_info5: 'Pages 6-8',
+                                                                        item_volume: 'Box 14',
                                                                         call_number: 'SC0097 Computers and Typesetting',
                                                                         site: 'SPECUA'
                                                                       ))

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
       # Submit still disabled: second item is incomplete
       expect(page).to have_button('Submit request', disabled: true)
 
-      find('[data-content-id]', text: 'ABC 321').click_link('Save for later')
+      find('[data-content-id]', text: 'ABC 321').click_button('Save for later')
       expect(page).to have_css('.saved-item', text: 'ABC 321')
 
       # Submit enabled: first item complete, second saved for later
@@ -184,7 +184,7 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
 
       within('[data-save-for-later-target="list"]') do
         expect(page).to have_content 'ABC 321'
-        click_link 'Undo'
+        click_button 'Undo'
       end
 
       # Submit disabled again: restored item is incomplete

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   let(:reading_rooms) { JSON.load_file('spec/fixtures/reading_rooms.json').map { |room| Aeon::ReadingRoom.from_dynamic(room) } }
   let(:aeon_user) { Aeon::User.new(username: user.email_address, auth_type: 'Default') }
   let(:stub_aeon_client) do
-    instance_double(AeonClient, find_user: aeon_user, create_request: created_request, reading_rooms:, available_appointments:)
+    instance_double(AeonClient, find_user: aeon_user, create_request: created_request, update_request_route: nil,
+                                reading_rooms:, available_appointments:)
   end
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, draft?: false, valid?: true) }
   let(:available_appointments) do
@@ -109,8 +110,7 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   context 'with multiple holdings' do
     let(:folio_instance) { :special_collections_holdings }
 
-    # rubocop:disable RSpec/ExampleLength
-    it 'allows the user to submit a digitization request' do
+    it 'allows the user to submit a digitization request' do # rubocop:disable RSpec/ExampleLength
       choose 'Digitization'
       check 'I agree to these terms'
       click_button 'Continue'
@@ -156,6 +156,45 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
                                                                         call_number: 'ABC 321'
                                                                       ))
     end
-    # rubocop:enable RSpec/ExampleLength
+
+    it 'allows the user to save items for later' do # rubocop:disable RSpec/ExampleLength
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+
+      check 'ABC 123'
+      check 'ABC 321'
+      click_button 'Continue'
+
+      # Submit disabled: no items are complete yet
+      expect(page).to have_button('Submit request', disabled: true)
+
+      fill_in 'Requested pages', with: 'Pages 1-10'
+      choose 'Yes'
+      click_button 'Next item'
+
+      # Submit still disabled: second item is incomplete
+      expect(page).to have_button('Submit request', disabled: true)
+
+      find('[data-content-id]', text: 'ABC 321').click_link('Save for later')
+      expect(page).to have_css('.saved-item', text: 'ABC 321')
+
+      # Submit enabled: first item complete, second saved for later
+      expect(page).to have_button('Submit request', disabled: false)
+
+      within('[data-save-for-later-target="list"]') do
+        expect(page).to have_content 'ABC 321'
+        click_link 'Undo'
+      end
+
+      # Submit disabled again: restored item is incomplete
+      expect(page).to have_button('Submit request', disabled: true)
+
+      expect(page).to have_no_css '.saved-item'
+
+      within('.digitization-accordion') do
+        expect(page).to have_content 'ABC 321'
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/sul-dlss/sul-requests/issues/3397

This is the all-client side version. It maintains our notion of "requests missing required data are created as Aeon draft requests".

I ran into a lot of nooks and crannies, so there are a lot of feature tests. Maybe too many.

<img width="712" height="421" alt="Screenshot 2026-04-10 at 4 48 23 PM" src="https://github.com/user-attachments/assets/4a2c7bf3-6e1e-4dbd-9440-4db1224a426a" />
