### PR TITLE
fix appt dropdown background

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -713,6 +713,10 @@ label.btn-close {
 }
 
 .custom-select {
+  button {
+    --bs-btn-bg: white;
+  }
+
   .selected {
     background-color: var(--bs-primary-bg-subtle);
     &::before {


### PR DESCRIPTION
Before:
<img width="341" height="371" alt="Screenshot 2026-04-15 at 12 08 35 PM" src="https://github.com/user-attachments/assets/f8e49ad9-f6ac-49d6-badb-ddc6c2262fee" />

After:
<img width="364" height="290" alt="Screenshot 2026-04-15 at 12 06 17 PM" src="https://github.com/user-attachments/assets/69d47baf-f9e8-4c45-ae31-96e9b66ec938" />
