### PR TITLE
wrap earliest appointment inline with label

### DIFF
--- a/app/views/patron_requests/_reading_or_digitization.html.erb
+++ b/app/views/patron_requests/_reading_or_digitization.html.erb
@@ -1,15 +1,16 @@
 
 <fieldset class="ps-2">
-  <div>
+  <div class="d-flex">
     <%= f.radio_button :request_type, 'pickup', class: 'form-check-input', required: true, data: { action: 'patron-request#updateType', terms: false } %>
-    <%= f.label :request_type_pickup, class: 'form-check-label ms-1' do %>
-      Reading room appointment
-    <% end %>
-    <span class="text-cardinal ms-2 mt-1">
-      Earliest appointment available:
-      <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_appointments_path(f.object.aeon_reading_room&.id, Date.today) %>
-    </span>
-
+    <div class="ms-1 d-flex flex-wrap column-gap-2">
+      <%= f.label :request_type_pickup, class: 'form-check-label' do %>
+        Reading room appointment
+      <% end %>
+      <span class="text-cardinal">
+        Earliest appointment available:
+        <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_appointments_path(f.object.aeon_reading_room&.id, Date.today) %>
+      </span>
+    </div>
   </div>
   <div class="mt-2">
     <%= f.radio_button :request_type, 'scan', class: 'form-check-input', data: { action: 'patron-request#updateType', terms: true } %>


### PR DESCRIPTION
closes #3485 
This removes the wrapping of the text to a new line. In my opinion this looks better but I can update this to do what we were previously doing, it is going to be kind of a pain and I think look worse but I can do it.
<img width="786" height="259" alt="Screenshot 2026-04-17 at 3 31 29 PM" src="https://github.com/user-attachments/assets/a2169cdc-d8cc-4dc7-aa79-76d470579eb7" />
<img width="649" height="281" alt="Screenshot 2026-04-17 at 3 31 24 PM" src="https://github.com/user-attachments/assets/f624f15f-30de-441c-88e8-5628926cd6da" />
