### PR TITLE
Update the layout + top-level design for the RequestGroup

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,7 @@ layer(components);
 :root {
   --stanford-jungle-green-rgb: 39, 153, 137;
   --stanford-process-black-50-rgb: 151, 150, 148;
+  --stanford-lagunita-dark-rgb: 0, 107, 129;
 
   --bs-danger: #dc3545;
   --bs-danger-rgb: 220, 53, 69;
@@ -52,6 +53,10 @@ layer(components);
 
 .text-jungle-green {
   color: rgba(var(--stanford-jungle-green-rgb), 1);
+}
+
+.bg-lagunita-dark {
+  background-color: rgba(var(--stanford-lagunita-dark-rgb), 1);
 }
 
 .bg-cardinal {
@@ -460,21 +465,6 @@ label.btn-close {
 
   .rounded-pill {
     padding: 4px 12px;
-  }
-
-  .cancelled, .draft {
-    color: var(--stanford-black);
-    background-color: var(--stanford-10-black);
-  }
-
-  .pending {
-    color: rgba(var(--stanford-plum-dark-rgb), 1);
-    background-color: rgba(var(--stanford-plum-rgb), 0.1);
-  }
-
-  .ready {
-    color: rgba(var(--stanford-digital-green-dark-rgb), 1);
-    background-color: rgba(var(--stanford-digital-green-rgb), 0.1);
   }
 
   .appointment-details > * + *::before {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -826,7 +826,6 @@ label.btn-close {
 
 .request-group {
   margin-bottom: 1rem;
-  padding: 1rem;
 }
 
 .modal-body.add-items {

--- a/app/components/aeon/appointment_component.html.erb
+++ b/app/components/aeon/appointment_component.html.erb
@@ -1,22 +1,24 @@
-<div class="card bg-body-tertiary border-light-subtle shadow-sm mb-4">
-  <div class="card-header d-flex justify-content-between align-items-center bg-body-tertiary">
+<%= render CardComponent.new do |c| %>
+  <% c.with_title do %>
     <h2 class="card-title mb-0 h4 d-flex gap-3">
       <span><i class="bi bi-calendar me-2"></i><%= appointment_date %></span>
       <span><i class="bi bi-clock me-2"></i><%= appointment_time_range %></span>
       <span><i class="bi bi-geo-alt-fill me-2"></i><%= appointment.reading_room.name %></span>
     </h2>
-    <div class="d-flex gap-2">
-      <%= link_to edit_aeon_appointment_path(appointment.id), class: 'text-decoration-none', data: { action: 'modal#open' } do %>
-        <i class="bi bi-pencil-fill"></i><span class="visually-hidden">Edit appointment</span>
-      <% end %>
-      <% if helpers.can? :destroy, appointment %>
-        <button class="btn btn-link su-underline p-0" data-bs-toggle="modal" data-bs-target="#delete-appointment-<%= @appointment.id %>">
-          <i class="bi bi-trash align-middle"></i><span class="visually-hidden">Delete appointment</span>
-        </button>
-      <% end %>
-    </div>
-  </div>
-  <div class="card-body">
+  <% end %>
+
+  <% c.with_actions do %>
+    <%= link_to edit_aeon_appointment_path(appointment.id), class: 'text-decoration-none', data: { action: 'modal#open' } do %>
+      <i class="bi bi-pencil-fill"></i><span class="visually-hidden">Edit appointment</span>
+    <% end %>
+    <% if helpers.can? :destroy, appointment %>
+      <button class="btn btn-link su-underline p-0" data-bs-toggle="modal" data-bs-target="#delete-appointment-<%= @appointment.id %>">
+        <i class="bi bi-trash align-middle"></i><span class="visually-hidden">Delete appointment</span>
+      </button>
+    <% end %>
+  <% end %>
+
+  <% c.with_body do %>
     <% if appointment.requests.present? %>
         <% request_groups = Aeon::RequestGrouping.from_requests(appointment.requests) %>
         <%= render Aeon::RequestGroupPerAppointmentComponent.with_collection(request_groups) %>
@@ -28,11 +30,15 @@
         </div>
       </div>
     <% end %>
-  </div>
-  <div class="card-footer bg-body-tertiary d-flex justify-content-between align-items-center">
+  <% end %>
+
+  <% c.with_footer do %>
     <%= render Aeon::AppointmentLimitComponent.from_appointment(appointment) %>
     <%= link_to "Add items", add_items_path, class: 'btn btn-outline-primary btn-sm', data: { action: 'modal#open' } unless add_item_disabled? %>
-  </div>
-  <!-- Delete modal -->
-  <%= render Aeon::CancelAppointmentModalComponent.new(appointment: appointment, id: "delete-appointment-#{@appointment.id}") %>
-</div>
+  <% end %>
+
+  <% c.with_post do %>
+    <!-- Delete modal -->
+    <%= render Aeon::CancelAppointmentModalComponent.new(appointment: appointment, id: "delete-appointment-#{@appointment.id}") %>
+  <% end %>
+<% end %>

--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,17 +1,24 @@
 <%= render CardComponent.new classes: 'request-group', data: { controller: 'empty-remove' } do |c| %>
   <% c.with_title do %>
     <div>
-      <div class="d-flex flex-wrap gap-1 align-items-center mb-2">
-        <%= render Aeon::RequestStatusPillComponent.new(request: status_request) %>
-        <%= render Aeon::RequestStatusMessageComponent.new(request: status_request) %>
-        <% if appointment_reading_room.present? %>
-        <span class="appointment-details ms-1">
-          <span class="ms-2 fw-semibold text-nowrap text-green"><%= appointment_reading_room.name %></span>
+      <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">
+        <span>
+          <%= render Aeon::RequestStatusPillComponent.new(request: status_request) %>
+          <% if appointment_reading_room.present? %>
+          <span class="appointment-details ms-1">
+            <span class="ms-2 fw-semibold text-nowrap text-green"><%= appointment_reading_room.name %></span>
+          </span>
+          <% end %>
         </span>
-        <% end %>
+
+        <span>
+          <%= render Aeon::RequestStatusMessageComponent.new(request: status_request) %>
+        </span>
       </div>
 
-      <%= render RecordHeaderComponent.new(record: requests.first, brief: true) %>
+      <div>
+        <%= render RecordHeaderComponent.new(record: requests.first, brief: true) %>
+      </div>
     </div>
   <% end %>
 

--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,21 +1,23 @@
-<div class="request-group card mb-4" data-controller="empty-remove">
-  <div class="card-header fw-semibold p-3 ps-2 d-flex gap-1 flex-row align-items-md-center justify-content-between">
-    <div class="d-flex flex-wrap gap-1 align-items-center">
-      <%= render Aeon::RequestStatusPillComponent.new(request: status_request) %>
-      <%= render Aeon::RequestStatusMessageComponent.new(request: status_request) %>
-      <% if appointment_reading_room.present? %>
-      <span class="appointment-details ms-1">
-        <span class="ms-2 fw-semibold text-nowrap text-green"><%= appointment_reading_room.name %></span>
-      </span>
-      <% end %>
-    </div>
-  </div>
-  <div class="card-body">
-    <div class="metadata">
+<%= render CardComponent.new classes: 'request-group', data: { controller: 'empty-remove' } do |c| %>
+  <% c.with_title do %>
+    <div>
+      <div class="d-flex flex-wrap gap-1 align-items-center mb-2">
+        <%= render Aeon::RequestStatusPillComponent.new(request: status_request) %>
+        <%= render Aeon::RequestStatusMessageComponent.new(request: status_request) %>
+        <% if appointment_reading_room.present? %>
+        <span class="appointment-details ms-1">
+          <span class="ms-2 fw-semibold text-nowrap text-green"><%= appointment_reading_room.name %></span>
+        </span>
+        <% end %>
+      </div>
+
       <%= render RecordHeaderComponent.new(record: requests.first, brief: true) %>
-      <ul class="list-group list-group-flush">
-        <%= render Aeon::RequestGroupItemComponent.with_collection(requests) %>
-      </ul>
     </div>
-  </div>
-</div>
+  <% end %>
+
+  <% c.with_body do %>
+    <ul class="list-group list-group-flush gap-3">
+      <%= render Aeon::RequestGroupItemComponent.with_collection(requests) %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/components/aeon/request_group_item_component.html.erb
+++ b/app/components/aeon/request_group_item_component.html.erb
@@ -1,4 +1,4 @@
-<li id="<%= dom_id(request) %>" class="request list-group-item px-0 <%= "request-status-#{request.status}" %>" data-empty-remove-target="item">
+<li id="<%= dom_id(request) %>" class="request list-group-item <%= "request-status-#{request.status}" %>" data-empty-remove-target="item">
   <div class="d-flex flex-row align-items-center justify-content-between">
     <div class="d-flex gap-3">
       <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>

--- a/app/components/aeon/request_item_detail_component.html.erb
+++ b/app/components/aeon/request_item_detail_component.html.erb
@@ -1,5 +1,5 @@
 <% if @variant == :text %>
 (<%= format_info %>)
 <% else %>
-<span class="p-1 fw-semibold"><%= format_info %></span>
+<span class="fw-semibold"><%= format_info %></span>
 <% end %>

--- a/app/components/aeon/request_item_identifier_component.html.erb
+++ b/app/components/aeon/request_item_identifier_component.html.erb
@@ -1,4 +1,4 @@
-<span class="p-1 fw-semibold">
+<span class="fw-semibold">
   <%= call_number %>
   <% if separator? %><i class="bi bi-chevron-right"></i><% end %>
   <%= container %>

--- a/app/components/aeon/request_status_message_component.html.erb
+++ b/app/components/aeon/request_status_message_component.html.erb
@@ -1,6 +1,6 @@
 <% case status_level %>
 <% when :warning %>
-<i class="bi bi-exclamation-triangle-fill align-middle ms-2 text-digital-red"></i><span class="text-digital-red fw-normal"><%= status_message %></span>
+<i class="bi bi-exclamation-triangle-fill align-middle mx-2 text-digital-red"></i><span class="text-digital-red fw-normal"><%= status_message %></span>
 <% when :pending %>
 <span class="ms-2 text-plum-dark fw-normal"><%= status_message %></span>
 <% else %>

--- a/app/components/aeon/request_status_pill_component.html.erb
+++ b/app/components/aeon/request_status_pill_component.html.erb
@@ -1,3 +1,3 @@
-<span class="rounded-pill <%= status_class %>">
+<span class="rounded-pill text-white bg-lagunita-dark <%= status_class %>">
   <% if status_icon %><i class="bi bi-<%= status_icon %> align-middle me-1"></i><% end %><%= status_text %>
 </span>

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,0 +1,23 @@
+<%= tag.div class: %w[card bg-body-tertiary border-light-subtle shadow-sm mb-4] + classes, **tag_options do %>
+  <%= pre %>
+  <div class="card-header d-flex justify-content-between align-items-center bg-body-tertiary">
+    <%= title %>
+    <% if actions? %>
+      <div class="d-flex gap-2">
+        <%= actions %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="card-body">
+    <%= body %>
+  </div>
+
+  <% if footer? %>
+    <div class="card-footer bg-body-tertiary d-flex justify-content-between align-items-center">
+      <%= footer %>
+    </div>
+  <% end %>
+
+  <%= post %>
+<% end %>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Render card
+class CardComponent < ViewComponent::Base
+  renders_one :pre
+  renders_one :title
+  renders_one :actions
+  renders_one :body
+  renders_one :footer
+  renders_one :post
+
+  attr_reader :classes, :tag_options
+
+  def initialize(classes: [], **tag_options)
+    @classes = Array(classes)
+    @tag_options = tag_options
+  end
+end

--- a/app/components/record_header_component.html.erb
+++ b/app/components/record_header_component.html.erb
@@ -1,4 +1,4 @@
-<h2 class="fs-4"><%= record.title || 'Not available' %></h2>
+<h2 class="fs-5"><%= record.title || 'Not available' %></h2>
 <div class="d-flex gap-md-3 flex-md-row flex-column">
   <span>
     <%= render Icons::DocumentBox1Component.new classes: 'me-1 align-text-bottom' %>

--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -23,7 +23,8 @@ class AeonRequestsController < ApplicationController
   def cancelled
     authorize! :read, Aeon::Request
 
-    @aeon_requests = sort_aeon_requests(filter_aeon_requests(current_user&.aeon&.cancelled_requests || []))
+    requests = sort_aeon_requests(filter_aeon_requests(current_user&.aeon&.cancelled_requests || []))
+    @aeon_request_groups = Aeon::RequestGrouping.from_requests(requests)
   end
 
   def submitted

--- a/app/views/aeon_requests/_list_requests.html.erb
+++ b/app/views/aeon_requests/_list_requests.html.erb
@@ -7,9 +7,5 @@
 </div>
 
 <% @aeon_request_groups.each do |requests_in_group| %>
-  <% if requests_in_group.one? && !requests_in_group.first.multi_item_selector? %>
-    <%= render Aeon::RequestComponent.new(request: requests_in_group.first) %>
-  <% else %>
-    <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
-  <% end %>
+  <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
 <% end %>

--- a/app/views/aeon_requests/cancelled.html.erb
+++ b/app/views/aeon_requests/cancelled.html.erb
@@ -1,10 +1,1 @@
-<div class="container">
-  <div class="d-flex flex-wrap gap-2 justify-content-between mb-3">
-    <h1>Cancelled requests</h1>
-    <div class="d-flex flex-wrap gap-2">
-      <%= render 'sort_dropdown' %>
-      <%= render 'filter_dropdown' %>
-    </div>
-  </div>
-  <%= render Aeon::RequestComponent.with_collection(@aeon_requests) %>
-</div>
+<%= render 'list_requests', header: 'Cancelled Requests' %>

--- a/app/views/aeon_requests/drafts.html.erb
+++ b/app/views/aeon_requests/drafts.html.erb
@@ -14,11 +14,7 @@
       </div>
 
       <% @aeon_request_groups.each do |requests_in_group| %>
-        <% if requests_in_group.one? && !requests_in_group.first.multi_item_selector? %>
-          <%= render Aeon::RequestComponent.new(request: requests_in_group.first) %>
-        <% else %>
-          <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
-        <% end %>
+        <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
       <% end %>
     </div>
     <aside class="col-md-4 offcanvas-md offcanvas-bottom offcanvas-sm-start overflow-auto"  tabindex="-1" id="appointments">


### PR DESCRIPTION
Part of #3466, just getting the top-level card layout closer. Dealing with the individual boxes + items will happen in a future PR.
<img width="725" height="557" alt="Screenshot 2026-04-17 at 13 26 29" src="https://github.com/user-attachments/assets/6665945f-172c-47e0-854e-5c0cf5c7254e" />
