### PR TITLE
Always render grouped requests.

### DIFF
--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -23,7 +23,8 @@ class AeonRequestsController < ApplicationController
   def cancelled
     authorize! :read, Aeon::Request
 
-    @aeon_requests = sort_aeon_requests(filter_aeon_requests(current_user&.aeon&.cancelled_requests || []))
+    requests = sort_aeon_requests(filter_aeon_requests(current_user&.aeon&.cancelled_requests || []))
+    @aeon_request_groups = Aeon::RequestGrouping.from_requests(requests)
   end
 
   def submitted

--- a/app/views/aeon_requests/_list_requests.html.erb
+++ b/app/views/aeon_requests/_list_requests.html.erb
@@ -7,9 +7,5 @@
 </div>
 
 <% @aeon_request_groups.each do |requests_in_group| %>
-  <% if requests_in_group.one? && !requests_in_group.first.multi_item_selector? %>
-    <%= render Aeon::RequestComponent.new(request: requests_in_group.first) %>
-  <% else %>
-    <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
-  <% end %>
+  <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
 <% end %>

--- a/app/views/aeon_requests/cancelled.html.erb
+++ b/app/views/aeon_requests/cancelled.html.erb
@@ -1,10 +1,1 @@
-<div class="container">
-  <div class="d-flex flex-wrap gap-2 justify-content-between mb-3">
-    <h1>Cancelled requests</h1>
-    <div class="d-flex flex-wrap gap-2">
-      <%= render 'sort_dropdown' %>
-      <%= render 'filter_dropdown' %>
-    </div>
-  </div>
-  <%= render Aeon::RequestComponent.with_collection(@aeon_requests) %>
-</div>
+<%= render 'list_requests', header: 'Cancelled Requests' %>

--- a/app/views/aeon_requests/drafts.html.erb
+++ b/app/views/aeon_requests/drafts.html.erb
@@ -14,11 +14,7 @@
       </div>
 
       <% @aeon_request_groups.each do |requests_in_group| %>
-        <% if requests_in_group.one? && !requests_in_group.first.multi_item_selector? %>
-          <%= render Aeon::RequestComponent.new(request: requests_in_group.first) %>
-        <% else %>
-          <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
-        <% end %>
+        <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
       <% end %>
     </div>
     <aside class="col-md-4 offcanvas-md offcanvas-bottom offcanvas-sm-start overflow-auto"  tabindex="-1" id="appointments">


### PR DESCRIPTION
My impression from #3466 is we're always rendering grouped requests. If that's true, there's a next step for cleaning + consolidating.