### PR TITLE
Increase margin on reading room appointment option

### DIFF
--- a/app/views/patron_requests/_reading_or_digitization.html.erb
+++ b/app/views/patron_requests/_reading_or_digitization.html.erb
@@ -2,7 +2,7 @@
 <fieldset class="ps-2">
   <div class="d-flex">
     <%= f.radio_button :request_type, 'pickup', class: 'form-check-input', required: true, data: { action: 'patron-request#updateType', terms: false } %>
-    <div class="ms-1 d-flex flex-wrap column-gap-2">
+    <div class="ms-2 d-flex flex-wrap column-gap-2">
       <%= f.label :request_type_pickup, class: 'form-check-label' do %>
         Reading room appointment
       <% end %>


### PR DESCRIPTION
I think with the switch to `d-flex` in 60556a15 we lost the inline whitespace in this case, so Digitization is 0.25rem to the right, compared to Reading Room:


Before:
<img width="652" height="84" alt="Screenshot 2026-04-27 at 2 35 42 PM" src="https://github.com/user-attachments/assets/ac8545a2-c212-4252-9eb4-07d59b41171d" />


After:
<img width="405" height="104" alt="Screenshot 2026-04-27 at 2 35 18 PM" src="https://github.com/user-attachments/assets/4f718128-2ea8-49f7-b624-1c70838722e4" />
<img width="600" height="94" alt="Screenshot 2026-04-27 at 2 35 11 PM" src="https://github.com/user-attachments/assets/545078f1-f0e4-4c59-96c9-b3551e459898" />
