### PR TITLE
Trim trailing comma from EAD unit titles

### DIFF
--- a/app/models/ead/document.rb
+++ b/app/models/ead/document.rb
@@ -174,7 +174,8 @@ module Ead
       end
 
       def title
-        @node.xpath('did/unittitle').first&.text&.strip
+        unittitle = @node.xpath('did/unittitle').first&.text&.strip
+        unittitle&.delete_suffix(',')
       end
 
       def date


### PR DESCRIPTION
Before:
<img width="496" height="85" alt="Screenshot 2026-04-27 at 2 56 43 PM" src="https://github.com/user-attachments/assets/f5e61e9f-6687-495d-9820-1064f4f6528e" />


After:
<img width="519" height="82" alt="Screenshot 2026-04-27 at 2 53 49 PM" src="https://github.com/user-attachments/assets/57b87c57-633e-440c-b124-d2c67d745685" />
