### PR TITLE
Only show the appointment separator if both components are present

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -471,10 +471,9 @@ label.btn-close {
     padding: 4px 12px;
   }
 
-  .appointment-details > * + *::before {
-    content: "•";
-    margin-left: 0.125rem;
-    margin-right: 0.375rem;
+  .appointment-details .bi-dot {
+    margin-inline-start: -0.25rem;
+    margin-inline-end: -0.25rem;
   }
 
   .card-footer {

--- a/app/components/aeon/request_appointment_time_component.html.erb
+++ b/app/components/aeon/request_appointment_time_component.html.erb
@@ -2,7 +2,12 @@
   <i class="bi bi-calendar text-green me-1"></i>
   <span class="appointment-details ms-1">
     <span class="fw-bold text-green"><%= appointment_date %></span>
-    <span class="fw-normal text-nowrap text-green"><%= appointment_time_range %></span>
-    <% if @with_reading_room %><span class="fw-normal text-nowrap text-green"><%= appointment_reading_room_name %></span><% end %>
+    <% if appointment_time_range.present? %>
+      <i class="bi bi-dot text-green align-middle fs-4"></i>
+      <span class="fw-normal text-nowrap text-green"><%= appointment_time_range %></span>
+    <% end %>
+    <% if @with_reading_room %>
+      <span class="fw-normal text-nowrap text-green"><%= appointment_reading_room_name %></span>
+    <% end %>
   </span>
 </span>


### PR DESCRIPTION
I think this helps with one of my comments in https://github.com/sul-dlss/sul-requests/pull/3494?

<img width="323" height="41" alt="Screenshot 2026-04-27 at 4 58 47 PM" src="https://github.com/user-attachments/assets/82b4992d-1940-4055-b5f2-4bbdd809851c" />

<img width="252" height="49" alt="Screenshot 2026-04-27 at 5 04 08 PM" src="https://github.com/user-attachments/assets/a6e6cc73-4242-4ed2-b15a-cc99f45c18ed" />
