### PR TITLE
Add a method to get active requests only from the Aeon API

### DIFF
--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -30,16 +30,24 @@ module Aeon
       @requests ||= self.class.aeon_client.requests_for(username:)
     end
 
+    # Active requests exclude requests sitting in terminal queues (Cancelled by
+    # User/Staff, Request Finished). Fetching all requests is slow for users
+    # with many cancelled or completed requests, so prefer this over `requests`
+    # when terminal requests aren't required.
+    def active_requests
+      @active_requests ||= self.class.aeon_client.requests_for(username:, active_only: true)
+    end
+
     def activities
       @activities ||= self.class.aeon_client.activities_for(username:)
     end
 
     def draft_requests
-      requests.select(&:draft?)
+      active_requests.select(&:draft?)
     end
 
     def submitted_requests
-      requests.select(&:submitted?)
+      active_requests.select(&:submitted?)
     end
 
     def cancelled_requests
@@ -52,7 +60,7 @@ module Aeon
 
     def appointments
       @appointments ||= self.class.aeon_client.appointments_for(username:).sort_by(&:sort_key).reject(&:cancelled?).each do |appointment|
-        appointment.requests = requests.select { |request| !request.cancelled? && request.appointment_id == appointment.id }
+        appointment.requests = active_requests.select { |request| !request.cancelled? && request.appointment_id == appointment.id }
       end
     end
 

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Accessibility testing', :js do
 
     before do
       allow(AeonClient).to receive(:new).and_return(stub_aeon_client)
-      allow(aeon_user).to receive_messages(requests: all_requests)
+      allow(aeon_user).to receive_messages(requests: all_requests, active_requests: all_requests)
       login_as(current_user)
     end
 


### PR DESCRIPTION
I'm a special case because I have so many cancelled requests, but this reduces the Aeon response time from 8s -> 0.75s for me.