### PR TITLE
Restore open hours to the appointment view.

### DIFF
--- a/app/components/aeon/appointment_component.rb
+++ b/app/components/aeon/appointment_component.rb
@@ -10,20 +10,20 @@ module Aeon
     end
 
     def time_range_html(margin: 'me-2')
-      return if appointment.reading_room.day_only_appointments?
-
-      tag.i(class: "bi bi-clock #{margin}") + appointment_time_range
+      tag.span do
+        if appointment.reading_room.day_only_appointments?
+          tag.i(class: "bi bi-clock #{margin}") + "Open hours: #{appointment_time_range}"
+        else
+          tag.i(class: "bi bi-clock #{margin}") + appointment_time_range
+        end
+      end
     end
 
     def appointment_time_range
       start = l(appointment.start_time, format: :time_only)
       stop = l(appointment.stop_time, format: :time_only)
 
-      if appointment.reading_room.day_only_appointments?
-        "Open hours: #{start} - #{stop}"
-      else
-        "#{start} - #{stop}"
-      end
+      "#{start} - #{stop}"
     end
 
     def appointment_date


### PR DESCRIPTION
#3494 went a little too far and removed the open hours from the appointments display + sidebar.

<img width="541" height="178" alt="Screenshot 2026-04-28 at 09 58 50" src="https://github.com/user-attachments/assets/6ced2db7-184f-43ea-abf8-d0b2f7249a87" />

<img width="339" height="184" alt="Screenshot 2026-04-28 at 09 59 00" src="https://github.com/user-attachments/assets/413d0bd2-08d4-491f-9058-0c4c26fdb733" />
