### PR TITLE
Small refactor for EAD container contents modal

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -885,13 +885,8 @@ label.btn-close {
   margin-bottom: 3rem;
 }
 
-ul.container-content li {
-  list-style: none;
+.modal .container-content li:not(:last-child) {
   border-bottom: 1px solid var(--stanford-10-black);
-}
-
-ul.container-content li:last-child {
-  border-bottom: none;
 }
 
 .banner {

--- a/app/javascript/controllers/view_container_contents_controller.js
+++ b/app/javascript/controllers/view_container_contents_controller.js
@@ -5,21 +5,13 @@ import DOMPurify from "dompurify";
 
 export default class extends Controller {
   static targets = ["viewModal", "banner", "contents", "displayButton"]
-  connect() {
-  
-  }
 
   displayButtonTargetConnected(targetElement) {
-    // Get the href for the collapsible content tied to this item
-    const contentsHref = '#container-items-' + targetElement.dataset.itemId
-    // Find if this exists, if so, then contents are available in the selected item
-    const anchor = document.querySelector("a[data-bs-toggle='collapse'][href='" + contentsHref + "']")
-    if(anchor) {
+    if (this.contentsFor(targetElement.dataset.itemId)) {
       targetElement.classList.remove("d-none")
     }
   }
   
-
   openViewModal(event) {
     // Without this, clicking the button that triggers the event may lead to a form submission
     event.preventDefault();
@@ -51,10 +43,12 @@ export default class extends Controller {
 
   // Based on the item id, get the appropriate item selection element
   addContents(itemId) {
-    const contentsId = 'container-items-' + itemId
-    const contentsElement = document.querySelector("#" + contentsId + " ul")
-    const contents = Array.from(contentsElement.children).map(contentElement => "<li>" + contentElement.innerHTML + "</li>")
-    this.contentsTarget.innerHTML = "<ul class='container-content p-0 m-0'>" + contents.join('') + "</ul>"
+    const clone = this.contentsFor(itemId).cloneNode(true)
+    clone.className = "container-content list-unstyled p-0 m-0"
+    this.contentsTarget.replaceChildren(clone)
+  }
 
+  contentsFor(itemId) {
+    return document.getElementById("container-items-" + itemId)?.querySelector('.container-content')
   }
 }

--- a/app/views/patron_requests/_ead_series_contents.html.erb
+++ b/app/views/patron_requests/_ead_series_contents.html.erb
@@ -48,7 +48,7 @@
           <span class="badge bg-dark-subtle text-dark fw-normal rounded-pill"><%= display_group.contents.count %></span>
           <%# Collapsible list of items in this container %>
           <div id="<%= content_id %>" class="collapse" data-archives-series-target="content">
-            <ul class="list-unstyled ms-2 my-2">
+            <ul class="container-content list-unstyled ms-2 my-2">
               <% display_group.contents.each do |item| %>
                 <li class="mb-1">
                   <% if item.folder %>


### PR DESCRIPTION
If we add a class to the contents, we can use cloneNode and avoid needing to know it's a list.