### PR TITLE
Add responsive handling to the expand/collapse EAD contents buttons

### DIFF
--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -56,11 +56,13 @@
     <% component.with_body do %>
       <% if f.object.ead_doc.series_and_subseries.present? %>
         <div data-controller="archives-series ead-search">
-          <div class="mb-2 d-flex gap-2 align-items-center">
+          <div class="mb-2 d-flex flex-wrap gap-2 align-items-center">
             <div>Use checkboxes to select items.</div>
             <!--TODO: pull out text into template?-->
-            <button class="btn btn-link p-0 su-underline" data-action="click->archives-series#expandAll"><i class="bi bi-chevron-double-right me-1"></i>Expand all (see full content list)</button>
-            <button class="btn btn-link p-0 su-underline" data-action="click->archives-series#collapseAll"><i class="bi bi-chevron-double-down me-1"></i>Collapse all</button>
+            <div class="d-flex flex-wrap gap-2">
+              <button class="btn btn-link p-0 su-underline text-start" data-action="click->archives-series#expandAll"><i class="bi bi-chevron-double-right me-1"></i>Expand all (see full content list)</button>
+              <button class="btn btn-link p-0 su-underline text-start" data-action="click->archives-series#collapseAll"><i class="bi bi-chevron-double-down me-1"></i>Collapse all</button>
+            </div>
           </div>
           <% if f.object.ead_doc.digital_content? %>
             <div class="mb-2"><%= render Icons::OnlineComponent.new classes: 'me-1 align-text-bottom text-digital-blue' %><span class="fw-semibold">Digital content</span> - Some materials from this collection are available online.</div>


### PR DESCRIPTION
Before:
<img width="326" height="91" alt="Screenshot 2026-04-28 at 3 52 26 PM" src="https://github.com/user-attachments/assets/5eb2ef2d-d35d-4466-b70c-b737e02fbcb1" />


After:
<img width="307" height="168" alt="Screenshot 2026-04-28 at 4 03 01 PM" src="https://github.com/user-attachments/assets/c6baa2e4-41e9-4b8d-8c88-aca76d2db1ad" />
<img width="428" height="184" alt="Screenshot 2026-04-28 at 4 02 51 PM" src="https://github.com/user-attachments/assets/aeeb80d7-8686-43a8-b269-1402e2050aa1" />
<img width="585" height="132" alt="Screenshot 2026-04-28 at 4 02 40 PM" src="https://github.com/user-attachments/assets/238a21e2-43a9-4166-b191-66a2ad77559f" />
