### PR TITLE
Only pass Aeon item data appropriate for the request type

### DIFF
--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -18,6 +18,14 @@ class PatronRequest < ApplicationRecord
 
   delegate :instance_id, :finding_aid, :finding_aid?, to: :folio_instance
 
+  # Per-item fields that are meaningful for each Aeon request_type. Hidden accordion sections in the
+  # form still submit their inputs, so we drop anything that doesn't belong to the selected type.
+  AEON_ITEM_FIELDS_BY_REQUEST_TYPE = {
+    'scan' => %w[id title hierarchy for_publication requested_pages additional_information],
+    'pickup' => %w[id title hierarchy appointment_id],
+    'activity' => %w[id title hierarchy]
+  }.freeze
+
   validates :request_type, inclusion: { in: %w[scan pickup mediated mediated/approved mediated/done activity] }
   validates :scan_title, presence: true, on: :create, if: :folio_scan?
   validate :pickup_service_point_is_valid, on: :create, if: :folio_pickup?
@@ -47,6 +55,8 @@ class PatronRequest < ApplicationRecord
   has_many :admin_comments, as: :request, dependent: :delete_all
 
   attr_writer :folio_instance
+
+  before_validation :prune_irrelevant_aeon_request_data
 
   before_create do
     self.request_type = 'mediated' if mediateable? && !request_type.start_with?('mediated') && !aeon_page?
@@ -727,5 +737,12 @@ class PatronRequest < ApplicationRecord
     return if instance_hrid.present? || ead_url.present?
 
     errors.add(:instance_id, 'Either a FOLIO instance HRID or an EAD URL must be provided')
+  end
+
+  def prune_irrelevant_aeon_request_data
+    if aeon_item.present? && (fields = AEON_ITEM_FIELDS_BY_REQUEST_TYPE[request_type])
+      self.aeon_item = aeon_item.transform_values { |item| item.slice(*fields) }
+    end
+    self.activity_ids = nil unless request_type == 'activity'
   end
 end

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -258,6 +258,46 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(page).to have_button('Submit request', disabled: false)
     end
 
+    it 'does not retain reading-room appointment data after switching to digitization' do # rubocop:disable RSpec/ExampleLength
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Reading room appointment'
+      click_button 'Continue'
+
+      click_link 'Computers and Typesetting'
+      click_link 'Legal size documents'
+      check 'Box 12'
+      click_button 'Continue'
+
+      within('[data-content-id]', text: 'Box 12') do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+      expect(page).to have_button('Submit request', disabled: false)
+
+      # User changes their mind and switches to digitization
+      within('#request-type-accordion') { click_button 'Edit' }
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+      expect(page).to have_css('#items-accordion .accordion-collapse.show')
+      click_button 'Continue'
+
+      within('[data-content-id]', text: 'Box 12') do
+        fill_in 'Requested pages', with: 'Pages 1-10'
+        choose 'No'
+      end
+
+      perform_enqueued_jobs { click_button 'Submit request' }
+      expect(page).to have_css('.confirmation')
+
+      patron_request = PatronRequest.last
+      expect(patron_request.request_type).to eq 'scan'
+      box_12_data = patron_request.aeon_item.values.find { |v| v['requested_pages'] == 'Pages 1-10' }
+      expect(box_12_data).to be_present
+      expect(box_12_data['appointment_id']).to be_blank
+    end
+
     it 'shows the request-type Edit button when save-for-later is triggered from the digitization flow' do
       visit new_archives_request_path(value: 'http://example.com/ead.xml')
 

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -196,5 +196,45 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
         expect(page).to have_text 'ABC 321'
       end
     end
+
+    it 'does not retain digitization data after switching to a reading-room appointment' do # rubocop:disable RSpec/ExampleLength
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+
+      check 'ABC 123'
+      click_button 'Continue'
+
+      within('[data-content-id]', text: 'ABC 123') do
+        fill_in 'Requested pages', with: 'Pages 1-10'
+        choose 'No'
+        fill_in 'Additional information', with: 'Testing only'
+      end
+      expect(page).to have_button('Submit request', disabled: false)
+
+      # User changes their mind and switches to a reading-room appointment
+      within('#request-type-accordion') { click_button 'Edit' }
+      choose 'Reading room appointment'
+      click_button 'Continue'
+      expect(page).to have_css('#items-accordion .accordion-collapse.show')
+      click_button 'Continue'
+
+      within('[data-content-id]', text: 'ABC 123') do
+        click_button 'Select existing appointment'
+        click_button 'Feb 19'
+      end
+
+      perform_enqueued_jobs { click_button 'Submit request' }
+      expect(page).to have_css('.confirmation')
+
+      patron_request = PatronRequest.last
+      expect(patron_request.request_type).to eq 'pickup'
+      abc_123_data = patron_request.aeon_item.values.find { |v| v['appointment_id'].present? }
+      expect(abc_123_data).to be_present
+      expect(abc_123_data['appointment_id']).to eq '1'
+      expect(abc_123_data['requested_pages']).to be_blank
+      expect(abc_123_data['for_publication']).to be_blank
+      expect(abc_123_data['additional_information']).to be_blank
+    end
   end
 end

--- a/spec/models/patron_request_spec.rb
+++ b/spec/models/patron_request_spec.rb
@@ -48,6 +48,49 @@ RSpec.describe PatronRequest do
     it { is_expected.to be_scan }
   end
 
+  describe 'pruning irrelevant aeon request data on validation' do
+    # Stub items so the unrelated folio_scan?/folio_pickup? validation predicates resolve cleanly.
+    let(:folio_instance) { instance_double(Folio::Instance, title: 'Title', items: []) }
+    let(:full_aeon_item) do
+      { 'box-1' => { 'id' => 'box-1', 'title' => 'Box 1', 'appointment_id' => '7',
+                     'requested_pages' => '1-10', 'for_publication' => 'false', 'additional_information' => 'note' } }
+    end
+
+    context 'with a digitization request' do
+      let(:attr) { { request_type: 'scan', aeon_item: full_aeon_item, activity_ids: %w[3] } }
+
+      it 'drops appointment_id and activity_ids' do
+        request.valid?
+        expect(request.aeon_item['box-1']).not_to have_key('appointment_id')
+        expect(request.aeon_item['box-1']).to include('requested_pages' => '1-10', 'for_publication' => 'false')
+        expect(request.activity_ids).to be_nil
+      end
+    end
+
+    context 'with a reading-room request' do
+      let(:attr) { { request_type: 'pickup', aeon_item: full_aeon_item, activity_ids: %w[3] } }
+
+      it 'drops digitization fields and activity_ids' do
+        request.valid?
+        expect(request.aeon_item['box-1']).to include('appointment_id' => '7')
+        expect(request.aeon_item['box-1'].keys).not_to include('requested_pages', 'for_publication', 'additional_information')
+        expect(request.activity_ids).to be_nil
+      end
+    end
+
+    context 'with an activity request' do
+      let(:attr) { { request_type: 'activity', aeon_item: full_aeon_item, activity_ids: %w[3] } }
+
+      it 'drops both appointment and digitization fields and keeps activity_ids' do
+        request.valid?
+        expect(request.aeon_item['box-1'].keys).not_to include(
+          'appointment_id', 'requested_pages', 'for_publication', 'additional_information'
+        )
+        expect(request.activity_ids).to eq %w[3]
+      end
+    end
+  end
+
   describe '#display_type' do
     context 'request type scan' do
       let(:attr) { { request_type: 'scan' } }


### PR DESCRIPTION
I'm still noodling on this one, but you can make digitization requests with appointments currently 😈 

<img width="856" height="247" alt="Screenshot 2026-04-28 at 5 47 11 PM" src="https://github.com/user-attachments/assets/78772826-ed85-430a-9ade-adb77a2b2c0e" />
