### PR TITLE
Render requests as an `ol`

### DIFF
--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new classes: 'request-group', data: { controller: 'empty-remove' } do |c| %>
+<%= render CardComponent.new element: element, classes: 'request-group', data: { controller: 'empty-remove' } do |c| %>
   <% c.with_title do %>
     <div>
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/aeon/request_group_component.rb
+++ b/app/components/aeon/request_group_component.rb
@@ -3,12 +3,13 @@
 module Aeon
   # Render a group of requests that share the same title and request type
   class RequestGroupComponent < ViewComponent::Base
-    attr_reader :request_group
+    attr_reader :request_group, :element
 
     delegate :appointment_reading_room, :base_callnumber, :requests, :status_request, :title, to: :request_group
 
-    def initialize(request_group:)
+    def initialize(request_group:, element: 'div')
       @request_group = request_group
+      @element = element
     end
 
     def render?

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: %w[card bg-body-tertiary border-light-subtle shadow-sm mb-4] + classes, **tag_options do %>
+<%= tag.public_send element, class: %w[card bg-body-tertiary border-light-subtle shadow-sm mb-4] + classes, **tag_options do %>
   <%= pre %>
   <div class="card-header d-flex justify-content-between align-items-center bg-body-tertiary">
     <%= title %>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -9,9 +9,10 @@ class CardComponent < ViewComponent::Base
   renders_one :footer
   renders_one :post
 
-  attr_reader :classes, :tag_options
+  attr_reader :element, :classes, :tag_options
 
-  def initialize(classes: [], **tag_options)
+  def initialize(element: 'div', classes: [], **tag_options)
+    @element = element
     @classes = Array(classes)
     @tag_options = tag_options
   end

--- a/app/views/aeon_requests/index.html.erb
+++ b/app/views/aeon_requests/index.html.erb
@@ -59,11 +59,9 @@
     </div>
   </div>
   <div class="row">
-    <div class="<% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-md-9<% end %>">
-      <% @aeon_request_groups.each do |requests_in_group| %>
-        <%= render Aeon::RequestGroupComponent.new(request_group: requests_in_group) %>
-      <% end %>
-    </div>
+    <ol id="requests" class="list-unstyled <% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-md-9<% end %>">
+      <%= render Aeon::RequestGroupComponent.with_collection(@aeon_request_groups, element: 'li') %>
+    </ol>
 
     <%= content_for(:sidebar) %>
   </div>


### PR DESCRIPTION
This is plausibly more semantic?