### PR TITLE
Add custom datepicker component and Lookbook views

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -907,4 +907,39 @@ label.btn-close {
 
 .zero-items-alert:only-child {
   display: flex;
+/* ---- Custom date picker ---- */
+.date-picker-popup {
+  position: absolute;
+  z-index: 1000;
+  background: white;
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  box-shadow: var(--bs-box-shadow);
+  padding: 0.75rem;
+  min-width: 280px;
+}
+
+.date-picker-grid {
+  border-collapse: separate;
+  border-spacing: 2px;
+}
+
+.date-picker-day {
+  padding: 0.2rem 0;
+  font-size: 0.85rem;
+  min-width: 2rem;
+}
+
+.date-picker-day:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.date-picker-dot {
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  margin: 1px auto 0;
 }

--- a/app/components/aeon/appointment_date_picker_component.html.erb
+++ b/app/components/aeon/appointment_date_picker_component.html.erb
@@ -1,0 +1,29 @@
+<div class="mb-3">
+  <%= form.label :date, class: 'd-block fw-semibold redesign-required-label' %>
+  <div class="position-relative" <%= tag.attributes(controller_data) %>>
+    <%= form.hidden_field :date, data: { "date-picker-target": "input", action: "change->appointment#refreshAvailability" } %>
+    <div data-date-picker-target="announce"
+         aria-live="polite"
+         aria-atomic="true"
+         class="visually-hidden"></div>
+    <button type="button"
+            class="btn btn-outline-secondary w-100 text-start"
+            data-date-picker-target="display"
+            data-action="click->date-picker#toggle"
+            aria-haspopup="dialog"
+            aria-expanded="false">Select a date</button>
+    <div class="date-picker-popup mt-1"
+         data-date-picker-target="calendar"
+         role="dialog"
+         aria-modal="true"
+         aria-labelledby="date-picker-month-label"
+         hidden>
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <button type="button" class="btn btn-sm btn-light" data-action="click->date-picker#prevMonth" aria-label="Previous month">&#8249;</button>
+        <strong id="date-picker-month-label" data-date-picker-target="monthLabel"></strong>
+        <button type="button" class="btn btn-sm btn-light" data-action="click->date-picker#nextMonth" aria-label="Next month">&#8250;</button>
+      </div>
+      <div data-date-picker-target="grid"></div>
+    </div>
+  </div>
+</div>

--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Renders the custom Stimulus date-picker for the Aeon appointment date field.
+  #
+  # Usage:
+  #   <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
+  #   <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: ['2026-05-01'], marked: ['2026-05-10']) %>
+  class AppointmentDatePickerComponent < ViewComponent::Base
+    attr_reader :form, :disabled, :marked
+
+    def initialize(form:, disabled: [], marked: [])
+      @form = form
+      @disabled = disabled
+      @marked = marked
+    end
+
+    def min
+      appointment = form.object
+      next_start = appointment.reading_room&.next_appointment&.start_time
+      next_start&.to_date&.iso8601 || Time.zone.today.iso8601
+    end
+
+    def controller_data
+      attrs = { controller: 'date-picker' }
+      attrs[:'date-picker-min-value'] = min if min.present?
+      attrs[:'date-picker-disabled-value'] = disabled.to_json if disabled.any?
+      attrs[:'date-picker-marked-value'] = marked.to_json if marked.any?
+      { data: attrs }
+    end
+  end
+end

--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -1,0 +1,195 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Custom date picker.
+//
+// Data attributes on the controller element:
+//   data-date-picker-disabled-value  JSON array of ISO dates to disable, e.g. '["2026-04-24","2026-04-27"]'
+//   data-date-picker-marked-value    JSON array of ISO dates to mark with a dot, e.g. '["2026-04-23"]'
+//   data-date-picker-min-value       ISO date string; any date before this is disabled, e.g. '"2026-04-23"'
+//
+// Targets:
+//   input       hidden <input> that holds the selected ISO date value
+//   display     clickable element (button/span) that shows the formatted date and opens/closes the calendar
+//   calendar    the popup wrapper div
+//   monthLabel  element where the current month/year label is rendered
+//   grid        element where the day buttons are rendered
+export default class extends Controller {
+  static targets = ["input", "calendar", "display", "monthLabel", "grid", "announce"]
+  static values = { disabled: Array, marked: Array, min: String }
+
+  connect() {
+    const initial = this.inputTarget.value
+    let seed = initial ? new Date(`${initial}T00:00:00`) : new Date()
+    // If no date is selected but a minValue exists in a future month (e.g. the earliest
+    // available appointment is May 5 but today is April 30), open the calendar to that
+    // future month instead of the current one so the user sees selectable dates immediately.
+    if (!initial && this.minValue) {
+      const min = new Date(`${this.minValue}T00:00:00`)
+      if (min > seed) seed = min
+    }
+    this.viewYear = seed.getFullYear()
+    this.viewMonth = seed.getMonth() // 0-indexed
+    this.renderCalendar()
+    document.addEventListener("click", this.#handleOutsideClick)
+    this.element.addEventListener("keydown", this.#handleKeydown)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.#handleOutsideClick)
+    this.element.removeEventListener("keydown", this.#handleKeydown)
+  }
+
+  toggle() {
+    this.calendarTarget.hidden ? this.open() : this.close()
+  }
+
+  open() {
+    this.renderCalendar()
+    this.calendarTarget.hidden = false
+    this.displayTarget.setAttribute("aria-expanded", "true")
+    // move focus to the selected day, or the first enabled day
+    requestAnimationFrame(() => {
+      const focused = this.gridTarget.querySelector("button[aria-pressed='true']:not(:disabled)") ||
+                      this.gridTarget.querySelector("button:not(:disabled)")
+      focused?.focus()
+    })
+  }
+
+  close() {
+    this.calendarTarget.hidden = true
+    this.displayTarget.setAttribute("aria-expanded", "false")
+    this.displayTarget.focus()
+  }
+
+  prevMonth() {
+    if (this.viewMonth === 0) { this.viewMonth = 11; this.viewYear-- }
+    else { this.viewMonth-- }
+    this.renderCalendar()
+  }
+
+  nextMonth() {
+    if (this.viewMonth === 11) { this.viewMonth = 0; this.viewYear++ }
+    else { this.viewMonth++ }
+    this.renderCalendar()
+  }
+
+  selectDay(event) {
+    const date = event.currentTarget.dataset.date
+    this.inputTarget.value = date
+    this.inputTarget.dispatchEvent(new Event('change', { bubbles: true }))
+    const formatted = this.#formatDisplay(date)
+    this.displayTarget.textContent = formatted
+    this.announceTarget.textContent = `Selected ${formatted}`
+    this.close()
+    this.renderCalendar() // re-render to reflect selection
+  }
+
+  renderCalendar() {
+    const { viewYear: year, viewMonth: month } = this
+    this.monthLabelTarget.textContent = new Date(year, month, 1)
+      .toLocaleDateString("en-US", { month: "long", year: "numeric" })
+
+    const firstDayOfWeek = new Date(year, month, 1).getDay() // 0 = Sunday
+    const daysInMonth = new Date(year, month + 1, 0).getDate()
+    const selected = this.inputTarget.value
+
+    const dayNames = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+    const rows = [["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]]
+    let week = Array(firstDayOfWeek).fill(null)
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      week.push(day)
+      if (week.length === 7) { rows.push(week); week = [] }
+    }
+    if (week.length) rows.push(week.concat(Array(7 - week.length).fill(null)))
+
+    // Build DOM nodes — no innerHTML interpolation of user data
+    const table = document.createElement("table")
+    table.className = "date-picker-grid w-100 text-center"
+    table.setAttribute("role", "grid")
+
+    const thead = table.createTHead()
+    const headerRow = thead.insertRow()
+    dayNames.forEach(name => {
+      const th = document.createElement("th")
+      th.className = "date-picker-day-name small text-muted pb-1"
+      th.scope = "col"
+      th.textContent = name
+      headerRow.appendChild(th)
+    })
+
+    const tbody = table.createTBody()
+    rows.slice(1).forEach(weekDays => {
+      const tr = tbody.insertRow()
+      weekDays.forEach(day => {
+        const td = tr.insertCell()
+        if (day === null) return
+
+        const isoDate = [
+          year,
+          String(month + 1).padStart(2, "0"),
+          String(day).padStart(2, "0")
+        ].join("-")
+
+        const isDisabled = this.disabledValue.includes(isoDate) ||
+          (this.minValue && isoDate < this.minValue)
+        const isMarked = this.markedValue.includes(isoDate)
+        const isSelected = isoDate === selected
+
+        td.setAttribute("role", "gridcell")
+
+        const btn = document.createElement("button")
+        btn.type = "button"
+        btn.className = [
+          "date-picker-day",
+          "btn btn-sm w-100 position-relative",
+          isSelected ? "btn-primary" : "btn-light"
+        ].join(" ")
+        btn.dataset.date = isoDate
+        btn.dataset.action = "click->date-picker#selectDay"
+        btn.disabled = isDisabled
+        btn.setAttribute("aria-pressed", String(isSelected))
+        btn.textContent = day
+
+        // Build accessible label: "April 22, 2026" + optional ", existing appointment"
+        const [y, mo, d] = isoDate.split("-").map(Number)
+        let label = new Date(y, mo - 1, d).toLocaleDateString("en-US", {
+          month: "long", day: "numeric", year: "numeric"
+        })
+        if (isMarked) label += ", existing appointment"
+        btn.setAttribute("aria-label", label)
+
+        if (isMarked) {
+          const dot = document.createElement("span")
+          dot.className = "date-picker-dot"
+          dot.setAttribute("aria-hidden", "true")
+          btn.appendChild(dot)
+        }
+
+        td.appendChild(btn)
+      })
+    })
+
+    this.gridTarget.replaceChildren(table)
+  }
+
+  // --- private ---
+
+  #formatDisplay(isoDate) {
+    const [y, m, d] = isoDate.split("-").map(Number)
+    return new Date(y, m - 1, d).toLocaleDateString("en-US", {
+      month: "long", day: "numeric", year: "numeric"
+    })
+  }
+
+  #handleOutsideClick = (event) => {
+    if (!this.element.contains(event.target)) this.close()
+  }
+
+  #handleKeydown = (event) => {
+    if (event.key === "Escape" && !this.calendarTarget.hidden) {
+      event.stopPropagation()
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -64,6 +64,9 @@ application.register("status-counter", StatusCounterController)
 import DraftRequestController from "./draft_request_controller"
 application.register("draft-request", DraftRequestController)
 
+import DatePickerController from "./date_picker_controller"
+application.register("date-picker", DatePickerController)
+
 import CharCounterController from "./char_counter_controller"
 application.register("char-counter", CharCounterController)
 

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview.rb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Preview at /lookbook/previews/aeon/appointment_date_picker_component
+  class AppointmentDatePickerComponentPreview < ViewComponent::Preview
+    layout 'lookbook'
+
+    # Default — today forward, no restrictions
+    def default; end
+
+    # With a minimum date 2 weeks out
+    def with_min_date; end
+
+    # With marked days (existing appointments shown as dots)
+    def with_marked_days; end
+
+    # With individual disabled days and a disabled range
+    def with_disabled_days; end
+
+    # With weekends disabled
+    def with_weekends_disabled; end
+  end
+end

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/default.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/default.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
+  <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
+<% end %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_disabled_days.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_disabled_days.html.erb
@@ -1,0 +1,12 @@
+<%
+  today = Time.zone.today
+  # A couple of individual days
+  individual = [today + 2, today + 6]
+  # A range: next Monday through Wednesday
+  next_monday = today + ((1 - today.wday) % 7 + 7) % 7
+  range = (next_monday .. next_monday + 2).to_a
+  disabled = (individual + range).map(&:iso8601).uniq
+%>
+<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
+  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: disabled) %>
+<% end %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_marked_days.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_marked_days.html.erb
@@ -1,0 +1,7 @@
+<%
+  today = Time.zone.today
+  marked = [today + 2, today + 5, today + 9, today + 14].map(&:iso8601)
+%>
+<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
+  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, marked: marked) %>
+<% end %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_min_date.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_min_date.html.erb
@@ -1,0 +1,19 @@
+<%
+  reading_room = Aeon::ReadingRoom.new(id: 5, name: 'Field Reading Room', available_seats: 15,
+                                       time_zone_id: 'Pacific Standard Time', min_appointment_length: 30,
+                                       max_appointment_length: 480, appointment_padding: 0,
+                                       appointment_increment: 15, last_modified_time: Time.zone.now,
+                                       sites: ['SPECUA'], open_hours: [], policies: [])
+  next_appt = Aeon::Appointment.new(id: nil, username: nil, reading_room_id: 5,
+                                    start_time: 2.weeks.from_now, stop_time: 2.weeks.from_now + 1.hour,
+                                    name: nil, available_to_proxies: false, appointment_status: nil,
+                                    reading_room: nil, creation_date: nil)
+  reading_room.instance_variable_set(:@next_appointment, next_appt)
+  appointment = Aeon::Appointment.new(id: nil, username: nil, reading_room_id: 5, start_time: nil,
+                                      stop_time: nil, name: nil, available_to_proxies: false,
+                                      appointment_status: nil, reading_room: reading_room,
+                                      creation_date: nil)
+%>
+<%= form_with(model: appointment, url: '#') do |f| %>
+  <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
+<% end %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb
@@ -1,0 +1,8 @@
+<%
+  today = Time.zone.today
+  # Disable all Saturdays (wday 6) and Sundays (wday 0) for the next 3 months
+  weekends = (today .. today + 90).select { |d| d.wday == 0 || d.wday == 6 }.map(&:iso8601)
+%>
+<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
+  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: weekends) %>
+<% end %>

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -160,6 +160,35 @@ RSpec.describe 'Accessibility testing', :js do
     expect(page).to be_accessible
   end
 
+  context 'for the appointment date picker component' do
+    let(:user) { create(:sso_user) }
+    let(:current_user) { CurrentUser.new(username: user.sunetid, shibboleth: true) }
+    let(:aeon_user) { Aeon::User.new(username: user.email_address, auth_type: 'Default') }
+    let(:reading_room) { build(:aeon_reading_room) }
+    let(:stub_aeon_client) do
+      instance_double(AeonClient,
+                      find_user: aeon_user,
+                      appointments_for: [],
+                      available_appointments: [],
+                      reading_rooms: [reading_room])
+    end
+
+    before do
+      allow(AeonClient).to receive(:new).and_return(stub_aeon_client)
+      login_as(current_user)
+    end
+
+    it 'validates the custom stimulus datepicker',
+       skip: 'Skip until custom datepicker is used in the form' do
+      visit new_aeon_appointment_path(reading_room_id: reading_room.id)
+      expect(page).to be_accessible
+
+      find('[data-date-picker-target="display"]').click
+      expect(page).to have_css('[data-date-picker-target="calendar"]:not([hidden])') # picker is open
+      expect(page).to be_accessible
+    end
+  end
+
   def be_accessible
     be_axe_clean.with_options({ preload: false })
   end


### PR DESCRIPTION
I'd like to walk folks through this and then deploy it to stage so that the experts in this flow can test live.
Hard to test the JS code in our testing environment, but no existing tests break. If this approach is generally approved I can add deeper testing.

Full disclosure the JS was largely vibecoded.

I tried to review for accessibility -- among other things, tabbing through the calendar grid works correctly.

I included multiple Lookbook pages to demonstrate different states of the calendar
<img width="254" height="159" alt="Screenshot 2026-04-30 at 11 18 41 AM" src="https://github.com/user-attachments/assets/848d374a-63d7-41d7-8f33-b43ea1be3e5a" />

----

<img width="756" height="249" alt="Screenshot 2026-04-30 at 11 15 38 AM" src="https://github.com/user-attachments/assets/e3ca4729-0bfa-4fe5-a863-c9493b00e099" />
<img width="763" height="457" alt="Screenshot 2026-04-30 at 11 15 44 AM" src="https://github.com/user-attachments/assets/bfc3d588-b9bf-482e-8c97-8eb185bf19b0" />
<img width="847" height="477" alt="Screenshot 2026-04-30 at 11 15 59 AM" src="https://github.com/user-attachments/assets/a4dfac48-eaff-4a8c-a157-92b10e9426c6" />
