### PR TITLE
Extract an Aeon appointment heading component

### DIFF
--- a/app/components/aeon/appointment_heading_component.html.erb
+++ b/app/components/aeon/appointment_heading_component.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag(tag, class: classes.presence) do %>
+  <%= content %><% if reading_room %><i class="bi bi-dot mt-1"></i><span class="h3 my-1"><%= reading_room.name %></span><% end %>
+<% end %>

--- a/app/components/aeon/appointment_heading_component.rb
+++ b/app/components/aeon/appointment_heading_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Heading that optionally appends a reading room name after a dot separator.
+  class AppointmentHeadingComponent < ViewComponent::Base
+    def initialize(reading_room: nil, tag: :h1, classes: %w[d-flex align-items-center mb-0])
+      @reading_room = reading_room
+      @tag = tag
+      @classes = Array(classes)
+    end
+
+    attr_reader :reading_room, :tag, :classes
+  end
+end

--- a/app/views/aeon_appointments/edit.html+modal.erb
+++ b/app/views/aeon_appointments/edit.html+modal.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag params[:modal] do %>
   <div class="modal-header">
-    <h1>Edit appointment<% if @appointment %><i class="bi bi-dot"></i><%= @appointment.reading_room.name %><% end %></h1>
+    <%= render Aeon::AppointmentHeadingComponent.new(reading_room: @appointment&.reading_room) do %>Edit appointment<% end %>
     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
   </div>
 

--- a/app/views/aeon_appointments/edit.html.erb
+++ b/app/views/aeon_appointments/edit.html.erb
@@ -1,3 +1,3 @@
-<h1>Edit appointment<% if @appointment %><i class="bi bi-dot"></i><%= @appointment.reading_room.name %><% end %></h1>
+<%= render Aeon::AppointmentHeadingComponent.new(reading_room: @appointment&.reading_room) do %>Edit appointment<% end %>
 
 <%= render 'form' %>

--- a/app/views/aeon_appointments/new.html+modal.erb
+++ b/app/views/aeon_appointments/new.html+modal.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag params[:modal] do %>
   <div class="modal-header">
-    <h1 class="mb-0">Create new appointment<% if @reading_room %><i class="bi bi-dot"></i><%= @reading_room.name %><% end %></h1>
+    <%= render Aeon::AppointmentHeadingComponent.new(reading_room: @reading_room) do %>Create new appointment<% end %>
     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
   </div>
 

--- a/app/views/aeon_appointments/new.html.erb
+++ b/app/views/aeon_appointments/new.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="appointment-form">
-  <h1>Create new appointment<% if @reading_room %><i class="bi bi-dot"></i><%= @reading_room.name %><% end %></h1>
+  <%= render Aeon::AppointmentHeadingComponent.new(reading_room: @reading_room) do %>Create new appointment<% end %>
   <% if @appointment.reading_room_id %>
     <%= render 'form' %>
   <% else %>

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Appointments', :js do
         select 'Field Reading Room'
         click_on 'Continue'
 
-        expect(page).to have_text 'Create new appointmentField Reading Room'
+        expect(page).to have_text 'Create new appointment Field Reading Room', normalize_ws: true
         expect(page).to have_field('aeon_appointment[date]', type: 'date')
         expect(page).to have_no_text('Duration')
         click_on 'Cancel'
@@ -57,7 +57,7 @@ RSpec.describe 'Appointments', :js do
         select 'Archive of Recorded Sound'
         click_on 'Continue'
 
-        expect(page).to have_text 'Create new appointmentArchive of Recorded Sound'
+        expect(page).to have_text 'Create new appointment Archive of Recorded Sound', normalize_ws: true
         expect(page).to have_field('aeon_appointment[date]', type: 'date')
         expect(page).to have_text('Duration')
         expect(page).to have_text('Available time slots')


### PR DESCRIPTION
https://github.com/sul-dlss/sul-requests/issues/3525 has these styles in the design and I thought it looked good.

<img width="826" height="93" alt="Screenshot 2026-05-01 at 3 50 30 PM" src="https://github.com/user-attachments/assets/5b9c6496-3ef2-4f7a-990d-2a0d76ffafb2" />
<img width="608" height="84" alt="Screenshot 2026-05-01 at 3 50 09 PM" src="https://github.com/user-attachments/assets/ff0372fa-bde5-4b45-9ad1-87edc322a6f3" />
<img width="531" height="91" alt="Screenshot 2026-05-01 at 3 49 34 PM" src="https://github.com/user-attachments/assets/7e0e9eff-7954-4d37-9b13-4d5c634e5743" />
