### PR TITLE
Add create new appointment info alert

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -122,6 +122,11 @@ body {
   --bs-green-rgb: 25, 135, 84;
 }
 
+.alert-info {
+  --bs-alert-color: rgba(var(--stanford-digital-blue-dark-rgb), 1);
+  --bs-alert-border-color: rgba(var(--stanford-digital-blue-dark-rgb), 1);
+}
+
 input[type="radio"] {
   --bs-border-color: var(--stanford-50-black);
 }

--- a/app/components/alert_component.html.erb
+++ b/app/components/alert_component.html.erb
@@ -1,0 +1,6 @@
+<div role="alert" class="alert alert-<%= type %> d-flex shadow-sm align-items-center">
+  <div role="img" aria-label="<%= aria_label %>" class="<%= icon_class %> fs-3 me-3 align-self-center d-flex justify-content-center"></div>
+  <div class="text-body">
+    <div><%= content %></div>
+  </div>
+</div>

--- a/app/components/alert_component.html.erb
+++ b/app/components/alert_component.html.erb
@@ -1,4 +1,4 @@
-<div role="alert" class="alert alert-<%= type %> d-flex shadow-sm align-items-center">
+<div role="alert" class="<%= alert_class %> d-flex shadow-sm align-items-center">
   <div role="img" aria-label="<%= aria_label %>" class="<%= icon_class %> fs-3 me-3 align-self-center d-flex justify-content-center"></div>
   <div class="text-body">
     <div><%= content %></div>

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Alert with a leading icon. Pass a type (:info, :success, :warning).
+class AlertComponent < ViewComponent::Base
+  ICONS = {
+    info: 'info-circle-fill',
+    success: 'check-circle-fill',
+    warning: 'exclamation-triangle-fill'
+  }.freeze
+
+  def initialize(type:)
+    @type = type
+  end
+
+  attr_reader :type
+
+  def icon_class
+    "bi bi-#{ICONS.fetch(type)}"
+  end
+
+  def aria_label
+    "#{type.to_s.capitalize} icon"
+  end
+end

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -3,9 +3,15 @@
 # Alert with a leading icon. Pass a type (:info, :success, :warning).
 class AlertComponent < ViewComponent::Base
   ICONS = {
-    info: 'info-circle-fill',
-    success: 'check-circle-fill',
-    warning: 'exclamation-triangle-fill'
+    info: 'bi-info-circle-fill',
+    success: 'bi-check-circle-fill',
+    warning: 'bi-exclamation-triangle-fill'
+  }.freeze
+
+  ALERTS = {
+    info: 'alert-info',
+    success: 'alert-success',
+    warning: 'alert-warning'
   }.freeze
 
   def initialize(type:)
@@ -15,7 +21,11 @@ class AlertComponent < ViewComponent::Base
   attr_reader :type
 
   def icon_class
-    "bi bi-#{ICONS.fetch(type)}"
+    "bi #{ICONS.fetch(type)}"
+  end
+
+  def alert_class
+    "alert #{ALERTS.fetch(type)}"
   end
 
   def aria_label

--- a/app/views/aeon_appointments/_choose_reading_room.html.erb
+++ b/app/views/aeon_appointments/_choose_reading_room.html.erb
@@ -1,5 +1,6 @@
 <form data-controller="appointment">
   <div class="modal-body">
+    <%= render AlertComponent.new(type: :info) do %>Materials must be used in their associated reading room.<% end %>
     <label for="reading_room_id" class="d-block fw-semibold redesign-required-label mb-2">For which reading room?</label>
     <%= select_tag 'reading_room_id', options_from_collection_for_select(@reading_rooms, "id", "name"), include_blank: true, class: 'bg-white border rounded px-2 py-1' %>
   </div>

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Appointments', :js do
       expect(page).to have_css '.modal'
       within '.modal' do
         expect(page).to have_text 'Create new appointment'
+        expect(page).to have_text 'Materials must be used in their associated reading room'
         select 'Field Reading Room'
         click_on 'Continue'
 


### PR DESCRIPTION
Part of #3525 

<img width="836" height="355" alt="Screenshot 2026-05-01 at 5 00 01 PM" src="https://github.com/user-attachments/assets/3c417bf2-d75d-492c-b278-5d87d2cc2b83" />

If we're cool with the Alert component, I'll use that going forward and start replacing existing alerts.