### PR TITLE
Edit appt

### DIFF
--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -15,7 +15,8 @@
 </div>
 <% else %>
   <% unless @appointment.reading_room&.day_only_appointments? %>
-    <div class="selected-appointment d-flex flex-row d-none" data-appointment-target="selection">
+    <div class="selected-appointment d-flex flex-row" data-appointment-target="selection">
+      Select date and time
     </div>
   <% end %>
 <% end %>

--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -3,20 +3,22 @@
   <div class="w-50 border-end">
     <h4>Current</h4>
     <%= @appointment.date&.strftime('%b %e, %Y') %>
-    <i class="bi bi-dot"></i>
-    <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
+    <% unless @appointment.reading_room&.day_only_appointments? %>
+      <i class="bi bi-dot"></i>
+      <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
+    <% end %>
   </div>
   <div class="ms-3">
     <h4>
       New
     </h4>
     <div data-appointment-target="selection">
-      Select date and time
+      Select date <%= 'and time' unless @appointment.reading_room&.day_only_appointments? %>
     </div>
   </div>
 </div>
 <% else %>
   <div class="selected-appointment d-flex flex-row d-none" data-appointment-target="selection">
-    Select date and time
+    Select date <%= 'and time' unless @appointment.reading_room&.day_only_appointments? %>
   </div>
 <% end %>

--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -20,4 +20,4 @@
     Select date and time
   </div>
 <% end %>
-  
+

--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -1,0 +1,23 @@
+<% if existing_appointment? %>
+<div class="selected-appointment d-flex flex-row">
+  <div class="w-50 border-end">
+    <h4>Current</h4>
+    <%= @appointment.date&.strftime('%b %e, %Y') %>
+    <i class="bi bi-dot"></i>
+    <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
+  </div>
+  <div class="ms-3">
+    <h4>
+      New
+    </h4>
+    <div data-appointment-target="selection">
+      Select date and time
+    </div>
+  </div>
+</div>
+<% else %>
+  <div class="selected-appointment d-flex flex-row d-none" data-appointment-target="selection">
+    Select date and time
+  </div>
+<% end %>
+  

--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -20,4 +20,3 @@
     Select date and time
   </div>
 <% end %>
-

--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -2,11 +2,7 @@
 <div class="selected-appointment d-flex flex-row">
   <div class="w-50 border-end">
     <h4>Current</h4>
-    <%= @appointment.date&.strftime('%b %e, %Y') %>
-    <% unless @appointment.reading_room&.day_only_appointments? %>
-      <i class="bi bi-dot"></i>
-      <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
-    <% end %>
+    <%= render AppointmentTimeRangeComponent.new(appointment: @appointment) %>
   </div>
   <div class="ms-3">
     <h4>
@@ -18,7 +14,8 @@
   </div>
 </div>
 <% else %>
-  <div class="selected-appointment d-flex flex-row d-none" data-appointment-target="selection">
-    Select date <%= 'and time' unless @appointment.reading_room&.day_only_appointments? %>
-  </div>
+  <% unless @appointment.reading_room&.day_only_appointments? %>
+    <div class="selected-appointment d-flex flex-row d-none" data-appointment-target="selection">
+    </div>
+  <% end %>
 <% end %>

--- a/app/components/aeon/appointment_selection_component.rb
+++ b/app/components/aeon/appointment_selection_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Render section of modal responsible for displaying appointment selection or
+  class AppointmentSelectionComponent < ViewComponent::Base
+    def initialize(appointment:)
+      @appointment = appointment
+    end
+
+    def existing_appointment?
+      @appointment.date.present?
+    end
+  end
+end

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -61,6 +61,7 @@ export default class extends Controller {
   }
 
   updateBanner() {
+    if (!this.hasSelectionTarget) { return }
     // get the text for the updated appointment text
     const formData = new FormData(this.element);
     const form_date = formData.get('aeon_appointment[date]');
@@ -76,7 +77,6 @@ export default class extends Controller {
     }
     // Update the selection portion
     this.selectionTarget.innerHTML = `<div class="d-flex">${text}</div>`;
-    this.selectionTarget.classList.remove('d-none');
   }
 
   formatTime(start_time, duration) {
@@ -114,6 +114,5 @@ export default class extends Controller {
         radio.checked = false;
       }
     });
-    this.updateBanner();
   }
 }

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["availability", "duration", "fieldset", "banner", "selection"]
+  static targets = ["availability", "duration", "fieldset", "selection"]
   static values = {
     availabilityRoute: String
   }
@@ -76,8 +76,7 @@ export default class extends Controller {
     }
     // Update the selection portion
     this.selectionTarget.innerHTML = `<div class="d-flex">${text}</div>`;
-    // Display the banner
-    this.bannerTarget.classList.remove('d-none');
+    this.selectionTarget.classList.remove('d-none');
   }
 
   formatTime(start_time, duration) {

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -70,13 +70,13 @@ export default class extends Controller {
     const start_time =  this.element.querySelector('[name="aeon_appointment[start_time]"]:checked')?.dataset?.timestamp;
     const duration = formData.get('aeon_appointment[duration]');
     const options = { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' };
-    let text = `${date.toLocaleDateString('en-US', options)}`
+    let text = `<span>${date.toLocaleDateString('en-US', options)}</span>`
     if (start_time && duration) {
       const formattedTime = this.formatTime(start_time, duration)
-      text += `<i class="bi bi-dot"></i>${formattedTime}`
+      text += `<i class="bi bi-dot"></i><span>${formattedTime}</span>`
     }
     // Update the selection portion
-    this.selectionTarget.innerHTML = `<div class="d-flex">${text}</div>`;
+    this.selectionTarget.innerHTML = text;
   }
 
   formatTime(start_time, duration) {

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["availability", "duration", "fieldset", "banner"]
+  static targets = ["availability", "duration", "fieldset", "banner", "selection"]
   static values = {
     availabilityRoute: String
   }
@@ -61,11 +61,11 @@ export default class extends Controller {
   }
 
   updateBanner() {
+    // get the text for the updated appointment text
     const formData = new FormData(this.element);
     const form_date = formData.get('aeon_appointment[date]');
     if (!form_date) { return }
     const date = new Date(Date.parse(form_date));
-    this.bannerTarget.classList.remove('d-none');
     const start_time =  this.element.querySelector('[name="aeon_appointment[start_time]"]:checked')?.dataset?.timestamp;
     const duration = formData.get('aeon_appointment[duration]');
     const options = { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' };
@@ -74,7 +74,10 @@ export default class extends Controller {
       const formattedTime = this.formatTime(start_time, duration)
       text += `<i class="bi bi-dot"></i>${formattedTime}`
     }
-    this.bannerTarget.innerHTML = `<div class="d-flex">${text}</div>`;
+    // Update the selection portion
+    this.selectionTarget.innerHTML = `<div class="d-flex">${text}</div>`;
+    // Display the banner
+    this.bannerTarget.classList.remove('d-none');
   }
 
   formatTime(start_time, duration) {

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -15,7 +15,7 @@
     <div class="mb-3">
       <%= f.label :date, class: 'd-block fw-semibold redesign-required-label' %>
       <div class="d-flex align-items-center gap-2">
-        <%= f.date_field :date, value: "", required: true, data: { action: 'appointment#refreshAvailability' }, min: (@appointment.reading_room.next_appointment.start_time.to_date.iso8601 if @appointment.reading_room&.next_appointment), class: 'border rounded px-2 py-1' %>
+        <%= f.date_field :date, value: "", required: true, data: { action: 'appointment#refreshAvailability appointment#updateBanner' }, min: (@appointment.reading_room.next_appointment.start_time.to_date.iso8601 if @appointment.reading_room&.next_appointment), class: 'border rounded px-2 py-1' %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>
       </div>
     </div>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -2,6 +2,12 @@
   <%
     banner_display = @appointment.date.present? ? '' : 'd-none'
     selection_classes =  @appointment.date.present? ? 'ms-3 ' : ''
+    requests_message = ''
+    if @appointment.requests.present?
+      requests_number = @appointment.requests.length
+      item_text = requests_number > 1 ? 'items' : 'item'
+      requests_message = "#{requests_number} #{item_text} will move to the new appointment." 
+    end
   %>
   <div data-appointment-target="banner" class="selected-appointment d-flex flex-row <%= banner_display %>">
     <div data-appointment-target-="current" class="w-50 border-end <%= banner_display %>">
@@ -70,6 +76,9 @@
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
         <div class="selection-message">Select a reading room, date, and duration to see available appointments.</div>
       </turbo-frame>
+    <% end %>
+    <% if requests_message.present? %>
+      <div class="alert alert-info"><%= requests_message %></div>
     <% end %>
   </div>
 

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -16,7 +16,7 @@
       <i class="bi bi-dot"></i>
       <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
     </div>
-    <div class="<%= selection_classes %>"> 
+    <div class="<%= selection_classes %>">
       <h4 class="<%= banner_display %>">
         New
       </h4>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -1,5 +1,7 @@
 <%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id) }) do |f| %>
-  <div data-appointment-target="banner" class="selected-appointment d-none"></div>
+  <div data-appointment-target="banner" class="selected-appointment d-none" 
+   data-appointment-date="<%= @appointment&.date %>" data-appointment-start="<%= @appointment&.start_time %>"
+   data-appointment-stop="<%= @appointment&.stop_time %>"></div>
 
   <div class="modal-body">
     <div>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -1,25 +1,5 @@
 <%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id) }) do |f| %>
-  <%
-    banner_display = @appointment.date.present? ? '' : 'd-none'
-    selection_classes =  @appointment.date.present? ? 'ms-3 ' : ''
-  %>
-  <div data-appointment-target="banner" class="selected-appointment d-flex flex-row <%= banner_display %>">
-    <div data-appointment-target-="current" class="w-50 border-end <%= banner_display %>">
-      <h4>Current</h4>
-      <%= @appointment.date&.strftime('%b %e, %Y') %>
-      <i class="bi bi-dot"></i>
-      <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
-    </div>
-    <div class="<%= selection_classes %>">
-      <h4 class="<%= banner_display %>">
-        New
-      </h4>
-      <div data-appointment-target="selection">
-        Select date and time
-      </div>
-    </div>
-  </div>
-
+  <%= render Aeon::AppointmentSelectionComponent.new(appointment: @appointment) %>
   <div class="modal-body">
     <div>
       <%= f.hidden_field :reading_room_id %>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -1,7 +1,24 @@
 <%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id) }) do |f| %>
-  <div data-appointment-target="banner" class="selected-appointment d-none" 
-   data-appointment-date="<%= @appointment&.date %>" data-appointment-start="<%= @appointment&.start_time %>"
-   data-appointment-stop="<%= @appointment&.stop_time %>"></div>
+  <%
+    banner_display = @appointment.date.present? ? '' : 'd-none'
+    selection_classes =  @appointment.date.present? ? 'ms-3 ' : ''
+  %>
+  <div data-appointment-target="banner" class="selected-appointment d-flex flex-row <%= banner_display %>">
+    <div data-appointment-target-="current" class="w-50 border-end <%= banner_display %>">
+      <h4>Current</h4>
+      <%= @appointment.date&.strftime('%b %e, %Y') %>
+      <i class="bi bi-dot"></i>
+      <%= @appointment.start_time&.strftime('%l:%M %p') %> - <%= @appointment.stop_time&.strftime('%l:%M %p') %>
+    </div>
+    <div class="<%= selection_classes %>"> 
+      <h4 class="<%= banner_display %>">
+        New
+      </h4>
+      <div data-appointment-target="selection">
+        Select date and time
+      </div>
+    </div>
+  </div>
 
   <div class="modal-body">
     <div>
@@ -18,7 +35,7 @@
     <div class="mb-3">
       <%= f.label :date, class: 'd-block fw-semibold redesign-required-label' %>
       <div class="d-flex align-items-center gap-2">
-        <%= f.date_field :date, required: true, data: { action: 'appointment#refreshAvailability' }, min: (@appointment.reading_room.next_appointment.start_time.to_date.iso8601 if @appointment.reading_room&.next_appointment), class: 'border rounded px-2 py-1' %>
+        <%= f.date_field :date, value: "", required: true, data: { action: 'appointment#refreshAvailability' }, min: (@appointment.reading_room.next_appointment.start_time.to_date.iso8601 if @appointment.reading_room&.next_appointment), class: 'border rounded px-2 py-1' %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>
       </div>
     </div>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -2,12 +2,6 @@
   <%
     banner_display = @appointment.date.present? ? '' : 'd-none'
     selection_classes =  @appointment.date.present? ? 'ms-3 ' : ''
-    requests_message = ''
-    if @appointment.requests.present?
-      requests_number = @appointment.requests.length
-      item_text = requests_number > 1 ? 'items' : 'item'
-      requests_message = "#{requests_number} #{item_text} will move to the new appointment." 
-    end
   %>
   <div data-appointment-target="banner" class="selected-appointment d-flex flex-row <%= banner_display %>">
     <div data-appointment-target-="current" class="w-50 border-end <%= banner_display %>">
@@ -77,8 +71,8 @@
         <div class="selection-message">Select a reading room, date, and duration to see available appointments.</div>
       </turbo-frame>
     <% end %>
-    <% if requests_message.present? %>
-      <div class="alert alert-info"><%= requests_message %></div>
+    <% if @appointment.requests.any? %>
+      <div class="alert alert-info"><%= pluralize(@appointment.requests.length, 'item') %> will move to the new appointment.</div>
     <% end %>
   </div>
 

--- a/app/views/aeon_appointments/edit.html+modal.erb
+++ b/app/views/aeon_appointments/edit.html+modal.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag params[:modal] do %>
   <div class="modal-header">
-    <%= render Aeon::AppointmentHeadingComponent.new(reading_room: @appointment&.reading_room) do %>Edit appointment<% end %>
+    <%= render Aeon::AppointmentHeadingComponent.new(reading_room: @appointment&.reading_room) do %>Change appointment<% end %>
     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
   </div>
 

--- a/spec/components/aeon/appointment_selection_component_spec.rb
+++ b/spec/components/aeon/appointment_selection_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::AppointmentSelectionComponent, type: :component do
+  context 'with existing appointment' do
+    let(:appointment) { build(:aeon_appointment) }
+
+    before do
+      render_inline(described_class.new(appointment:))
+    end
+
+    it 'renders existing appointment time and date and placeholder for date and time to be selected' do
+      within('.selected-appointment ') do
+        expect(page).to have_css('h4', text: 'Current')
+        expect(page).to have_text('Mar 11, 2024')
+        expect(page).to have_text('1:00 PM -  1:15 PM')
+        expect(page).to have_css('h4', text: 'New')
+        expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date and time')
+      end
+    end
+  end
+
+  context 'with new appointment' do
+    before do
+      render_inline(described_class.new(appointment: Aeon::Appointment.new))
+    end
+
+    it 'renders only the selection placeholder to be hidden' do
+      expect(page).to have_no_text('Current')
+      expect(page).to have_no_text('New')
+      expect(page).to have_css('div[data-appointment-target="selection"].d-none')
+    end
+  end
+end

--- a/spec/components/aeon/appointment_selection_component_spec.rb
+++ b/spec/components/aeon/appointment_selection_component_spec.rb
@@ -42,15 +42,33 @@ RSpec.describe Aeon::AppointmentSelectionComponent, type: :component do
     end
   end
 
-  context 'with new appointment' do
+  context 'with new appointment for reading room with date and time' do
+    let(:appointment) { Aeon::Appointment.new }
+
     before do
-      render_inline(described_class.new(appointment: Aeon::Appointment.new))
+      appointment.reading_room = Aeon::ReadingRoom.from_dynamic(reading_rooms[2])
+      render_inline(described_class.new(appointment:))
     end
 
     it 'renders only the selection placeholder to be hidden' do
       expect(page).to have_no_text('Current')
       expect(page).to have_no_text('New')
-      expect(page).to have_css('div[data-appointment-target="selection"].d-none')
+      expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date and time')
+    end
+  end
+
+  context 'with new appointment for reading room that is day only' do
+    let(:appointment) { Aeon::Appointment.new }
+
+    before do
+      appointment.reading_room = Aeon::ReadingRoom.from_dynamic(reading_rooms[3])
+      render_inline(described_class.new(appointment:))
+    end
+
+    it 'renders only the selection placeholder to be hidden' do
+      expect(page).to have_no_text('Current')
+      expect(page).to have_no_text('New')
+      expect(page).to have_no_css('div[data-appointment-target="selection"]')
     end
   end
 end

--- a/spec/components/aeon/appointment_selection_component_spec.rb
+++ b/spec/components/aeon/appointment_selection_component_spec.rb
@@ -3,15 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe Aeon::AppointmentSelectionComponent, type: :component do
-  context 'with existing appointment' do
+  let(:reading_rooms) { JSON.load_file('spec/fixtures/reading_rooms.json') }
+
+  context 'with existing appointment and day only appointment reading room' do
     let(:appointment) { build(:aeon_appointment) }
 
     before do
       render_inline(described_class.new(appointment:))
     end
 
-    it 'renders existing appointment time and date and placeholder for date and time to be selected' do
-      within('.selected-appointment ') do
+    it 'renders existing appointment time and date and placeholder for date to be selected' do
+      within('.selected-appointment') do
+        expect(page).to have_css('h4', text: 'Current')
+        expect(page).to have_text('Mar 11, 2024')
+        expect(page).to have_no_text('1:00 PM -  1:15 PM')
+        expect(page).to have_css('h4', text: 'New')
+        expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date')
+      end
+    end
+  end
+
+  context 'with existing appointment and reading room with date and time' do
+    let(:appointment) { build(:aeon_appointment) }
+
+    before do
+      appointment.reading_room = Aeon::ReadingRoom.from_dynamic(reading_rooms[2])
+      render_inline(described_class.new(appointment:))
+    end
+
+    it 'renders existing appointment time and date and placeholder for date to be selected' do
+      within('.selected-appointment') do
         expect(page).to have_css('h4', text: 'Current')
         expect(page).to have_text('Mar 11, 2024')
         expect(page).to have_text('1:00 PM -  1:15 PM')

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe 'Appointments', :js do
         expect(page).to have_text 'Select date'
         expect(page).to have_text '1 item will move to the new appointment.'
         # Input a date a month from now
-        fill_in 'aeon_appointment_date', with:  (Date.today >> 1).strftime('%m%d%Y')
-        expect(page).to have_text (Date.today >> 1).strftime('%b %e, %Y')
+        fill_in 'aeon_appointment_date', with: (Time.zone.today >> 1).strftime('%m%d%Y')
+        expect(page).to have_text (Time.zone.today >> 1).strftime('%b %e, %Y')
         click_on 'Cancel'
       end
       expect(page).to have_no_css '.modal'

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -85,8 +85,14 @@ RSpec.describe 'Appointments', :js do
     it 'opens and closes the edit appointment modal' do
       click_on 'Edit'
       within '.modal' do
-        expect(page).to have_text 'Edit appointment'
+        expect(page).to have_text 'Change appointment'
         expect(page).to have_text 'Field Reading Room'
+        expect(page).to have_text 'Current'
+        expect(page).to have_text appointment.date.strftime('%b %e, %Y')
+        expect(page).to have_text appointment.start_time.strftime('%l:%M %p')
+        expect(page).to have_text 'New'
+        expect(page).to have_text 'Select date and time'
+        expect(page).to have_text '1 item will move to the new appointment.'
         click_on 'Cancel'
       end
       expect(page).to have_no_css '.modal'

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -82,17 +82,20 @@ RSpec.describe 'Appointments', :js do
   end
 
   describe 'edit appointment modal' do
-    it 'opens and closes the edit appointment modal' do
+    it 'opens and closes modal for day only reading room' do
       click_on 'Edit'
       within '.modal' do
         expect(page).to have_text 'Change appointment'
         expect(page).to have_text 'Field Reading Room'
         expect(page).to have_text 'Current'
         expect(page).to have_text appointment.date.strftime('%b %e, %Y')
-        expect(page).to have_text appointment.start_time.strftime('%l:%M %p')
+        expect(page).to have_no_text appointment.start_time.strftime('%l:%M %p')
         expect(page).to have_text 'New'
-        expect(page).to have_text 'Select date and time'
+        expect(page).to have_text 'Select date'
         expect(page).to have_text '1 item will move to the new appointment.'
+        # Input a date a month from now
+        fill_in 'aeon_appointment_date', with:  (Date.today >> 1).strftime('%m%d%Y')
+        expect(page).to have_text (Date.today >> 1).strftime('%b %e, %Y')
         click_on 'Cancel'
       end
       expect(page).to have_no_css '.modal'


### PR DESCRIPTION
Closes #2851 

Create appointment modal screenshots for East Asia (i.e. a library we want both date and time for and the banner to show up for creation as well)

<img width="778" height="803" alt="Screenshot 2026-05-12 at 2 07 10 PM" src="https://github.com/user-attachments/assets/8a005858-5777-47fe-bec2-4c3aa103c617" />
--
<img width="795" height="792" alt="Screenshot 2026-05-12 at 2 07 17 PM" src="https://github.com/user-attachments/assets/c61d718e-df6c-4a76-b373-69e99433c003" />

---
Edit appointment modal screenshots for East Asia

<img width="791" height="892" alt="Screenshot 2026-05-12 at 2 09 29 PM" src="https://github.com/user-attachments/assets/112611b7-0328-4cb1-8e08-ea5f4a97453a" />
--
<img width="798" height="891" alt="Screenshot 2026-05-12 at 2 09 40 PM" src="https://github.com/user-attachments/assets/63faa898-722a-4a54-8bd0-4dd9ad326bed" />
---

Create appointment modal for Field (i.e. day only library)
This shows that the banner is not there at all - which is what we want.

<img width="796" height="339" alt="Screenshot 2026-05-12 at 2 10 59 PM" src="https://github.com/user-attachments/assets/5d4ce9af-2614-41ac-9126-e290b6538927" />

---
Edit appointment modal for Field 
<img width="792" height="415" alt="Screenshot 2026-05-12 at 2 13 17 PM" src="https://github.com/user-attachments/assets/e49da3ec-986e-4476-ae12-0950fe9c5603" />

<img width="788" height="411" alt="Screenshot 2026-05-12 at 2 11 59 PM" src="https://github.com/user-attachments/assets/8c0085ad-038e-4c78-9593-9a0ee69cc38c" />





