### PR TITLE
Use the reading room lead time from Aeon in the alert

### DIFF
--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -50,7 +50,7 @@ module Aeon
     end
 
     def edit_policy
-      reading_room.policies.first.appointment_min_lead_days
+      reading_room.appointment_min_lead_days
     end
 
     def editable?

--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -87,6 +87,10 @@ module Aeon
       day_groups.join(', ')
     end
 
+    def appointment_min_lead_days
+      policies.first.appointment_min_lead_days
+    end
+
     def next_appointment
       @next_appointment ||= available_appointments(Time.zone.now.to_date, include_next_available: true)&.first
     end

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -8,7 +8,7 @@
 
     <%= render AlertComponent.new(type: :info) do %>
       <ul class="mb-0">
-        <li>An appointment must be scheduled at least 3 business days in advance to access items.</li>
+        <li>An appointment must be scheduled at least <%= @appointment.reading_room.appointment_min_lead_days %> business days in advance to access items.</li>
         <li><%= @appointment.reading_room.name %> is open <%= @appointment.reading_room.human_readable_hours %>.</li>
       </ul>
     <% end %>

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Appointments', :js do
         click_on 'Continue'
 
         expect(page).to have_text 'Create new appointment Field Reading Room', normalize_ws: true
-        expect(page).to have_text 'An appointment must be scheduled at least 3 business days in advance to access items'
+        expect(page).to have_text 'An appointment must be scheduled at least 5 business days in advance to access items'
         expect(page).to have_text 'Field Reading Room is open Monday - Friday, 9:00 - 4:45 pm'
         expect(page).to have_field('aeon_appointment[date]', type: 'date')
         expect(page).to have_no_text('Duration')


### PR DESCRIPTION
Part of #3525

<img width="743" height="106" alt="Screenshot 2026-05-05 at 3 16 08 PM" src="https://github.com/user-attachments/assets/d7be2a81-0d99-4573-a692-bfd6da17a625" />
