### PR TITLE
Make the appointment heading responsive

### DIFF
--- a/app/components/aeon/appointment_heading_component.html.erb
+++ b/app/components/aeon/appointment_heading_component.html.erb
@@ -1,3 +1,3 @@
 <%= content_tag(tag, class: classes.presence) do %>
-  <%= content %><% if reading_room %><i class="bi bi-dot mt-1"></i><span class="h3 my-1"><%= reading_room.name %></span><% end %>
+  <%= content %><% if reading_room %><i class="bi bi-dot mt-1 d-none d-lg-inline-block"></i><span class="h3 my-1"><%= reading_room.name %></span><% end %>
 <% end %>

--- a/app/components/aeon/appointment_heading_component.rb
+++ b/app/components/aeon/appointment_heading_component.rb
@@ -3,7 +3,8 @@
 module Aeon
   # Heading that optionally appends a reading room name after a dot separator.
   class AppointmentHeadingComponent < ViewComponent::Base
-    def initialize(reading_room: nil, tag: :h1, classes: %w[d-flex align-items-center mb-0])
+    def initialize(reading_room: nil, tag: :h1,
+                   classes: %w[d-flex flex-column flex-lg-row align-items-start align-items-lg-center mb-0])
       @reading_room = reading_room
       @tag = tag
       @classes = Array(classes)


### PR DESCRIPTION
Before:
<img width="489" height="150" alt="Screenshot 2026-05-06 at 8 19 19 AM" src="https://github.com/user-attachments/assets/f9e68a3c-4629-4f0a-943c-8c019f419450" />


After:
<img width="491" height="147" alt="Screenshot 2026-05-06 at 8 19 45 AM" src="https://github.com/user-attachments/assets/c6056bf7-0999-453a-90d5-e466dd8641c5" />

With room:
<img width="826" height="130" alt="Screenshot 2026-05-06 at 8 19 54 AM" src="https://github.com/user-attachments/assets/cbe22b89-4ca3-4efb-839a-0e786c66076f" />
