### PR TITLE
Keep the duration and available time buttons on one line more often

### DIFF
--- a/app/components/aeon/appointment_duration_selector_component.html.erb
+++ b/app/components/aeon/appointment_duration_selector_component.html.erb
@@ -5,7 +5,7 @@
   <% [30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours].each do |duration| %>
     <span class="duration-selector" data-appointment-target="duration" data-seconds="<%= duration %>">
       <%= form.radio_button :duration, duration.to_i, class: 'btn-check', checked: selected == duration.to_i, data: { action: 'appointment#applyDurationFilter' } %>
-      <%= form.label "duration_#{duration.to_i}", duration.inspect, class: 'btn border' %>
+      <%= form.label "duration_#{duration.to_i}", duration.inspect.sub('minutes', 'min'), class: 'btn border px-1' %>
     </span>
   <% end %>
   </div>

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -12,7 +12,7 @@
         <div class="flex-wrap gap-3 appointment-slots">
         <% @available_appointments.select { |x| x.start_time.to_date == @date }.each do |appointment| %>
           <%= f.radio_button :start_time, l(appointment.start_time, format: :time_only), required: true, id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { timestamp: appointment.start_time.to_i, maximum_appointment_length: appointment.maximum_appointment_length, action: 'click->appointment#updateBanner'  }, class: 'btn-check', checked: @selected_time == l(appointment.start_time, format: :time_only) %>
-          <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border' %>
+          <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border px-1' %>
         <% end %>
         </div>
       </fieldset>


### PR DESCRIPTION
This bugs me. I'm not sure if it bothers anybody else 😄 

Before:
<img width="693" height="474" alt="Screenshot 2026-05-06 at 9 10 48 AM" src="https://github.com/user-attachments/assets/70942480-a680-44be-aead-1f7ce4c3e1e2" />

After:
<img width="500" height="493" alt="Screenshot 2026-05-06 at 9 21 19 AM" src="https://github.com/user-attachments/assets/9e0ae88a-2807-4a22-9803-7781c30a8cfe" />
<img width="741" height="497" alt="Screenshot 2026-05-06 at 9 25 23 AM" src="https://github.com/user-attachments/assets/20bd2163-c147-4451-8b77-a9eb71b1abb6" />
