### PR TITLE
Maintain a min-height for appointment slots

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -529,6 +529,20 @@ label.btn-close {
   display: flex;
 }
 
+/* Maintain a relatively fixed height for appointment slots, to maintain the position of the save button */
+/* 3.125rem is slot size (height + gap), 2rem is for the fieldset legend */
+.modal-dialog.modal-lg .appointment-slots-container {
+  /* modal-lg fits 4 per row at this size */
+  @media (min-width: 576px) {
+    min-height: calc(3.125rem * round(up, var(--appointment-slots), 4) / 4 + 2rem);
+  }
+
+  /* modal-lg fits 6 per row at this size */
+  @media (min-width: 992px) {
+    min-height: calc(3.125rem * round(up, var(--appointment-slots), 6) / 6 + 2rem);
+  }
+}
+
 #available_appointments:not(.form-incomplete)[busy=""] {
   .loading-overlay {
     display: flex;

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -8,11 +8,9 @@ class AeonReadingRoomsController < ApplicationController
 
   before_action :load_reading_rooms
   before_action :load_reading_room
+  before_action :load_appointments
 
   def available
-    @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
-    @available_appointments = @reading_room.available_appointments(@date, include_next_available: true)
-    @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
     @selected_time = params[:selected]
 
     respond_to do |format|
@@ -31,5 +29,12 @@ class AeonReadingRoomsController < ApplicationController
     reading_room_id = params.expect(:id).to_i
 
     @reading_room = @reading_rooms.find { |rr| rr.id == reading_room_id }
+  end
+
+  def load_appointments
+    @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
+    @available_appointments = @reading_room.available_appointments(@date, include_next_available: true)
+    @available_appointments_on_selected_date = @available_appointments.select { |x| x.start_time.to_date == @date }
+    @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
   end
 end

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -7,17 +7,19 @@
       <% end %>
     <% else %>
       <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, selected:  params['duration'].to_i) %>
-      <fieldset class="mb-3" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
-        <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
-        <div class="flex-wrap gap-3 appointment-slots">
-        <% @available_appointments.select { |x| x.start_time.to_date == @date }.each do |appointment| %>
-          <%= f.radio_button :start_time, l(appointment.start_time, format: :time_only), required: true, id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { timestamp: appointment.start_time.to_i, maximum_appointment_length: appointment.maximum_appointment_length, action: 'click->appointment#updateBanner'  }, class: 'btn-check', checked: @selected_time == l(appointment.start_time, format: :time_only) %>
-          <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border px-1' %>
-        <% end %>
-        </div>
-      </fieldset>
-      <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
-      <div class="alert alert-info select">Select a reading room, date, and duration to see available appointments.</div>
+      <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments_on_selected_date.count %>">
+        <fieldset class="mb-3" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
+          <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
+          <div class="flex-wrap gap-3 appointment-slots">
+            <% @available_appointments_on_selected_date.each do |appointment| %>
+              <%= f.radio_button :start_time, l(appointment.start_time, format: :time_only), required: true, id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { timestamp: appointment.start_time.to_i, maximum_appointment_length: appointment.maximum_appointment_length, action: 'click->appointment#updateBanner'  }, class: 'btn-check', checked: @selected_time == l(appointment.start_time, format: :time_only) %>
+              <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border px-1' %>
+            <% end %>
+          </div>
+        </fieldset>
+        <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
+        <div class="alert alert-info select">Select a reading room, date, and duration to see available appointments.</div>
+      </div>
     <% end %>
     <% if params[:date] && next_appt = @available_appointments.find { |x| x.start_time.to_date > @date } %>
       <div>


### PR DESCRIPTION
Part of #3525 

Sets a `min-height` for the appointment slot container when the modal is at predictable breakpoints. At smaller sizes the `min-height` is counterproductive.

We'll still have the save button change positions during some date changes, but it should no longer jump around as the user explores durations, for the given breakpoints.