### PR TITLE
Disable turbo on the saved for later confirmation link

### DIFF
--- a/app/components/aeon/confirmation_saved_for_later_component.html.erb
+++ b/app/components/aeon/confirmation_saved_for_later_component.html.erb
@@ -1,3 +1,3 @@
 <div class="my-4">
-  <i class="bi bi-pin-angle-fill me-2 text-digital-red"></i>You <%= submitted_requests? ? 'also saved' : 'saved' %> <%= pluralize(saved_count, 'item') %> for later. <%= digital? ? 'Complete' : 'Schedule' %> them anytime at Requests &gt; <%= link_to 'Saved for later', aeon_requests_path(kind: 'drafts'), class: 'su-underline' %>.
+  <i class="bi bi-pin-angle-fill me-2 text-digital-red"></i>You <%= submitted_requests? ? 'also saved' : 'saved' %> <%= pluralize(saved_count, 'item') %> for later. <%= digital? ? 'Complete' : 'Schedule' %> them anytime at Requests &gt; <%= link_to 'Saved for later', aeon_requests_path(kind: 'drafts'), class: 'su-underline', data: { turbo: false } %>.
 </div>


### PR DESCRIPTION
https://github.com/sul-dlss/sul-requests/pull/3304 wrapped this in a turboframe, we need to break out.
<img width="303" height="138" alt="Screenshot 2026-05-07 at 3 21 21 PM" src="https://github.com/user-attachments/assets/c833694f-680e-46b6-8653-f0247cc121a6" />
