### PR TITLE
Use graphql to retrieve extra user data.

### DIFF
--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -26,8 +26,9 @@ module Folio
 
     delegate :folio_client, to: :class
 
-    def initialize(user_info = {})
+    def initialize(user_info = {}, extended_user_info: nil)
       @user_info = user_info
+      @extended_user_info = extended_user_info
     end
 
     def id

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -24,8 +24,10 @@ module Folio
 
     attr_reader :user_info
 
-    def initialize(fields = {})
-      @user_info = fields
+    delegate :folio_client, to: :class
+
+    def initialize(user_info = {})
+      @user_info = user_info
     end
 
     def id
@@ -75,9 +77,14 @@ module Folio
     end
 
     # this returns the full patronGroup object
-    def patron_group
+    def patron_group # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
       @patron_group ||= Folio::NullPatron.visitor_patron_group if expired?
       @patron_group ||= Folio::Types.patron_groups.find_by(id: patron_group_id) if patron_group_id
+
+      @patron_group ||= if extended_user_info&.dig('patronGroup').present?
+                          Folio::PatronGroup.from_dynamic(extended_user_info&.dig('patronGroup'))
+                        end
+
       @patron_group ||= Folio::NullPatron.visitor_patron_group
     end
 
@@ -124,9 +131,7 @@ module Folio
       @proxies ||= proxies_of_response.filter_map do |info|
         next nil unless valid_proxy_relation?(info)
 
-        # Find the patron corresponding to the Folio user id for the proxy
-        proxy_patron = self.class.find_by(patron_key: info['proxyUserId'])
-        proxy_patron.presence
+        self.class.new(info['proxyUser']) if info['proxyUser'].present?
       end
     end
 
@@ -136,9 +141,7 @@ module Folio
       @sponsors ||= sponsors_for_response.filter_map do |info|
         next nil unless valid_proxy_relation?(info)
 
-        # Find the patron corresponding to the Folio user id for the sponsor
-        sponsor_patron = self.class.find_by(patron_key: info['userId'])
-        sponsor_patron.presence
+        self.class.new(info['user']) if info['user'].present?
       end
     end
 
@@ -178,6 +181,10 @@ module Folio
 
     private
 
+    def extended_user_info
+      @extended_user_info ||= folio_client.extended_user_info(id)
+    end
+
     def valid_proxy_relation?(info)
       return false unless info['requestForSponsor']&.downcase == 'yes'
       return false if info['expirationDate'].present? && Time.zone.parse(info['expirationDate']).past?
@@ -194,13 +201,13 @@ module Folio
     # Get all the sponsors for this patron
     def sponsors_for_response
       @sponsors_for_response ||= user_info.dig('stubs', 'sponsors') # used for stubbing
-      @sponsors_for_response ||= self.class.folio_client.proxies(proxyUserId: id)
+      @sponsors_for_response ||= extended_user_info&.dig('proxiesFor')
     end
 
     # Get all the proxies of this patron
     def proxies_of_response
       @proxies_of_response ||= user_info.dig('stubs', 'proxies') # used for stubbing
-      @proxies_of_response ||= self.class.folio_client.proxies(userId: id)
+      @proxies_of_response ||= extended_user_info&.dig('proxiesOf')
     end
 
     def standing
@@ -213,7 +220,7 @@ module Folio
 
     def patron_blocks
       @patron_blocks ||= user_info.dig('stubs', 'patron_blocks') # used for stubbing
-      @patron_blocks ||= self.class.folio_client.patron_blocks(id).fetch('automatedPatronBlocks', [])
+      @patron_blocks ||= extended_user_info&.dig('blocks')
     end
 
     # Encryptor/decryptor for the token used in the PIN reset process

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -99,11 +99,7 @@ class FolioClient
     check_response(response, title: 'Assign pin', context: { user_id: })
   end
 
-  def proxies(**args)
-    response = get_json('/proxiesfor', params: { query: CqlQuery.new(**args).to_query })
-
-    response['proxiesFor']
-  end
+  delegate :extended_user_info, to: :folio_graphql_client
 
   def patron_account(patron_key)
     get_json("/patron/account/#{CGI.escape(patron_key)}", params: {
@@ -111,10 +107,6 @@ class FolioClient
                includeCharges: true,
                includeHolds: true
              })
-  end
-
-  def patron_blocks(user_id)
-    get_json("/automated-patron-blocks/#{user_id}")
   end
 
   # Defines the hold request data for Folio

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -228,6 +228,87 @@ class FolioGraphqlClient
     data.dig('data', 'loanPolicies')
   end
 
+  def extended_user_info(patron_uuid)
+    data = post_json('/', json: {
+                       query: "query Query($patronId: UUID!) {
+                                 user {
+                                    username
+                                    barcode
+                                    active
+                                    personal {
+                                      email
+                                      lastName
+                                      firstName
+                                      preferredFirstName
+                                    }
+                                    proxiesFor {
+                                      userId
+                                      requestForSponsor
+                                      status
+                                      expirationDate
+                                      user {
+                                        id
+                                        barcode
+                                        personal {
+                                          firstName
+                                          preferredFirstName
+                                          lastName
+                                        }
+                                      }
+                                    }
+                                    proxiesOf {
+                                      proxyUserId
+                                      requestForSponsor
+                                      status
+                                      expirationDate
+                                      proxyUser {
+                                        id
+                                        barcode
+                                        personal {
+                                          firstName
+                                          preferredFirstName
+                                          lastName
+                                        }
+                                      }
+                                    }
+                                    expirationDate
+                                    externalSystemId
+                                    patronGroup {
+                                      id
+                                      desc
+                                      group
+                                      limits {
+                                        conditionId
+                                        id
+                                        patronGroupId
+                                        value
+                                        condition {
+                                          blockBorrowing
+                                          blockRenewals
+                                          blockRequests
+                                          message
+                                          name
+                                          valueType
+                                        }
+                                      }
+                                    }
+                                    blocks {
+                                      message
+                                    }
+                                    manualBlocks {
+                                      desc
+                                    }
+                                    patronGroupId
+                                  }
+                              }",
+                       variables: { patronId: patron_uuid }
+                     })
+
+    Honeybadger.notify(data['errors'].pluck('message').join("\n"), context: { patron_uuid: }) if data.key?('errors')
+
+    data.dig('data', 'user')
+  end
+
   def patron_info(patron_uuid)
     data = post_json('/', json: {
                        query: "query Query($patronId: UUID!) {

--- a/spec/models/folio/patron_spec.rb
+++ b/spec/models/folio/patron_spec.rb
@@ -5,9 +5,12 @@ require 'rails_helper'
 RSpec.describe Folio::Patron do
   subject(:patron) do
     described_class.new(
-      fields.deep_stringify_keys
+      fields.deep_stringify_keys, extended_user_info: extended_user_info&.deep_stringify_keys
     )
   end
+
+  let(:fields) { {} }
+  let(:extended_user_info) { nil }
 
   context 'when the patron is a fee borrower' do
     let(:patron_group_id) { '985acbb9-f7a7-4f44-9b34-458c02a78fbc' } # fee borrower
@@ -105,39 +108,42 @@ RSpec.describe Folio::Patron do
     let(:fields) do
       {
         id: 'sponsor',
-        personal: { firstName: 'Sponsor' },
-        stubs: {
-          proxies: [
-            {
-              proxyUserId: 'proxy1',
-              requestForSponsor: 'Yes',
-              status: 'Active',
-              proxyUser: {
-                id: 'proxy1'
-              }
-            },
-            {
-              proxyUserId: 'proxy2',
-              requestForSponsor: 'Yes',
-              status: 'Active',
-              proxyUser: {
-                id: 'proxy2'
-              }
-            },
-            {
-              proxyUserId: 'proxy-expired',
-              requestForSponsor: 'Yes',
-              expirationDate: '2023-05-20T00:13:20.324+00:00',
-              status: 'Active'
-            },
-            {
-              proxyUserId: 'proxy-inactive',
-              requestForSponsor: 'Yes',
-              expirationDate: '2051-05-20T00:13:20.324+00:00',
-              status: 'Inactive'
+        personal: { firstName: 'Sponsor' }
+      }
+    end
+
+    let(:extended_user_info) do
+      {
+        proxiesOf: [
+          {
+            proxyUserId: 'proxy1',
+            requestForSponsor: 'Yes',
+            status: 'Active',
+            proxyUser: {
+              id: 'proxy1'
             }
-          ]
-        }
+          },
+          {
+            proxyUserId: 'proxy2',
+            requestForSponsor: 'Yes',
+            status: 'Active',
+            proxyUser: {
+              id: 'proxy2'
+            }
+          },
+          {
+            proxyUserId: 'proxy-expired',
+            requestForSponsor: 'Yes',
+            expirationDate: '2023-05-20T00:13:20.324+00:00',
+            status: 'Active'
+          },
+          {
+            proxyUserId: 'proxy-inactive',
+            requestForSponsor: 'Yes',
+            expirationDate: '2051-05-20T00:13:20.324+00:00',
+            status: 'Inactive'
+          }
+        ]
       }
     end
 
@@ -150,39 +156,42 @@ RSpec.describe Folio::Patron do
     let(:fields) do
       {
         id: 'proxy',
-        personal: { firstName: 'Proxy' },
-        stubs: {
-          sponsors: [
-            {
-              userId: 'sponsor1',
-              requestForSponsor: 'Yes',
-              status: 'Active',
-              user: {
-                id: 'sponsor1'
-              }
-            },
-            {
-              userId: 'sponsor2',
-              requestForSponsor: 'Yes',
-              status: 'Active',
-              user: {
-                id: 'sponsor2'
-              }
-            },
-            {
-              userId: 'sponsor-expired',
-              requestForSponsor: 'Yes',
-              expirationDate: '2023-05-20T00:13:20.324+00:00',
-              status: 'Active'
-            },
-            {
-              userId: 'sponsor-inactive',
-              requestForSponsor: 'Yes',
-              expirationDate: '2051-05-20T00:13:20.324+00:00',
-              status: 'Inactive'
+        personal: { firstName: 'Proxy' }
+      }
+    end
+
+    let(:extended_user_info) do
+      {
+        proxiesFor: [
+          {
+            userId: 'sponsor1',
+            requestForSponsor: 'Yes',
+            status: 'Active',
+            user: {
+              id: 'sponsor1'
             }
-          ]
-        }
+          },
+          {
+            userId: 'sponsor2',
+            requestForSponsor: 'Yes',
+            status: 'Active',
+            user: {
+              id: 'sponsor2'
+            }
+          },
+          {
+            userId: 'sponsor-expired',
+            requestForSponsor: 'Yes',
+            expirationDate: '2023-05-20T00:13:20.324+00:00',
+            status: 'Active'
+          },
+          {
+            userId: 'sponsor-inactive',
+            requestForSponsor: 'Yes',
+            expirationDate: '2051-05-20T00:13:20.324+00:00',
+            status: 'Inactive'
+          }
+        ]
       }
     end
 

--- a/spec/models/folio/patron_spec.rb
+++ b/spec/models/folio/patron_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Folio::Patron do
     end
 
     describe '#make_request_as_patron?' do
-      let(:folio_client) { instance_double(FolioClient, patron_blocks:) }
-      let(:patron_blocks) do
-        { 'automatedPatronBlocks' => [
+      let(:folio_client) { instance_double(FolioClient, extended_user_info:) }
+      let(:extended_user_info) do
+        { 'blocks' => [
           {
             patronBlockConditionId: 'ac13a725-b25f-48fa-84a6-4af021d13afe',
             blockBorrowing: false,
@@ -111,12 +111,18 @@ RSpec.describe Folio::Patron do
             {
               proxyUserId: 'proxy1',
               requestForSponsor: 'Yes',
-              status: 'Active'
+              status: 'Active',
+              proxyUser: {
+                id: 'proxy1'
+              }
             },
             {
               proxyUserId: 'proxy2',
               requestForSponsor: 'Yes',
-              status: 'Active'
+              status: 'Active',
+              proxyUser: {
+                id: 'proxy2'
+              }
             },
             {
               proxyUserId: 'proxy-expired',
@@ -134,19 +140,8 @@ RSpec.describe Folio::Patron do
         }
       }
     end
-    let(:patron_one) { instance_double(described_class, id: 'proxy1', display_name: 'Proxy One') }
-    let(:patron_two) { instance_double(described_class, id: 'proxy2', display_name: 'Proxy Two') }
-
-    let(:stub_client) { FolioClient.new }
-
-    before do
-      allow(FolioClient).to receive(:new).and_return(stub_client)
-    end
 
     it 'retrieves the names of the proxy user ids correctly' do
-      allow(described_class).to receive(:find_by).with(patron_key: 'proxy1').and_return(patron_one)
-      allow(described_class).to receive(:find_by).with(patron_key: 'proxy2').and_return(patron_two)
-
       expect(patron.proxies.length).to eq 2
     end
   end
@@ -161,12 +156,18 @@ RSpec.describe Folio::Patron do
             {
               userId: 'sponsor1',
               requestForSponsor: 'Yes',
-              status: 'Active'
+              status: 'Active',
+              user: {
+                id: 'sponsor1'
+              }
             },
             {
               userId: 'sponsor2',
               requestForSponsor: 'Yes',
-              status: 'Active'
+              status: 'Active',
+              user: {
+                id: 'sponsor2'
+              }
             },
             {
               userId: 'sponsor-expired',
@@ -184,17 +185,8 @@ RSpec.describe Folio::Patron do
         }
       }
     end
-    let(:sponsor_one) { instance_double(described_class, id: 'sponsor1', display_name: 'Sponsor One') }
-    let(:sponsor_two) { instance_double(described_class, id: 'sponsor2', display_name: 'Sponsor Two') }
-    let(:stub_client) { FolioClient.new }
-
-    before do
-      allow(FolioClient).to receive(:new).and_return(stub_client)
-    end
 
     it 'retrieves the names of the sponsor user ids correctly' do
-      allow(described_class).to receive(:find_by).with(patron_key: 'sponsor1').and_return(sponsor_one)
-      allow(described_class).to receive(:find_by).with(patron_key: 'sponsor2').and_return(sponsor_two)
       expect(patron.sponsors.length).to eq 2
     end
   end


### PR DESCRIPTION
MyLibrary is using graphql to package a lot of the user data we already need, so this PR incrementally replaces existing requests behavior with equivalent graphql calls. 

Unlike MyLibrary, which pretty much needs all the patron information about checkouts, requests, etc to draw any page, requests probably should be more selective (for performance reasons, if nothing else). This may cause multiple graphql calls, but should defer the "worst" calls until we actually need the data. 

Possible next steps include:
- pulling over the rest of the patron data from mylibrary (e.g. #3613)
- switch to using the graphql patron group information primarily (requires reworking some factories + tests)
- eagerly requesting the user graphql response if we already have the patron key (and using that instead of making a mod-users call at all)
 