### PR TITLE
Remove unused requests#index action

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -4,8 +4,6 @@
 #  Old requests controller that redirects new requests to the PatronRequestsController
 ###
 class RequestsController < ApplicationController
-  def index; end
-
   def new
     mapped_params = { 'instance_hrid' => new_params[:item_id],
                       'origin_location_code' => new_params[:origin_location],


### PR DESCRIPTION
This was left-over from a first attempt at scaffolding aeon requests (abandoned for `AeonRequestsController`)