### PR TITLE
Disable bootsnap when running coverage

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+require "bootsnap/setup" unless defined?(Coverage) && Coverage.running?


### PR DESCRIPTION
Seeing the following error in CI after dep updates:
```
An error occurred while loading ./spec/components/aeon/appointment_limit_component_spec.rb.
Failure/Error: require File.expand_path('../../config/environment', __FILE__)

RuntimeError:
  should not compile with coverage
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache/iseq.rb:32:in 'RubyVM::InstructionSequence#to_binary'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache/iseq.rb:32:in '<class:Compiler>'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache/iseq.rb:22:in '<module:ISeq>'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache/iseq.rb:8:in '<module:CompileCache>'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache/iseq.rb:7:in '<module:Bootsnap>'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache/iseq.rb:6:in '<top (required)>'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache.rb:19:in 'Kernel#require_relative'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/compile_cache.rb:19:in 'Bootsnap::CompileCache.setup'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap.rb:79:in 'Bootsnap.setup'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap.rb:144:in 'Bootsnap.default_setup'
# ./vendor/bundle/ruby/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap/setup.rb:5:in '<top (required)>'
# ./config/boot.rb:4:in '<top (required)>'
# ./config/application.rb:1:in 'Kernel#require_relative'
# ./config/application.rb:1:in '<top (required)>'
# ./config/environment.rb:2:in 'Kernel#require_relative'
# ./config/environment.rb:2:in '<top (required)>'
# ./spec/rails_helper.rb:6:in '<top (required)>'
# ./spec/components/aeon/appointment_limit_component_spec.rb:3:in '<top (required)>'
```

Something in the Ruby 4.0.4 release?

Maybe https://bugs.ruby-lang.org/issues/22018?