### PR TITLE
fix appt modal fixed height bug when date is selected

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -575,6 +575,11 @@ label.btn-close {
   fieldset > *:not(legend) {
     display: none;
   }
+
+  .appointment-slots-container {
+    --appointment-slots: 0!important;
+  }
+
   .selection-message {
     display: block;
   }


### PR DESCRIPTION
Before:

<img width="810" height="800" alt="Screenshot 2026-05-12 at 5 36 57 PM" src="https://github.com/user-attachments/assets/c14db8ab-7340-49ce-ac36-5fd982db90f5" />

After:
<img width="516" height="710" alt="Screenshot 2026-05-12 at 5 06 45 PM" src="https://github.com/user-attachments/assets/ae9f8518-fc9b-40a0-bb3b-f5b3a39cc784" />
