### PR TITLE
Restore class structure for the request title

### DIFF
--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -1,7 +1,8 @@
 <li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 d-grid row-gap-2 column-gap-3 text-nowrap" data-content-id="<%= dom_id %>">
   <i class="bi bi-check2 selected-item-status"></i>
   <div class="appt-title">
-    <span class="text-black fw-semibold selected-item-title text-wrap"><%= title %>
+    <span class="text-wrap">
+      <span class="text-black fw-semibold selected-item-title"><%= title %></span>
       <button class="btn btn-link d-none" data-action="view-container-contents#openViewModal"
               data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
         <i class="bi bi-list-ul"></i><span class="visually-hidden">View contents</span>


### PR DESCRIPTION
I should have done this in https://github.com/sul-dlss/sul-requests/pull/3622.

We want `selected-item-title` to be scoped for only the title, and not capture garbage from the view contents icon markup when we target elements with that class.

No visual changes.