### PR TITLE
Add closures to ReadingRoom model

### DIFF
--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -97,6 +97,10 @@ module Aeon
 
     def persisted? = id.present?
 
+    def closures
+      aeon_client.closures(reading_room_id: id)
+    end
+
     private
 
     def format_hours(reading_room_open_hours)

--- a/app/models/aeon/reading_room_closures.rb
+++ b/app/models/aeon/reading_room_closures.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Wraps an Aeon reading room closures
+  ReadingRoomClosures = Data.define(:start_date, :end_date) do
+    def self.from_dynamic(dyn)
+      new(
+        start_date: dyn['startDate'],
+        end_date: dyn['endDate']
+      )
+    end
+  end
+end

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -128,6 +128,14 @@ class AeonClient
     end
   end
 
+  def closures(reading_room_id:)
+    @closures_by_room_id ||= {}
+    @closures_by_room_id[reading_room_id] ||= Rails.cache.fetch("aeon/closures/#{reading_room_id}", expires_in: 1.hour) do
+      response = get("ReadingRooms/#{reading_room_id}/Closures")
+      handle_response(response, as_class: Aeon::ReadingRoomClosures, not_found: [])
+    end
+  end
+
   def find_queue(id:, type:)
     return unless id && type
 


### PR DESCRIPTION
This sets up https://github.com/sul-dlss/sul-requests/issues/3404 but doesn't close it yet -- we need to get the datepicker out of Lookbook and into the form first.

```bash
# this is Field
sul-requests(dev):001> r = Aeon::ReadingRoom.all.find { |rr| rr.id == 5 }
...
sul-requests(dev):002> r.closures
=> 
[#<data Aeon::ReadingRoomClosures
  start_date="2026-05-25T16:00:00Z",
  end_date="2026-05-25T23:45:00Z">,
 #<data Aeon::ReadingRoomClosures
  start_date="2026-06-15T16:55:00Z",
  end_date="2026-06-15T23:45:00Z">,
 #<data Aeon::ReadingRoomClosures
  start_date="2026-07-03T16:00:00Z",
  end_date="2026-07-03T23:45:00Z">,
 #<data Aeon::ReadingRoomClosures
  start_date="2026-09-07T16:00:00Z",
  end_date="2026-09-07T23:45:00Z">]

```