### PR TITLE
Use a card layout for checkouts

### DIFF
--- a/app/components/checkout_component.html.erb
+++ b/app/components/checkout_component.html.erb
@@ -1,81 +1,46 @@
-<li class="list-group-item <%= list_group_item_status_for_checkout %>" data-status-sort-value="<%= h checkout.sort_key(:status) %>" data-due-date-sort-value="<%= h checkout.sort_key(:due_date) %>" data-title-sort-value="<%= h checkout.sort_key(:title) %>" data-author-sort-value="<%= h checkout.sort_key(:author) %>" data-call-number-sort-value="<%= h checkout.sort_key(:call_number) %>">
-  <div class="row d-flex flex-wrap position-relative justify-content-between">
-    <div class="d-flex flex-row flex-grow-1 justify-content-between align-items-baseline col-12 row col-md-4">
-      <div class="col-6 col-md-12 col-lg-6 status">
-        <%= render_checkout_status %>
-      </div>
-      <div class="col-6 col-md-12 col-lg-6 text-right align-items-baseline text-md-left due_date">
-        <% if patron.can_renew? && checkout.renewable? %>
-          <span class="renewable-indicator">
-            <%= sul_icon 'renew' %>
-          </span>
-        <% end %>
-        <span class="d-inline d-md-none mr-2">Due</span>
-        <%= today_with_time_or_date(checkout.due_date, short_term: checkout.short_term_loan?) %>
-      </div>
-    </div>
-    <div class="order-1 order-md-1 d-flex col-10 col-md-5 align-items-baseline">
-      <h3 class="clamp clamp-3 record-title title text-reset"><%= checkout.title %></h3>
-    </div>
-    <div class="order-3 order-md-2 d-flex flex-row flex-grow-1 row col-md-3">
-      <div class="col-6 col-md-12 col-lg-6 clamp-1 author"><%= checkout.author %></div>
-      <div class="col-6 col-md-12 col-lg-6 call_number"><%= checkout.call_number %></div>
-    </div>
-    <button class="col-2 col-md order-2 order-md-3 btn collapsed stretched-link position-static" type="button" data-bs-toggle="collapse" data-bs-target="#collapseDetails-<%= checkout.key.parameterize %>" aria-expanded="false" aria-controls="collapseDetails-<%= checkout.key.parameterize %>">
-      <span class="expand-icon"><%= sul_icon :'sharp-add-24px' %><span class="sr-only">Expand</span></span>
-      <span class="collapse-icon"><%= sul_icon :'sharp-remove-24px' %><span class="sr-only">Collapse</span></span>
-    </button>
-  </div>
-  <div class="collapse w-100" id="collapseDetails-<%= checkout.key.parameterize %>">
-    <% if patron.can_renew? && checkout.renewable? %>
-      <div class="row">
-        <div class="col-11 offset-1 col-md-10 offset-md-2">
-          <%= form_tag renew_checkout_path(checkout.item_id), method: :post do %>
-            <%= hidden_field_tag :item_id, checkout.item_id %>
-            <%= hidden_field_tag :title, checkout.title %>
-            <%= hidden_field_tag :group, params[:group] if params[:group] %>
-            <%= button_tag class: 'btn btn-link btn-renewable-submit btn-icon-prefix',
-                           data: { turbo_submits_with: t('mylibrary.renew_item.in_progress_html') },
-                           type: 'submit' do %>
-              <%= sul_icon 'renew' %> Renew this item
-            <% end %>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-    <dl class="row mb-0">
-      <% if !patron.can_renew? %>
-          <dt class="col-3 offset-1 col-md-2 offset-md-2">Can I renew?</dt>
-          <dd class="col-8">No. Your status is blocked (or barred).</dd>
-      <% elsif !checkout.renewable? %>
-          <dt class="col-3 offset-1 col-md-2 offset-md-2">Can I renew?</dt>
-          <dd class="col-8"><%= checkout.non_renewable_reason %></dd>
-      <% end %>
-      <% if params[:group] %>
-        <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
-        <dd class="col-8"><%= patron.proxy_group.member_name(checkout.patron_key) %></dd>
-      <% end %>
-      <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrowed:</dt>
-      <dd class="col-8">
-        <%= today_with_time_or_date(checkout.checkout_date, short_term: checkout.short_term_loan?) %>
-      </dd>
-      <% if checkout.overdue? %>
-        <dt class="col-3 offset-1 col-md-2 offset-md-2">Days overdue:</dt>
-        <dd class="col-8"><%= checkout.days_overdue %></dd>
-        <dt class="col-3 offset-1 col-md-2 offset-md-2">Fines accrued:</dt>
-        <dd class="col-8"><%= number_to_currency(checkout.accrued) %> </dd>
-      <% else %>
-        <dt class="col-3 offset-1 col-md-2 offset-md-2">Remaining:</dt>
-        <dd class="col-8"><%= time_remaining_for_checkout %></dd>
-      <% end %>
-      <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
-      <dd class="col-8"><%= checkout.library_name %></dd>
-      <% if checkout.barcode %>
-        <dt class="col-3 offset-1 col-md-2 offset-md-2">Barcode:</dt>
-        <dd class="col-8"><%= checkout.barcode %></dd>
-      <% end %>
-    </dl>
+<%= render CardComponent.new(element: 'li', data: { 'status-sort-value': checkout.sort_key(:status), 'due-date-sort-value': checkout.sort_key(:due_date), 'title-sort-value': checkout.sort_key(:title), 'author-sort-value': checkout.sort_key(:author), 'call-number-sort-value': checkout.sort_key(:call_number)  }) do |c| %>
+  <% c.with_title do %>
+    <div class="d-flex flex-row gap-4">
+      <div>Due: <span class="fw-semibold"><%= today_with_time_or_date(checkout.due_date, short_term: checkout.short_term_loan?) %></span></div>
 
-    <%= detail_link_to_searchworks(checkout.catkey) unless checkout.from_ill? %>
-  </div>
-</li>
+      <%= render_checkout_status %>
+    </div>
+     <% if patron.can_renew? && checkout.renewable? %>
+      <%= form_tag renew_checkout_path(checkout.item_id), method: :post do %>
+        <%= hidden_field_tag :item_id, checkout.item_id %>
+        <%= hidden_field_tag :title, checkout.title %>
+        <%= hidden_field_tag :group, params[:group] if params[:group] %>
+        <%= button_tag class: 'btn btn-outline-primary btn-sm',
+                        data: { turbo_submits_with: t('mylibrary.renew_item.in_progress_html') },
+                        type: 'submit' do %>
+          <%= sul_icon 'renew' %> Renew
+        <% end %>
+      <% end %>
+    <% elsif !checkout.renewable? %>
+        <button disabled class="btn btn-outline-primary btn-disabled btn-sm"><%= sul_icon 'renew' %> <%= checkout.non_renewable_reason %></button>
+    <% end %>
+  <% end %>
+  <% c.with_footer do %>
+    <div class="d-flex flex-row gap-4 flex-wrap text-muted">
+      <% if checkout.barcode %>
+        <span>Barcode: <%= checkout.barcode %></span>
+      <% end %>
+
+      <span>Checked out:
+        <%= today_with_time_or_date(checkout.checkout_date, short_term: checkout.short_term_loan?) %>
+      </span>
+    </div>
+  <% end %>
+  <% c.with_body(classes: 'bg-white') do %>
+    <h3 class="mb-1 clamp clamp-3"><%= checkout.title %></h3>
+    <div class="row d-flex flex-wrap position-relative justify-content-between">
+      <div class="item-format"></div>
+      <div>Call number: <%= checkout.call_number %></div>
+      <%= detail_link_to_searchworks(checkout.catkey) unless checkout.from_ill? %>
+    </div>
+    <div class="clamp clamp-3 mb-1"><span class="visually-hidden">Author:</span><%= checkout.author %></div>
+    <div><span class="visually-hidden">Library:</span>
+      <%= checkout.library_name %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/checkout_component.rb
+++ b/app/components/checkout_component.rb
@@ -45,8 +45,6 @@ class CheckoutComponent < ViewComponent::Base
                            icon: 'sharp-warning-24px',
                            text: 'Overdue',
                            accrued: checkout.accrued)
-    else
-      tag.span 'OK', class: 'd-none d-md-block'
     end
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -18,9 +18,10 @@ module Folio
     SHORT_TERM_LOAN_PERIODS = %w[Hours Minutes].freeze
     FOLIO_LOST_STATUSES = ['Aged to lost', 'Declared lost'].freeze
 
-    def initialize(record, patron_type_id)
+    def initialize(record, patron_type_id, loan_policy: nil)
       @record = record
       @patron_type_id = patron_type_id
+      @loan_policy = loan_policy
     end
 
     def key

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -37,7 +37,7 @@
         <div class="col-md-12 col-lg-6 call_number" data-sort="call_number">Call number</div>
       </div>
     </div>
-    <ul class="list checkouts list-group" data-sortable-target="list" aria-live="polite">
+    <ul class="checkouts" data-sortable-target="list" aria-live="polite">
       <%= render CheckoutComponent.with_collection(other_checkouts, patron: patron_or_group) %>
     </ul>
   </div>

--- a/spec/component_previews/checkout_component_preview.rb
+++ b/spec/component_previews/checkout_component_preview.rb
@@ -3,5 +3,24 @@
 class CheckoutComponentPreview < ViewComponent::Preview
   layout 'lookbook'
 
-  def default; end
+  def default
+    render CheckoutComponent.new(
+      checkout: FactoryBot.build(:checkout, loan_policy: FactoryBot.build(:grad_mono_loans)),
+      patron: FactoryBot.build(:sponsor_patron)
+    )
+  end
+
+  def recall
+    render CheckoutComponent.new(
+      checkout: FactoryBot.build(:checkout_with_recall, loan_policy: FactoryBot.build(:grad_mono_loans)),
+      patron: FactoryBot.build(:sponsor_patron)
+    )
+  end
+
+  def overdue
+    render CheckoutComponent.new(
+      checkout: FactoryBot.build(:overdue_checkout, loan_policy: FactoryBot.build(:grad_mono_loans)),
+      patron: FactoryBot.build(:sponsor_patron)
+    )
+  end
 end

--- a/spec/component_previews/checkout_component_preview.rb
+++ b/spec/component_previews/checkout_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckoutComponentPreview < ViewComponent::Preview
+  layout 'lookbook'
+
+  def default; end
+end

--- a/spec/component_previews/checkout_component_preview/default.html.erb
+++ b/spec/component_previews/checkout_component_preview/default.html.erb
@@ -1,0 +1,6 @@
+<ul class="list checkouts list-group" data-sortable-target="list" aria-live="polite">
+  <%= render CheckoutComponent.new(
+      checkout: FactoryBot.build(:checkout, loan_policy: FactoryBot.build(:grad_mono_loans)),
+      patron: FactoryBot.build(:sponsor_patron)
+    ) %>
+</ul>

--- a/spec/component_previews/checkout_component_preview/default.html.erb
+++ b/spec/component_previews/checkout_component_preview/default.html.erb
@@ -1,6 +1,0 @@
-<ul class="list checkouts list-group" data-sortable-target="list" aria-live="polite">
-  <%= render CheckoutComponent.new(
-      checkout: FactoryBot.build(:checkout, loan_policy: FactoryBot.build(:grad_mono_loans)),
-      patron: FactoryBot.build(:sponsor_patron)
-    ) %>
-</ul>

--- a/spec/factories/folio.rb
+++ b/spec/factories/folio.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :checkout, class: 'Folio::Checkout' do
+    record do
+      { 'id' => 'f4817e08-7118-44e1-a5ab-40fc30b29ff7',
+        'item' =>
+            { 'title' =>
+              'Music, sound, language, theater',
+              'author' => 'Crown Point Press (Oakland, Calif.)',
+              'instanceId' => '7f3c7afd-4bfa-5166-a883-7016cbae016d',
+              'itemId' => '30d507db-6ac5-5574-b83c-665bd1573c07',
+              'isbn' => nil,
+              'instance' =>
+              { 'indexTitle' =>
+                'Music, sound, language, theater' },
+              'item' =>
+              { 'barcode' => '36105020835901',
+                'id' => '30d507db-6ac5-5574-b83c-665bd1573c07',
+                'status' => { 'date' => '2023-06-03T06:08:56.901+00:00', 'name' => 'Checked out' },
+                'effectiveShelvingOrder' => 'N 46494 C63 M87 41980 11',
+                'effectiveCallNumberComponents' => { 'callNumber' => 'N6494 .C63 M87 1980' },
+                'effectiveLocation' => { 'code' => 'ART-STACKS', 'library' => { 'code' => 'ART' } },
+                'permanentLocation' => { 'code' => 'ART-STACKS' } } },
+        'loanDate' => '2023-06-03T06:08:45.521+00:00',
+        'dueDate' => '2020-09-27T06:59:59.000+00:00',
+        'overdue' => false,
+        'details' =>
+            { 'renewalCount' => nil,
+              'dueDateChangedByRecall' => nil,
+              'dueDateChangedByHold' => nil,
+              'proxyUserId' => 'bdfa62a1-758c-4389-ae81-8ddb37860f9b',
+              'userId' => 'ec52d62d-9f0e-4ea5-856f-a1accb0121d1',
+              'status' => { 'name' => 'Open' } } }
+    end
+
+    loan_policy { nil }
+
+    initialize_with { new(record, nil, **attributes.except(:record)) }
+  end
+end

--- a/spec/factories/folio.rb
+++ b/spec/factories/folio.rb
@@ -38,4 +38,71 @@ FactoryBot.define do
 
     initialize_with { new(record, nil, **attributes.except(:record)) }
   end
+
+  factory :checkout_with_recall, parent: :checkout do
+    record do
+      { 'id' => '242c2dc3-6db5-40a1-a3ce-e1f27da86590',
+        'item' =>
+          { 'title' => 'Sci-fi architecture.',
+            'author' => 'Toy, Maggie',
+            'instanceId' => 'dbab2238-1a15-5ad8-af81-96805d798299',
+            'itemId' => 'ac37b537-24a5-5fb7-8908-b798c1edb2e8',
+            'isbn' => nil,
+            'instance' => { 'indexTitle' => 'Sci-fi architecure.' },
+            'item' =>
+            { 'barcode' => '36105021987123',
+              'id' => 'ac37b537-24a5-5fb7-8908-b798c1edb2e8',
+              'status' => { 'date' => '2023-06-03T06:12:03.850+00:00', 'name' => 'Checked out' },
+              'effectiveShelvingOrder' => 'NA 11 A16 V 269 NO 13 14 11',
+              'effectiveCallNumberComponents' => { 'callNumber' => 'NA1 .A16' },
+              'effectiveLocation' => { 'code' => 'ART-STACKS', 'library' => { 'code' => 'ART' } },
+              'permanentLocation' => { 'code' => 'ART-STACKS' } } },
+        'loanDate' => '2023-06-03T06:11:56.298+00:00',
+        'dueDate' => '2023-09-27T06:59:59.000+00:00',
+        'overdue' => false,
+        'details' =>
+          { 'renewalCount' => nil,
+            'dueDateChangedByRecall' => true,
+            'dueDateChangedByHold' => nil,
+            'proxyUserId' => nil,
+            'userId' => 'bdfa62a1-758c-4389-ae81-8ddb37860f9b',
+            'status' => { 'name' => 'Open' } } }
+    end
+  end
+
+  factory :overdue_checkout, parent: :checkout do
+    record do
+      { 'id' => 'f34e39a4-e6eb-4785-ab6d-d04627352577',
+        'item' =>
+           { 'title' =>
+             '(RE)DISCOVERING THE OLMEC - NATIONAL GEOGRAPHIC SOCIETY-SMITHSONIAN INSTITUTION',
+             'author' => 'LYON ROSEMARY DURKIN',
+             'instanceId' => '3f82ea4e-55ef-5ba3-b316-77e1ee455a02',
+             'itemId' => '5dfa4b14-f4ae-5bc8-b491-09919dd171c2',
+             'isbn' => nil,
+             'instance' =>
+             { 'indexTitle' =>
+               '(re)discovering the olmec - national geographic society-smithsonian institution' },
+             'item' =>
+             { 'barcode' => 'STA-12225730',
+               'id' => '5dfa4b14-f4ae-5bc8-b491-09919dd171c2',
+               'status' => { 'date' => '2023-08-24T07:22:00.183+00:00', 'name' => 'Aged to lost' },
+               'effectiveShelvingOrder' => 'F 41219.1 V47 L96 41997 11',
+               'effectiveCallNumberComponents' => { 'callNumber' => 'F1219.1.V47 L96 1997' },
+               'effectiveLocation' => { 'code' => 'SUL-BORROW-DIRECT', 'library' => { 'code' => 'SUL' } },
+               'permanentLocation' => { 'code' => 'SUL-BORROW-DIRECT' },
+               'holdingsRecord' => { 'effectiveLocation' => { 'code' => 'SUL-BORROW-DIRECT' } } } },
+        'loanDate' => '2023-06-21T16:12:27.891+00:00',
+        'dueDate' => '2023-08-17T06:59:59.000+00:00',
+        'overdue' => true,
+        'details' =>
+           { 'renewalCount' => nil,
+             'dueDateChangedByRecall' => nil,
+             'dueDateChangedByHold' => nil,
+             'proxyUserId' => nil,
+             'userId' => 'd7b67ab1-a3f2-45a9-87cc-d867bca8315f',
+             'status' => { 'name' => 'Open' },
+             'feesAndFines' => { 'amountRemainingToPay' => 200 } } }
+    end
+  end
 end

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -34,9 +34,8 @@ RSpec.describe 'Checkout Page' do
     expect(page).to have_css('ul.checkouts li', count: 1)
 
     within(first('ul.checkouts li')) do
-      expect(page).to have_css('.status', text: 'OK')
-      expect(page).to have_css('.title', text: /Blue-collar Broadway/)
-      expect(page).to have_css('.call_number', text: 'PN2277 .N7 W48 2015')
+      expect(page).to have_text(/Blue-collar Broadway/)
+      expect(page).to have_text('Call number: PN2277 .N7 W48 2015')
     end
   end
 
@@ -52,9 +51,9 @@ RSpec.describe 'Checkout Page' do
       expect(page).to have_css('ul.recalled-checkouts li', count: 1)
 
       within(first('ul.recalled-checkouts li')) do
-        expect(page).to have_css('.status', text: 'Recalled')
-        expect(page).to have_css('.title', text: /Sci-fi architecture./)
-        expect(page).to have_css('.call_number', text: 'NA1 .A16')
+        expect(page).to have_text 'Recalled'
+        expect(page).to have_text(/Sci-fi architecture./)
+        expect(page).to have_text 'Call number: NA1 .A16'
       end
     end
   end
@@ -66,43 +65,18 @@ RSpec.describe 'Checkout Page' do
             renewal_count: 0)
     end
 
-    it 'has renewable status indicator' do
+    it 'has a renewa button' do
       visit checkouts_path
 
-      expect(page).to have_css '.renewable-indicator .sul-icons'
+      expect(page).to have_button 'Renew'
     end
   end
 
-  context 'when data is hidden behind a toggle' do
-    let(:patron) do
-      build(:patron_with_overdue_items)
-    end
+  it 'shows other data in the footer' do
+    visit checkouts_path
 
-    it 'shows the renew data when the list item is expanded', :js do
-      visit checkouts_path
-
-      within('ul.checkouts li:nth-child(1)') do
-        click_on 'Expand'
-        expect(page).to have_css('dt', text: 'Can I renew?', visible: :visible)
-      end
-    end
-
-    it 'shows other data when the list item is expanded', :js do
-      visit checkouts_path
-
-      within(first('ul.checkouts li')) do
-        expect(page).to have_no_css('dl', visible: :visible)
-        expect(page).to have_no_css('dt', text: 'Borrowed:', visible: :visible)
-        click_on 'Expand'
-        expect(page).to have_css('dl', visible: :visible)
-        expect(page).to have_css('dt', text: 'Borrowed:', visible: :visible)
-        expect(page).to have_css('dt', text: 'Days overdue:', visible: :visible)
-        expect(page).to have_css('dd', text: /^\d+$/, visible: :visible)
-        expect(page).to have_css('dt', text: 'Barcode:', visible: :visible)
-        expect(page).to have_css('dd', text: '36105021987123', visible: :visible)
-        expect(page).to have_css('dt', text: 'Fines accrued:', visible: :visible)
-        expect(page).to have_css('dd', text: '$30.00', visible: :visible)
-      end
+    within(first('ul.checkouts li')) do
+      expect(page).to have_text 'Barcode: 36105212981729'
     end
   end
 
@@ -110,7 +84,7 @@ RSpec.describe 'Checkout Page' do
     visit checkouts_path
 
     within(first('ul.checkouts li')) do
-      expect(page).to have_css('dl dd', text: 'Green Library', visible: :all)
+      expect(page).to have_text 'Library: Green Library'
     end
   end
 
@@ -129,7 +103,7 @@ RSpec.describe 'Checkout Page' do
       expect(page).to have_css('.active[data-sortable-sort-param="title"]', visible: :all)
 
       within(first('ul.checkouts li')) do
-        expect(page).to have_css('.title', text: /Blue-collar Broadway/)
+        expect(page).to have_text(/Blue-collar Broadway/)
       end
     end
   end


### PR DESCRIPTION
Part of #2852, at this point just moving existing elements around into the new layout before tackling the new stuff (renew button, alert text, cover, format, etc)

<img width="988" height="262" alt="Screenshot 2026-05-13 at 09 06 28" src="https://github.com/user-attachments/assets/6e212274-d873-40b7-a49c-4a2f2608c7cb" />
