### PR TITLE
Add responsive design to digitization form elements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -245,6 +245,22 @@ summary .disclosure-icon::before {
   border-bottom-right-radius: 0 !important;
 }
 
+.accordion-toggle-overlay,
+.accordion-toggle-overlay:hover,
+.accordion-toggle-overlay:focus {
+  position: absolute;
+  inset: 0;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  z-index: 0;
+}
+
+.accordion-header:has(.accordion-toggle-overlay:focus-visible) {
+  outline: 2px solid var(--bs-focus-ring-color, #0d6efd);
+  outline-offset: 2px;
+}
+
 .step-number {
   width: 2rem;
   height: 2rem;
@@ -741,6 +757,10 @@ label.btn-close {
 
 /* Completed status styling for selected items */
 .selected-items-container {
+  .accordion-item .accordion-header > :first-child {
+    margin-inline-start: 1rem;
+  }
+
   .appointments-item[data-selected-item-form-status-value="complete"]:not(:only-child) {
     padding-inline-start: 2rem;
     @media (min-width: 576px) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -648,6 +648,11 @@ label.btn-close {
   display: none;
 }
 
+/* Hint to avoid wrapping only the view contents button */
+.text-wrap:has(.selected-item-title) {
+  text-wrap: pretty;
+}
+
 .appointments-item {
   padding: 0.5rem 1rem 0.5rem 1rem;
   grid-template-columns: 1fr;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -757,7 +757,7 @@ label.btn-close {
 
 /* Completed status styling for selected items */
 .selected-items-container {
-  .accordion-item .accordion-header > :first-child {
+  .accordion-item .accordion-header > div {
     margin-inline-start: 1rem;
   }
 
@@ -768,7 +768,7 @@ label.btn-close {
     }
   }
 
-  .accordion-item[data-selected-item-form-status-value="complete"]:not(:only-child) .accordion-header > :first-child {
+  .accordion-item[data-selected-item-form-status-value="complete"]:not(:only-child) .accordion-header > div {
     margin-inline-start: 2rem;
     @media (min-width: 576px) {
       margin-inline-start: 2.5rem;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -231,7 +231,7 @@ summary .disclosure-icon::before {
   --bs-accordion-active-color: var(--stanford-process-black);
 }
 
-.accordion-button:not(.collapsed) {
+.accordion-button:not(.collapsed):not(:focus-visible) {
   box-shadow: none !important;
 }
 

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,21 +1,15 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
-  <div class="accordion-header d-flex flex-nowrap align-items-center position-relative">
+  <div class="accordion-header d-flex flex-nowrap align-items-center position-relative py-2">
     <div class="d-flex align-items-center flex-grow-1 justify-content-between">
-      <div class="d-flex">
-        <%= button_tag(
-            type: "button",
-            class: "accordion-button d-inline-flex w-auto align-items-center position-static",
-            data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
-            aria: { expanded: !accordion?, controls: "content_#{dom_id}" },
-            disabled: !accordion?
-            ) do %>
-          <i class="bi bi-check2 selected-item-status"></i>
-          <span class="text-black fw-semibold selected-item-title stretched-link"><%= title %></span>
-        <% end %>
-        <button class="btn btn-link p-0 ps-1 pe-2 z-3 d-none" data-action="view-container-contents#openViewModal"
-        data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
-          <i class="bi bi-list-ul"></i><span class="visually-hidden">View contents</span>
-        </button>
+      <div class="d-flex align-items-center">
+        <i class="bi bi-check2 selected-item-status"></i>
+        <span id="title_<%= dom_id %>" class="text-black fw-semibold selected-item-title text-wrap">
+          <%= title %>
+          <button class="btn btn-link position-relative z-3 d-none" data-action="view-container-contents#openViewModal"
+                  data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
+            <i class="bi bi-list-ul"></i><span class="visually-hidden">View contents</span>
+          </button>
+        </span>
       </div>
       <div class="d-flex position-relative z-3">
         <% if save_for_later? %>
@@ -28,6 +22,14 @@
         </button>
       </div>
     </div>
+    <%= tag.button(
+        "",
+        type: "button",
+        class: "accordion-button accordion-toggle-overlay",
+        data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
+        aria: { expanded: !accordion?, controls: "content_#{dom_id}", labelledby: "title_#{dom_id}" },
+        disabled: !accordion?
+    ) %>
     <i class="bi bi-chevron-down accordion-header-icon ms-auto px-4"></i>
   </div>
   <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' if accordion? %>">

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative py-2">
-    <div class="d-flex align-items-center flex-grow-1 justify-content-between">
+    <div class="d-flex flex-wrap align-items-center flex-grow-1 justify-content-between">
       <div class="d-flex align-items-center">
         <i class="bi bi-check2 selected-item-status"></i>
         <span id="title_<%= dom_id %>" class="text-black fw-semibold selected-item-title text-wrap">

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,5 +1,13 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative py-2">
+    <%= tag.button(
+        "",
+        type: "button",
+        class: "accordion-button accordion-toggle-overlay",
+        data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
+        aria: { expanded: !accordion?, controls: "content_#{dom_id}", labelledby: "title_#{dom_id}" },
+        disabled: !accordion?
+    ) %>
     <div class="d-flex flex-column flex-lg-row align-items-lg-center flex-grow-1 justify-content-lg-between">
       <div class="d-flex align-items-center">
         <i class="bi bi-check2 selected-item-status"></i>
@@ -22,14 +30,6 @@
         </button>
       </div>
     </div>
-    <%= tag.button(
-        "",
-        type: "button",
-        class: "accordion-button accordion-toggle-overlay",
-        data: { bs_toggle: "collapse", bs_target: "#content_#{dom_id}" },
-        aria: { expanded: !accordion?, controls: "content_#{dom_id}", labelledby: "title_#{dom_id}" },
-        disabled: !accordion?
-    ) %>
     <i class="bi bi-chevron-down accordion-header-icon ms-auto px-4"></i>
   </div>
   <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' if accordion? %>">

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="accordion-item mb-3" data-content-id="<%= dom_id %>">
   <div class="accordion-header d-flex flex-nowrap align-items-center position-relative py-2">
-    <div class="d-flex flex-wrap align-items-center flex-grow-1 justify-content-between">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center flex-grow-1 justify-content-lg-between">
       <div class="d-flex align-items-center">
         <i class="bi bi-check2 selected-item-status"></i>
         <span id="title_<%= dom_id %>" class="text-wrap">
@@ -13,7 +13,7 @@
       </div>
       <div class="d-flex position-relative z-3">
         <% if save_for_later? %>
-        <button class="btn btn-link p-0 ps-1 z-3 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>">
+          <button class="btn btn-link p-0 ps-1 z-3 su-underline fs-14 text-nowrap" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>">
           <i class="bi bi-pin-angle-fill me-1"></i>Save for later
         </button>
         <% end %>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -3,8 +3,8 @@
     <div class="d-flex flex-wrap align-items-center flex-grow-1 justify-content-between">
       <div class="d-flex align-items-center">
         <i class="bi bi-check2 selected-item-status"></i>
-        <span id="title_<%= dom_id %>" class="text-black fw-semibold selected-item-title text-wrap">
-          <%= title %>
+        <span id="title_<%= dom_id %>" class="text-wrap">
+          <span class="text-black fw-semibold selected-item-title"><%= title %></span>
           <button class="btn btn-link position-relative z-3 d-none" data-action="view-container-contents#openViewModal"
                   data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
             <i class="bi bi-list-ul"></i><span class="visually-hidden">View contents</span>

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -361,7 +361,11 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'Box 12'
       click_button 'Continue'
 
-      expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]', text: 'Box 12')
+      within('.selected-items-container') do
+        within('.accordion-item', text: 'Box 12') do
+          expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
+        end
+      end
 
       # Go back to edit item selection
       within('#items-accordion') do
@@ -375,8 +379,12 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       click_button 'Continue'
 
       within('.selected-items-container') do
-        expect(page).to have_css('.accordion-button[aria-expanded="true"]', text: 'Box 12')
-        expect(page).to have_css('.accordion-button[aria-expanded="false"]', text: 'Box 14')
+        within('.accordion-item', text: 'Box 12') do
+          expect(page).to have_css('.accordion-button[aria-expanded="true"]')
+        end
+        within('.accordion-item', text: 'Box 14') do
+          expect(page).to have_css('.accordion-button[aria-expanded="false"]')
+        end
         expect(page).to have_no_css('.accordion-button[disabled]')
       end
 
@@ -628,7 +636,9 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       click_button 'Continue'
 
       within('.selected-items-container') do
-        expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]', text: 'Box 1')
+        within('.accordion-item', text: 'Box 1') do
+          expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
+        end
       end
     end
   end

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -361,10 +361,8 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'Box 12'
       click_button 'Continue'
 
-      within('.selected-items-container') do
-        within('.accordion-item', text: 'Box 12') do
-          expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
-        end
+      within('.selected-items-container .accordion-item', text: 'Box 12') do
+        expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
       end
 
       # Go back to edit item selection
@@ -635,10 +633,8 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'Box 1'
       click_button 'Continue'
 
-      within('.selected-items-container') do
-        within('.accordion-item', text: 'Box 1') do
-          expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
-        end
+      within('.selected-items-container .accordion-item', text: 'Box 1') do
+        expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
       end
     end
   end

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -68,7 +68,9 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
       click_button 'Continue'
 
       within('.selected-items-container') do
-        expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]', text: 'ABC 123')
+        within('.accordion-item', text: 'ABC 123') do
+          expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
+        end
       end
 
       fill_in 'Requested pages', with: 'Pages 1-10'
@@ -118,8 +120,8 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
       # Proceed with 1 selected item
       check 'ABC 123'
       click_button 'Continue'
-      within('.selected-items-container') do
-        expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]', text: 'ABC 123')
+      within('.selected-items-container .accordion-item', text: 'ABC 123') do
+        expect(page).to have_css('.accordion-button[disabled][aria-expanded="true"]')
       end
 
       # Go back to edit item selection
@@ -132,8 +134,12 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
       click_button 'Continue'
 
       within('.digitization-accordion') do
-        expect(page).to have_css('.accordion-button[aria-expanded="true"]', text: 'ABC 123')
-        expect(page).to have_css('.accordion-button[aria-expanded="false"]', text: 'ABC 321')
+        within('.accordion-item', text: 'ABC 123') do
+          expect(page).to have_css('.accordion-button[aria-expanded="true"]')
+        end
+        within('.accordion-item', text: 'ABC 321') do
+          expect(page).to have_css('.accordion-button[aria-expanded="false"]')
+        end
         expect(page).to have_no_css('.accordion-button[disabled]')
       end
 


### PR DESCRIPTION
Adds the digitization portion of the responsive design from #3513.

Breakpoints differ from designs (wraps earlier) after conversation with Darcy.


<img width="820" height="583" alt="Screenshot 2026-05-13 at 8 43 39 AM" src="https://github.com/user-attachments/assets/d1d55476-97fb-4f98-882a-626416eaa49c" />
<img width="478" height="731" alt="Screenshot 2026-05-13 at 8 44 01 AM" src="https://github.com/user-attachments/assets/6c13b596-d464-4919-810a-e077afdcfd82" />
