### PR TITLE
Add responsive design for Aeon request group items 

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -992,7 +992,7 @@ label.btn-close {
   }
 
   @media (min-width: 992px) {
-    grid-template-columns: 1fr 18rem auto;
+    grid-template-columns: 1fr 18rem 3rem;
     grid-template-areas:
       "id     fulfillment actions"
       "detail detail      detail"

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -99,6 +99,10 @@ layer(components);
     color: rgba(var(--stanford-plum-dark-rgb), 1);
 }
 
+.text-spirited-dark {
+  color: #C74632;
+}
+
 .text-30-black {
   color: var(--stanford-30-black);
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -935,34 +935,21 @@ label.btn-close {
   margin-bottom: 1rem;
 }
 
-.request.list-group-item:not(:has(.request-fulfillment)) {
+.request.list-group-item {
   display: grid;
+  column-gap: 1rem;
+}
+
+.request.list-group-item:not(:has(.request-fulfillment)) {
   grid-template-columns: 1fr;
   grid-template-areas:
     "id"
     "detail"
     "actions"
     "footer";
-  column-gap: 1rem;
 
-  @media (min-width: 768px) {
-    grid-template-columns: 1fr auto;
-    grid-template-areas:
-      "id     actions"
-      "detail detail"
-      "footer footer";
-  }
-
-  @media (min-width: 992px) {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "id"
-      "detail"
-      "actions"
-      "footer";
-  }
-
-  @media (min-width: 1200px) {
+  @media (min-width: 768px) and (max-width: 991.98px),
+         (min-width: 1200px) {
     grid-template-columns: 1fr auto;
     grid-template-areas:
       "id     actions"
@@ -972,7 +959,6 @@ label.btn-close {
 }
 
 .request.list-group-item:has(.request-fulfillment) {
-  display: grid;
   grid-template-columns: 1fr;
   grid-template-areas:
     "id"
@@ -980,7 +966,6 @@ label.btn-close {
     "fulfillment"
     "actions"
     "footer";
-  column-gap: 1rem;
 
   @media (min-width: 576px) {
     grid-template-columns: 1fr auto;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -935,6 +935,77 @@ label.btn-close {
   margin-bottom: 1rem;
 }
 
+.request.list-group-item:not(:has(.request-fulfillment)) {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "id"
+    "detail"
+    "actions"
+    "footer";
+  column-gap: 1rem;
+
+  @media (min-width: 768px) {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "id     actions"
+      "detail detail"
+      "footer footer";
+  }
+
+  @media (min-width: 992px) {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "id"
+      "detail"
+      "actions"
+      "footer";
+  }
+
+  @media (min-width: 1200px) {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "id     actions"
+      "detail detail"
+      "footer footer";
+  }
+}
+
+.request.list-group-item:has(.request-fulfillment) {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "id"
+    "detail"
+    "fulfillment"
+    "actions"
+    "footer";
+  column-gap: 1rem;
+
+  @media (min-width: 576px) {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "id          id"
+      "detail      detail"
+      "fulfillment actions"
+      "footer      footer";
+  }
+
+  @media (min-width: 992px) {
+    grid-template-columns: 1fr 18rem auto;
+    grid-template-areas:
+      "id     fulfillment actions"
+      "detail detail      detail"
+      "footer footer      footer";
+  }
+}
+
+.request.list-group-item > .rgi-id      { grid-area: id; }
+.request.list-group-item > .rgi-detail  { grid-area: detail; }
+.request.list-group-item > .request-fulfillment { grid-area: fulfillment; }
+.request.list-group-item > .rgi-actions { grid-area: actions; }
+.request.list-group-item > .rgi-footer  { grid-area: footer; }
+
 .modal-body.add-items {
   .reading-room {
     display: none;

--- a/app/components/aeon/request_fulfillment_component.html.erb
+++ b/app/components/aeon/request_fulfillment_component.html.erb
@@ -1,0 +1,12 @@
+<div class="request-fulfillment">
+  <% case mode %>
+  <% when :appointment %>
+    <%= render Aeon::RequestAppointmentTimeComponent.new(request:, with_reading_room: false) %>
+  <% when :delivered %>
+    <i class="bi bi-envelope me-1 text-green"></i>
+    <span class="ms-1 text-green"><span class="fw-semibold">Delivered</span> on <%= l(delivered_date.to_date, format: :short) %></span>
+  <% when :delivery_pending %>
+    <i class="bi bi-clock me-1 text-spirited-dark"></i>
+    <span class="ms-1 text-spirited-dark">Pending delivery</span>
+  <% end %>
+</div>

--- a/app/components/aeon/request_fulfillment_component.rb
+++ b/app/components/aeon/request_fulfillment_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Render the fulfillment context for a request.
+  # E.g., appointment time reading-room requests, delivery status for digitization.
+  class RequestFulfillmentComponent < ViewComponent::Base
+    attr_reader :request
+
+    delegate :appointment?, :digital?, :draft?, :scan_delivered?, :submitted?,
+             :photoduplication_date, :transaction_date, to: :request
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def render?
+      return false if draft?
+
+      mode.present?
+    end
+
+    def delivered_date
+      photoduplication_date.presence || transaction_date
+    end
+
+    def mode
+      return :appointment if appointment?
+      return :delivered if digital? && scan_delivered?
+
+      :delivery_pending if digital? && submitted?
+    end
+  end
+end

--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,6 +1,6 @@
 <%= render CardComponent.new id: request_group.dom_id, element: element, classes: 'request-group' do |c| %>
   <% c.with_title do %>
-    <div>
+    <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">
         <span>
           <%= render Aeon::RequestStatusPillComponent.new(request: status_request) %>

--- a/app/components/aeon/request_group_item_component.html.erb
+++ b/app/components/aeon/request_group_item_component.html.erb
@@ -1,33 +1,30 @@
 <li id="<%= dom_id(request) %>" class="request list-group-item">
-  <div class="d-flex flex-row align-items-start justify-content-between gap-5">
-    <div class="d-flex flex-row align-items-start justify-content-between gap-4 flex-grow-1">
-      <div class="d-flex flex-column">
-        <div class="d-flex justify-content-start align-items-center">
-          <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
+  <div class="rgi-id d-flex align-items-center">
+    <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
 
-          <% if remove_from_appointment? %>
-            <%= form_with(url: redraft_aeon_request_path(request, kind: request.request_type)) do |f| %>
-              <%= tag.button type: :submit, class: 'btn btn-link su-underline' do %>
-                <i class="bi bi-x align-middle me-1"></i><span>Remove</span>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
-
-        <%= render Aeon::RequestItemDetailComponent.new(request:) %>
-      </div>
-
-      <% if appointment? %>
-        <span class="ms-auto">
-          <%= render Aeon::RequestAppointmentTimeComponent.new(request:, with_reading_room: false) %>
-        </span>
+    <% if remove_from_appointment? %>
+      <%= form_with(url: redraft_aeon_request_path(request, kind: request.request_type)) do |f| %>
+        <%= tag.button type: :submit, class: 'btn btn-link su-underline' do %>
+          <i class="bi bi-x align-middle me-1"></i><span>Remove</span>
+        <% end %>
       <% end %>
-    </div>
-
-    <%= render Aeon::RequestActionsComponent.new(request:) if actions? %>
+    <% end %>
   </div>
+
+  <div class="rgi-detail pb-1">
+    <%= render Aeon::RequestItemDetailComponent.new(request:) %>
+  </div>
+
+  <%= render Aeon::RequestFulfillmentComponent.new(request:) if fulfillment? %>
+
+  <% if actions? %>
+    <div class="rgi-actions">
+      <%= render Aeon::RequestActionsComponent.new(request:) %>
+    </div>
+  <% end %>
+
   <% if footer? %>
-    <div class="pt-2 fs-14 text-body-secondary d-flex gap-sm-3 flex-sm-row flex-column">
+    <div class="rgi-footer pt-2 fs-14 text-body-secondary d-flex gap-sm-3 flex-sm-row flex-column">
       <div>Request #<%= transaction_number %></div>
       <div>Date added/modified: <%= l(transaction_date, format: :full) %></div>
     </div>

--- a/app/components/aeon/request_group_item_component.rb
+++ b/app/components/aeon/request_group_item_component.rb
@@ -9,10 +9,10 @@ module Aeon
 
     delegate :transaction_number, :transaction_date, to: :request
 
-    def initialize(request:, actions: true, appointment: true, remove_from_appointment: false, footer: true)
+    def initialize(request:, actions: true, fulfillment: true, remove_from_appointment: false, footer: true)
       @request = request
       @actions = actions
-      @appointment = appointment
+      @fulfillment = fulfillment
       @remove_from_appointment = remove_from_appointment
       @footer = footer
     end
@@ -21,8 +21,8 @@ module Aeon
       @actions
     end
 
-    def appointment?
-      @appointment
+    def fulfillment?
+      @fulfillment
     end
 
     def footer?

--- a/app/components/aeon/request_group_per_appointment_component.html.erb
+++ b/app/components/aeon/request_group_per_appointment_component.html.erb
@@ -8,7 +8,7 @@
     </h3>
     <span class="ms-2">Call number: <%= request_group.base_callnumber %></span>
     <ul class="list-group list-group-flush mt-2">
-      <%= render Aeon::RequestGroupItemComponent.with_collection(requests, actions: false, remove_from_appointment: true, appointment: false, footer: false) %>
+      <%= render Aeon::RequestGroupItemComponent.with_collection(requests, actions: false, remove_from_appointment: true, fulfillment: false, footer: false) %>
     </ul>
   </div>
 </div>

--- a/app/views/aeon_requests/index.html.erb
+++ b/app/views/aeon_requests/index.html.erb
@@ -36,7 +36,7 @@
 
 <div class="container" <% if params[:kind] == 'drafts' %>data-controller="draft-request"<% end %>>
   <div class="row">
-    <div class="<% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-md-9<% end %>">
+    <div class="<% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-xl-9<% end %>">
       <div class="d-flex flex-wrap gap-2 justify-content-between mb-4">
         <h1><%= t(params[:kind], scope: 'aeon_requests.index.header', default: 'Requests') %></h1>
         <div class="d-flex flex-wrap gap-2 align-items-baseline">
@@ -49,7 +49,7 @@
     </div>
   </div>
   <div class="row">
-    <ol id="requests" class="list-unstyled <% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-md-9<% end %>">
+    <ol id="requests" class="list-unstyled <% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-xl-9<% end %>">
       <%= render Aeon::RequestGroupComponent.with_collection(@aeon_request_groups, element: 'li') %>
     </ol>
 

--- a/app/views/aeon_requests/index.html.erb
+++ b/app/views/aeon_requests/index.html.erb
@@ -1,6 +1,6 @@
 <% if params[:kind] == 'drafts' %>
   <% content_for(:sidebar_responsive_button) do %>
-    <button class="btn btn-outline-primary d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#appointments" aria-controls="appointments">
+    <button class="btn btn-sm btn-outline-primary d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#appointments" aria-controls="appointments">
       Appointments
     </button>
   <% end %>
@@ -10,7 +10,7 @@
   <% end %>
 
   <% content_for(:sidebar) do %>
-    <aside class="col-md-4 offcanvas-md offcanvas-bottom offcanvas-sm-start overflow-auto"  tabindex="-1" id="appointments">
+    <aside class="col-lg-4 offcanvas-lg offcanvas-bottom offcanvas-sm-start overflow-auto"  tabindex="-1" id="appointments">
       <%= render 'aeon_appointments' %>
     </aside>
   <% end %>
@@ -36,7 +36,7 @@
 
 <div class="container" <% if params[:kind] == 'drafts' %>data-controller="draft-request"<% end %>>
   <div class="row">
-    <div class="<% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-xl-9<% end %>">
+    <div class="<% if content_for?(:sidebar) %>col-lg-8 pe-lg-5<% else %>col-xl-9<% end %>">
       <div class="d-flex flex-wrap gap-2 justify-content-between mb-4">
         <h1><%= t(params[:kind], scope: 'aeon_requests.index.header', default: 'Requests') %></h1>
         <div class="d-flex flex-wrap gap-2 align-items-baseline">
@@ -49,7 +49,7 @@
     </div>
   </div>
   <div class="row">
-    <ol id="requests" class="list-unstyled <% if content_for?(:sidebar) %>col-md-8 pe-md-5<% else %>col-xl-9<% end %>">
+    <ol id="requests" class="list-unstyled <% if content_for?(:sidebar) %>col-lg-8 pe-lg-5<% else %>col-xl-9<% end %>">
       <%= render Aeon::RequestGroupComponent.with_collection(@aeon_request_groups, element: 'li') %>
     </ol>
 

--- a/spec/component_previews/aeon/request_group_component_preview.rb
+++ b/spec/component_previews/aeon/request_group_component_preview.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Aeon
+  class RequestGroupComponentPreview < ViewComponent::Preview
+    layout 'lookbook'
+
+    # @!group Submitted
+    def submitted_single_appointment_request
+      request_group = Aeon::RequestGrouping.new(
+        [FactoryBot.build(:aeon_request, :submitted, call_number: 'XYZ 123')]
+      )
+      render Aeon::RequestGroupComponent.new(request_group:)
+    end
+
+    def submitted_multi_box_ead
+      request_group = Aeon::RequestGrouping.new(
+        [
+          FactoryBot.build(:aeon_request, :submitted, :ead, call_number: 'Box 1'),
+          FactoryBot.build(:aeon_request, :submitted, :ead, call_number: 'Box 2'),
+          FactoryBot.build(:aeon_request, :submitted, :ead, call_number: 'Box 3')
+        ]
+      )
+      render Aeon::RequestGroupComponent.new(request_group:)
+    end
+
+    def submitted_digitization
+      request_group = Aeon::RequestGrouping.new(
+        [
+          FactoryBot.build(:aeon_request, :submitted, :digitized, :ead, call_number: 'Box 1', item_info5: '12-20'),
+          FactoryBot.build(:aeon_request, :delivered, :digitized, :ead, call_number: 'Box 2', item_info5: '45-60')
+        ]
+      )
+      render Aeon::RequestGroupComponent.new(request_group:)
+    end
+
+    def submitted_rumsey_appointment
+      reading_room = FactoryBot.build(:aeon_reading_room, id: 7, name: 'David Rumsey Map Center', sites: ['RUMSEY'])
+      appointment = FactoryBot.build(:aeon_appointment, reading_room_id: 7, reading_room:)
+      request = FactoryBot.build(:aeon_request, :submitted, appointment:,
+                                                            item_title: 'Map of the city of San Francisco, 1872',
+                                                            call_number: 'G3300 1872 .R3')
+      render Aeon::RequestGroupComponent.new(request_group: Aeon::RequestGrouping.new([request]))
+    end
+    # @!endgroup
+
+    # @!group Draft
+    def draft_single_appointment_request
+      request_group = Aeon::RequestGrouping.new(
+        [FactoryBot.build(:aeon_request, :draft, call_number: 'XYZ 123')]
+      )
+      render Aeon::RequestGroupComponent.new(request_group:)
+    end
+
+    def draft_multi_box_ead
+      request_group = Aeon::RequestGrouping.new(
+        [
+          FactoryBot.build(:aeon_request, :draft, :ead, call_number: 'Box 1'),
+          FactoryBot.build(:aeon_request, :draft, :ead, call_number: 'Box 2'),
+          FactoryBot.build(:aeon_request, :draft, :ead, call_number: 'Box 3')
+        ]
+      )
+      render Aeon::RequestGroupComponent.new(request_group:)
+    end
+
+    def draft_digitization
+      request_group = Aeon::RequestGrouping.new(
+        [FactoryBot.build(:aeon_request, :draft, :digitized)]
+      )
+      render Aeon::RequestGroupComponent.new(request_group:)
+    end
+    # @!endgroup
+  end
+end

--- a/spec/factories/aeon.rb
+++ b/spec/factories/aeon.rb
@@ -101,5 +101,42 @@ FactoryBot.define do
       appointment_id { nil }
       appointment { nil }
     end
+
+    trait :submitted do
+      transaction_status { 8 }
+      after(:build) do |request|
+        request.instance_variable_set(
+          :@transaction_queue,
+          Aeon::Queue.new(id: 8, queue_name: 'Awaiting Request Processing', queue_type: 'Transaction')
+        )
+      end
+    end
+
+    trait :draft do
+      transaction_status { 5 }
+      appointment_id { nil }
+      appointment { nil }
+      after(:build) do |request|
+        request.instance_variable_set(
+          :@transaction_queue,
+          Aeon::Queue.new(id: 5, queue_name: 'Awaiting User Review', queue_type: 'Transaction')
+        )
+      end
+    end
+
+    trait :delivered do
+      transaction_status { 75 }
+      photoduplication_status { 23 }
+      after(:build) do |request|
+        request.instance_variable_set(
+          :@transaction_queue,
+          Aeon::Queue.new(id: 75, queue_name: 'Awaiting Item Reshelving', queue_type: 'Transaction')
+        )
+        request.instance_variable_set(
+          :@photoduplication_queue,
+          Aeon::Queue.new(id: 23, queue_name: 'Item Delivered', queue_type: 'Photoduplication')
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds the responsive design for the request group items in #3467 ("Submitted Requests", "Saved for later")

<img width="522" height="519" alt="Screenshot 2026-05-13 at 4 39 02 PM" src="https://github.com/user-attachments/assets/072e67ba-b12a-438b-b52f-d189a9950754" />

(only one screenshot, this one needs playing around with)

The designs have a mix of "fixed position" and "when there is room" behavior, and not always consistently. From conversations with Darcy, I've biased it toward consistent presentation. Some things won't match 1:1 with the designs.

I've touched on a few surrounding responsive elements, but this is really about focusing on the groups. Hoping to pick up minor spacing details w/Darcy.

The "fulfillment" component is not intended to be final, but is hopefully reasonable enough.