### PR TITLE
remove custom-select class from sidebar custom-select

### DIFF
--- a/app/components/sidebar_appointment_dropdown_component.html.erb
+++ b/app/components/sidebar_appointment_dropdown_component.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: request, data: { turbo: true}) do |f| %>
-  <div class="dropdown custom-select" data-controller="appointment-select-submit">
+  <div class="dropdown sidebar-custom-select" data-controller="appointment-select-submit">
     <%= hidden_field_tag 'sidebar', true %>
     <%= f.hidden_field :appointment_id, data: { appointment_select_submit_target: "input" } %>
     <%= button_tag 'Appointment', class: 'dropdown-toggle btn btn-link su-underline p-0', type: 'button', data: { bs_toggle: 'dropdown', appointment_select_target: 'button' }, aria: { expanded: false }, disabled: selectable_appointments.blank? %>


### PR DESCRIPTION
The branch I was working off of didn't have https://github.com/sul-dlss/sul-requests/commit/06d40c9e2447207c2580a3bd089a2ed1c2a90a31#diff-5bfcdc54bcda018d14515b827c80d9f9b8ee25704a4271b560a2f87439665f17R832-R837

Before:
<img width="384" height="442" alt="Screenshot 2026-05-14 at 2 51 51 PM" src="https://github.com/user-attachments/assets/133ae890-7c0f-4cf2-a2c6-962c34280637" />

After:
<img width="432" height="773" alt="Screenshot 2026-05-14 at 2 52 05 PM" src="https://github.com/user-attachments/assets/9451410b-458a-4821-8d5f-7414e6d08a36" />

