### PR TITLE
Fix activity request confirmation screen endless polling

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -39,7 +39,7 @@ class PatronRequestsController < ApplicationController
 
   def show
     if @patron_request.aeon_page? && use_requests_redesign? # rubocop:disable Style/GuardClause
-      @aeon_requests = Aeon::RequestGrouping.new(current_user.aeon.requests.select do |x|
+      @aeon_requests = Aeon::RequestGrouping.new(current_user.aeon.all_requests.select do |x|
         x.reference_number == @patron_request.to_global_id.to_s
       end)
       request.variant = :aeon

--- a/app/javascript/controllers/aeon_confirmation_poll_controller.js
+++ b/app/javascript/controllers/aeon_confirmation_poll_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   static values = {
     attempts: Number,
     interval: { type: Number, default: 1000 },
-    maxAttempts: { type: Number, default: 20 }
+    maxAttempts: { type: Number, default: 10 }
   }
 
   static targets = ["frame", "loading"]
@@ -26,10 +26,11 @@ export default class extends Controller {
   refresh() {
     this.attemptsValue++
 
-    if (this.attemptsValue >= this.maxAttemptsValue) return
-
     const url = new URL(window.location.href)
     url.searchParams.set("_poll", Date.now())
+    if (this.attemptsValue >= this.maxAttemptsValue) {
+      url.searchParams.set("stop_polling", "1")
+    }
     this.frameTarget.src = url.toString()
   }
 }

--- a/app/models/aeon/null_user.rb
+++ b/app/models/aeon/null_user.rb
@@ -15,6 +15,10 @@ module Aeon
       @requests ||= []
     end
 
+    def all_requests
+      @all_requests ||= []
+    end
+
     def appointments
       @appointments ||= []
     end

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -26,8 +26,12 @@ module Aeon
       auth_type == 'Default'
     end
 
+    def all_requests
+      @all_requests ||= self.class.aeon_client.requests_for(username:)
+    end
+
     def requests
-      @requests ||= self.class.aeon_client.requests_for(username:).reject(&:activity?)
+      @requests ||= all_requests.reject(&:activity?)
     end
 
     def activities

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -135,11 +135,13 @@ class PatronRequest < ApplicationRecord
   end
 
   def expected_aeon_item_count
-    if ead_url.present?
-      aeon_item&.count || 0
-    else
-      selected_items.count
-    end
+    item_count = if ead_url.present?
+                   aeon_item&.count || 0
+                 else
+                   selected_items.count
+                 end
+    activity_multiplier = activity_ids.presence&.count || 1
+    item_count * activity_multiplier
   end
 
   def item_mediation_data

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -12,7 +12,7 @@
     <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'mt-4 mb-4', title_classes: ['h3']) %>
     <div data-controller="aeon-confirmation-poll" data-aeon-confirmation-poll-attempts-value="0">
       <turbo-frame id="aeon-confirmation" data-aeon-confirmation-poll-target="frame">
-        <% if @aeon_requests.count < @patron_request.expected_aeon_item_count %>
+        <% if @aeon_requests.count < @patron_request.expected_aeon_item_count && !params[:stop_polling] %>
           <div class="d-flex align-items-center my-3" data-aeon-confirmation-poll-target="loading">
             <div class="spinner-border spinner-border-sm me-2" role="status">
               <span class="visually-hidden">Loading...</span>

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   let(:aeon_user) { Aeon::User.new(username: user.email_address, auth_type: 'Default') }
   let(:stub_aeon_client) do
     instance_double(AeonClient, find_user: aeon_user, create_request: created_request, update_request_route: nil,
-                                reading_rooms:, available_appointments:, activities_for: [])
+                                reading_rooms:, available_appointments:, activities_for: [], requests_for: [])
   end
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, draft?: false, valid?: true) }
   let(:available_appointments) do


### PR DESCRIPTION
<img width="773" height="516" alt="Screenshot 2026-05-14 at 5 15 07 PM" src="https://github.com/user-attachments/assets/a9ce5318-5dd3-405a-9524-81b55dda14b4" />

Also show whatever is in progress at when `maxAttempts` is reached, and lower `maxAttempts` to something that feels more reasonable.