### PR TITLE
Fix confirmation page when making Aeon activity requests

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -39,7 +39,7 @@ class PatronRequestsController < ApplicationController
 
   def show
     if @patron_request.aeon_page? && use_requests_redesign? # rubocop:disable Style/GuardClause
-      @aeon_requests = Aeon::RequestGrouping.new(current_user.aeon.requests.select do |x|
+      @aeon_requests = Aeon::RequestGrouping.new(current_user.aeon.all_requests.select do |x|
         x.reference_number == @patron_request.to_global_id.to_s
       end)
       request.variant = :aeon

--- a/app/javascript/controllers/aeon_confirmation_poll_controller.js
+++ b/app/javascript/controllers/aeon_confirmation_poll_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = {
     attempts: Number,
-    interval: { type: Number, default: 1000 },
+    interval: { type: Number, default: 500 },
     maxAttempts: { type: Number, default: 20 }
   }
 
@@ -26,10 +26,11 @@ export default class extends Controller {
   refresh() {
     this.attemptsValue++
 
-    if (this.attemptsValue >= this.maxAttemptsValue) return
-
     const url = new URL(window.location.href)
     url.searchParams.set("_poll", Date.now())
+    if (this.attemptsValue >= this.maxAttemptsValue) {
+      url.searchParams.set("stop_polling", "1")
+    }
     this.frameTarget.src = url.toString()
   }
 }

--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -8,10 +8,16 @@ class SubmitAeonPatronRequestJob < ApplicationJob
 
   def perform(patron_request)
     return unless patron_request.aeon_page?
-    return perform_activity_request(patron_request) if patron_request.data['activity_ids'].present?
-    return perform_ead_request(patron_request) if patron_request.ead_url.present?
 
-    perform_folio_request(patron_request)
+    if patron_request.data['activity_ids'].present?
+      perform_activity_request(patron_request)
+    elsif patron_request.ead_url.present?
+      perform_ead_request(patron_request)
+    else
+      perform_folio_request(patron_request)
+    end
+
+    patron_request.update(submitted_to_aeon_at: Time.current)
   end
 
   def perform_activity_request(patron_request)

--- a/app/models/aeon/null_user.rb
+++ b/app/models/aeon/null_user.rb
@@ -16,7 +16,7 @@ module Aeon
     end
 
     def all_requests
-      @all_requests ||= []
+      []
     end
 
     def appointments

--- a/app/models/aeon/null_user.rb
+++ b/app/models/aeon/null_user.rb
@@ -15,6 +15,10 @@ module Aeon
       @requests ||= []
     end
 
+    def all_requests
+      @all_requests ||= []
+    end
+
     def appointments
       @appointments ||= []
     end

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -26,8 +26,12 @@ module Aeon
       auth_type == 'Default'
     end
 
+    def all_requests
+      @all_requests ||= self.class.aeon_client.requests_for(username:)
+    end
+
     def requests
-      @requests ||= self.class.aeon_client.requests_for(username:).reject(&:activity?)
+      @requests ||= all_requests.reject(&:activity?)
     end
 
     def activities

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -27,7 +27,7 @@ module Aeon
     end
 
     def all_requests
-      @all_requests ||= self.class.aeon_client.requests_for(username:)
+      self.class.aeon_client.requests_for(username:)
     end
 
     def requests

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -134,14 +134,6 @@ class PatronRequest < ApplicationRecord
     aeon_page? && scan?
   end
 
-  def expected_aeon_item_count
-    if ead_url.present?
-      aeon_item&.count || 0
-    else
-      selected_items.count
-    end
-  end
-
   def item_mediation_data
     super || {}
   end

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -12,7 +12,7 @@
     <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'mt-4 mb-4', title_classes: ['h3']) %>
     <div data-controller="aeon-confirmation-poll" data-aeon-confirmation-poll-attempts-value="0">
       <turbo-frame id="aeon-confirmation" data-aeon-confirmation-poll-target="frame">
-        <% if @aeon_requests.count < @patron_request.expected_aeon_item_count %>
+        <% if @patron_request.submitted_to_aeon_at.nil? && !params[:stop_polling] %>
           <div class="d-flex align-items-center my-3" data-aeon-confirmation-poll-target="loading">
             <div class="spinner-border spinner-border-sm me-2" role="status">
               <span class="visually-hidden">Loading...</span>

--- a/db/migrate/20260515085854_add_submitted_to_aeon_at_to_patron_requests.rb
+++ b/db/migrate/20260515085854_add_submitted_to_aeon_at_to_patron_requests.rb
@@ -1,0 +1,5 @@
+class AddSubmittedToAeonAtToPatronRequests < ActiveRecord::Migration[8.1]
+  def change
+    add_column :patron_requests, :submitted_to_aeon_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_175606) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_15_085854) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "comment"
     t.string "commenter"
@@ -55,6 +55,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_175606) do
     t.string "patron_id"
     t.string "request_type"
     t.string "service_point_code"
+    t.datetime "submitted_to_aeon_at"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["display_type"], name: "index_patron_requests_on_display_type"

--- a/spec/factories/aeon.rb
+++ b/spec/factories/aeon.rb
@@ -43,6 +43,21 @@ FactoryBot.define do
     initialize_with { new(**attributes) }
   end
 
+  factory :aeon_activity, class: 'Aeon::Activity' do
+    id { 1 }
+    name { 'An Aeon Activity' }
+    activity_type { 'Class visit' }
+    start_time { Time.zone.parse('2026-02-19T12:00:00') }
+    stop_time { Time.zone.parse('2026-02-19T13:00:00') }
+    active { true }
+    status { 'Pending' }
+    location { 'Special Collections' }
+    sites { ['SPECUA'] }
+    users { [] }
+
+    initialize_with { new(**attributes) }
+  end
+
   factory :aeon_appointment, class: 'Aeon::Appointment' do
     id { 23 }
     username { 'nerdsquirrel@stanford.edu' }

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   let(:aeon_user) { Aeon::User.new(username: user.email_address, auth_type: 'Default') }
   let(:stub_aeon_client) do
     instance_double(AeonClient, find_user: aeon_user, create_request: created_request, update_request_route: nil,
-                                reading_rooms:, available_appointments:, activities_for: [])
+                                reading_rooms:, available_appointments:, activities_for: [], requests_for: [])
   end
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, draft?: false, valid?: true) }
   let(:available_appointments) do

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -109,6 +109,43 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
     end
   end
 
+  context 'with an activity request' do
+    let(:activity) { build(:aeon_activity, id: 42, users: [aeon_user]) }
+    let(:stub_aeon_client) do
+      instance_double(AeonClient, find_user: aeon_user, create_request: created_request, update_request_route: nil,
+                                  reading_rooms:, available_appointments:, activities_for: [activity])
+    end
+
+    before do
+      allow(stub_aeon_client).to receive(:requests_for) do
+        patron_request = PatronRequest.last
+        # Exercise the confirmation screen polling
+        next [] unless patron_request&.submitted_to_aeon_at
+
+        [build(:aeon_request, :submitted,
+               activity_id: 42,
+               web_request_form: 'multiple',
+               reference_number: patron_request.to_global_id.to_s)]
+      end
+    end
+
+    it 'shows the activity-grouped confirmation after submission' do
+      choose 'Activity (e.g., class visit or exhibit)'
+      click_button 'Continue'
+
+      check 'An Aeon Activity'
+
+      click_button 'Submit request'
+
+      expect(page).to have_text 'We received your activities request'
+
+      perform_enqueued_jobs
+
+      expect(page).to have_text 'An Aeon Activity'
+      expect(page).to have_text 'Request #307'
+    end
+  end
+
   context 'with multiple holdings' do
     let(:folio_instance) { :special_collections_holdings }
 


### PR DESCRIPTION
Maybe `expected_aeon_item_count` is too brittle and we should just write the time all the requests hit Aeon in the DB.

closes #3676