### PR TITLE
use transaction number for accordion, add chevron for accordion

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -501,6 +501,10 @@ label.btn-close {
  transform: rotate(180deg);
 }
 
+.accordion-header[aria-expanded="true"] .accordion-header-icon::before {
+  transform: rotate(180deg);
+}
+
 .request.card, .request-group.card {
   --bs-card-cap-bg: white;
   --bs-border-radius: 0.25rem;

--- a/app/components/aeon/confirmation_request_list_component.html.erb
+++ b/app/components/aeon/confirmation_request_list_component.html.erb
@@ -1,10 +1,10 @@
 <div class="border rounded p-3 mb-2">
   <h2 class="h3"><%= title %></h2>
   <ul class="list-unstyled mb-0">
-    <% requests.each_with_index do |request, index| %>
+    <% requests.each do |request| %>
       <li class="request accordion accordion-flush">
         <div class="accordion-item">
-          <div class="accordion-header bg-white accordion-button px-0 collapsed d-flex align-items-center justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#<%= accordion_name(index) %>" aria-expanded="false" aria-controls="<%= accordion_name(index) %>" id="<%= accordion_name(index) %>Heading">
+          <div class="accordion-header bg-white accordion-button px-0 collapsed d-flex align-items-center justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#<%= accordion_name(request) %>" aria-expanded="false" aria-controls="<%= accordion_name(request) %>" id="<%= accordion_name(request) %>Heading">
             <div>
               <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
               <span class="ms-2 fs-14">Request #<%= request.transaction_number %></span>
@@ -15,9 +15,10 @@
               <% elsif request.requested_pages.present? %>
                 Pages <%= request.requested_pages %>
               <% end %>
+              <i class="bi bi-chevron-down accordion-header-icon"></i>
             </div>
           </div>
-          <div id="<%= accordion_name(index) %>" class="accordion-collapse collapse" aria-labelledby="<%= accordion_name(index) %>Heading">
+          <div id="<%= accordion_name(request) %>" class="accordion-collapse collapse" aria-labelledby="<%= accordion_name(request) %>Heading">
             <div class="accordion-body">
               <%= request.special_request %>
               <% unless request.special_request.present? %>

--- a/app/components/aeon/confirmation_request_list_component.rb
+++ b/app/components/aeon/confirmation_request_list_component.rb
@@ -27,8 +27,8 @@ module Aeon
       activity.name
     end
 
-    def accordion_name(index)
-      "accordionRequest#{index}"
+    def accordion_name(request)
+      "accordionRequest#{request.transaction_number}"
     end
 
     attr_reader :requests


### PR DESCRIPTION
Because we were using an index for the accordion, when you click on the second item in an activity it would open both accordions for the second item in the list. Using the transaction number will work for all requests because it is a unique id.
Also adds the chevrons Darcy requested.

Before
<img width="1010" height="500" alt="Screenshot 2026-05-15 at 12 51 55 PM" src="https://github.com/user-attachments/assets/870c97e4-0351-4348-8ff8-b4f008929428" />

After:

<img width="850" height="786" alt="Screenshot 2026-05-15 at 3 56 02 PM" src="https://github.com/user-attachments/assets/93f188ba-397a-4b2f-b300-e13108baddfd" />
