### PR TITLE
allow wrapping for selected items in activities

### DIFF
--- a/app/views/patron_requests/_activity.html.erb
+++ b/app/views/patron_requests/_activity.html.erb
@@ -4,7 +4,7 @@
       <span class="text-black fw-semibold selected-item-title">__TITLE__</span>
     </div>
   </template>
-  <div class="selected-items-container px-0 gap-3 d-flex flex-row" data-item-selector-target="selectedItems" data-template="#activityTemplate">
+  <div class="selected-items-container px-0 gap-3 d-flex flex-row flex-wrap" data-item-selector-target="selectedItems" data-template="#activityTemplate">
   </div>
 
   <fieldset class="mt-4 p-2 pb-0 border rounded overflow-y-scroll overflow-x-hidden" style="max-height: 400px">


### PR DESCRIPTION
before:
<img width="673" height="521" alt="Screenshot 2026-05-15 at 3 58 52 PM" src="https://github.com/user-attachments/assets/728a6d23-24f0-4e13-89b2-05811d68f0d6" />

After:
<img width="626" height="499" alt="Screenshot 2026-05-15 at 4 01 33 PM" src="https://github.com/user-attachments/assets/c0c198d2-f824-4c26-8763-962ce7976d1f" />
