### PR TITLE
Use small button style for saved for later delete button

### DIFF
--- a/app/views/aeon_requests/_delete_drafts_button.html.erb
+++ b/app/views/aeon_requests/_delete_drafts_button.html.erb
@@ -1,5 +1,5 @@
 <div class="dropdown">
-  <button class="btn btn-delete" type="button" disabled aria-expanded="false"
+  <button class="btn btn-sm btn-delete" type="button" disabled aria-expanded="false"
     data-draft-request-target="deleteButton" data-action="draft-request#openDeleteModal" id="delete-all">
     <i class="bi bi-trash me-1"></i> Delete selected (<span class="count">0</span>)
   </button>


### PR DESCRIPTION
The designs may have changed on us, but the current designs have this button as the same size as the adjacent buttons.

Before:
<img width="469" height="101" alt="Screenshot 2026-05-22 at 9 39 40 AM" src="https://github.com/user-attachments/assets/6cbb007b-0db9-4c56-8e9b-bbd6fd7af681" />

After:
<img width="436" height="98" alt="Screenshot 2026-05-22 at 9 40 23 AM" src="https://github.com/user-attachments/assets/58462a46-bc97-4acd-94f7-c3cc25f5ad98" />
