### PR TITLE
Use spacing from the design for the confirmation screen chevron

### DIFF
--- a/app/components/aeon/confirmation_request_list_component.html.erb
+++ b/app/components/aeon/confirmation_request_list_component.html.erb
@@ -15,7 +15,7 @@
               <% elsif request.requested_pages.present? %>
                 Pages <%= request.requested_pages %>
               <% end %>
-              <i class="bi bi-chevron-down accordion-header-icon"></i>
+              <i class="bi bi-chevron-down accordion-header-icon ms-3"></i>
             </div>
           </div>
           <div id="<%= dom_id(request, :accordion) %>" class="accordion-collapse collapse" aria-labelledby="<%= dom_id(request, :heading) %>%">


### PR DESCRIPTION
<img width="758" height="271" alt="Screenshot 2026-05-22 at 1 58 04 PM" src="https://github.com/user-attachments/assets/31da85d1-1fab-43df-a328-33861cfc61a0" />
