### PR TITLE
Make the Aeon confirmation list a bit more responsive

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1005,6 +1005,34 @@ label.btn-close {
 .request.list-group-item > .rgi-actions { grid-area: actions; }
 .request.list-group-item > .rgi-footer  { grid-area: footer; }
 
+.confirmation-request-summary {
+  display: grid;
+  flex: 1 1 auto;
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+  align-items: center;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "id"
+    "time"
+    "num";
+
+  @media (min-width: 1200px) {
+    grid-template-columns: auto auto 1fr;
+    grid-template-areas: "id num time";
+  }
+}
+
+.confirmation-request-summary > .crs-id   { grid-area: id; }
+.confirmation-request-summary > .crs-num  { grid-area: num; }
+.confirmation-request-summary > .crs-time {
+  grid-area: time;
+
+  @media (min-width: 1200px) {
+    justify-self: end;
+  }
+}
+
 .modal-body.add-items {
   .reading-room {
     display: none;

--- a/app/components/aeon/confirmation_request_list_component.html.erb
+++ b/app/components/aeon/confirmation_request_list_component.html.erb
@@ -5,18 +5,18 @@
       <li class="request accordion accordion-flush">
         <div class="accordion-item">
           <div class="accordion-header bg-white accordion-button px-0 collapsed d-flex align-items-center justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#<%= dom_id(request, :accordion) %>" aria-expanded="false" aria-controls="<%= dom_id(request, :accordion) %>" id="<%= dom_id(request, :heading) %>">
-            <div>
-              <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
-              <span class="ms-2 fs-14">Request #<%= request.transaction_number %></span>
+            <div class="confirmation-request-summary">
+              <div class="crs-id"><%= render Aeon::RequestItemIdentifierComponent.new(request:) %></div>
+              <span class="crs-num small">Request #<%= request.transaction_number %></span>
+              <span class="crs-time text-nowrap">
+                <% if request.appointment %>
+                  <%= render AppointmentTimeRangeComponent.new(appointment: request.appointment) %>
+                <% elsif request.requested_pages.present? %>
+                  Pages <%= request.requested_pages %>
+                <% end %>
+              </span>
             </div>
-            <div>
-              <% if request.appointment %>
-                <%= render AppointmentTimeRangeComponent.new(appointment: request.appointment) %>
-              <% elsif request.requested_pages.present? %>
-                Pages <%= request.requested_pages %>
-              <% end %>
-              <i class="bi bi-chevron-down accordion-header-icon"></i>
-            </div>
+            <i class="ms-3 bi bi-chevron-down accordion-header-icon"></i>
           </div>
           <div id="<%= dom_id(request, :accordion) %>" class="accordion-collapse collapse" aria-labelledby="<%= dom_id(request, :heading) %>%">
             <div class="accordion-body">

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="confirmation col-8">
+  <div class="confirmation col-12 col-lg-8">
     <% if @patron_request.request_type == 'scan' %>
       <h1>We received your digitization request!</h1>
       <div class="bg-light p-2 fs-5 mb-4">We'll email you when your files are ready.</div>


### PR DESCRIPTION
Not blessed by Darcy but I wonder if we can iterate if she's not a fan. I think personally I'd consider always pushing that request number to another line.

Before (using a less optimistic example than in the designs) the request number can wrap oddly as well as the chevron:
<img width="917" height="577" alt="Screenshot 2026-05-22 at 2 51 14 PM" src="https://github.com/user-attachments/assets/cf9c1379-7a53-4219-a02f-032271af191a" />
<img width="543" height="729" alt="Screenshot 2026-05-22 at 2 51 27 PM" src="https://github.com/user-attachments/assets/0f21d228-af59-45a7-b43e-eaf658b0b7a3" />

After, better(?) but still not ideal with long EAD identifiers:
<img width="518" height="892" alt="Screenshot 2026-05-22 at 2 52 25 PM" src="https://github.com/user-attachments/assets/e6e89082-71e4-4282-9d2a-e4a29a043d92" />
<img width="888" height="583" alt="Screenshot 2026-05-22 at 2 51 58 PM" src="https://github.com/user-attachments/assets/9393d0b6-f020-4a79-80cf-28ee022de035" />
