### PR TITLE
Use consistent heading and button spacing for Aeon Appointments page

### DIFF
--- a/app/views/aeon_appointments/index.html.erb
+++ b/app/views/aeon_appointments/index.html.erb
@@ -2,9 +2,9 @@
   <div id="new-appt-alert"></div>
   <div class="row">
     <div class="col-lg-8 pe-5">
-      <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap">
-        <h1 class="mb-0">Reading room appointments</h1>
-        <div>
+      <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap gap-2">
+        <h1>Reading room appointments</h1>
+        <div class="d-flex flex-wrap gap-2 align-items-baseline">
           <button class="btn btn-outline-primary d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#draft_aeon_requests_sidebar" aria-controls="draft_aeon_requests_sidebar">
             Saved for later
           </button>


### PR DESCRIPTION
Mirrors "Saved for later"

Before:
<img width="423" height="97" alt="Screenshot 2026-05-22 at 3 11 03 PM" src="https://github.com/user-attachments/assets/ffac5455-5d55-45a1-9d8d-8db545c42f25" />

After:
<img width="457" height="115" alt="Screenshot 2026-05-22 at 3 13 42 PM" src="https://github.com/user-attachments/assets/892eec24-c435-43ae-aaa8-1cb4de690d7f" />
