### PR TITLE
Use the appointment banner styles from the designs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -91,6 +91,10 @@ layer(components);
   color: var(--stanford-digital-blue);
 }
 
+.text-digital-blue-dark {
+  color: var(--stanford-digital-blue-dark);
+}
+
 .text-digital-red {
   color: var(--stanford-digital-red);
 }
@@ -938,13 +942,6 @@ label.btn-close {
   caret-color: transparent;
 }
 
-.selected-appointment {
-  font-weight: 600;
-  padding: 0.5rem 1rem;
-  background-color: var(--stanford-fog-light);
-  color: var(--stanford-digital-blue-dark);
-}
-
 .request-group {
   margin-bottom: 1rem;
 }
@@ -1033,6 +1030,11 @@ label.btn-close {
   }
 }
 
+/* Non-specific rule to provide padding for when we use modal content in non-modal situations */
+.modal-body {
+  --bs-modal-padding: 1rem;
+}
+
 .modal-body.add-items {
   .reading-room {
     display: none;
@@ -1097,9 +1099,17 @@ label.btn-close {
 }
 
 .banner {
+  --bs-border-color: var(--stanford-20-black);
+  --bs-border-width: 1px;
   font-weight: 600;
   padding: 0.5rem 1rem;
-  background-color: var(--stanford-fog-light);  
+  background-color: var(--stanford-fog-light);
+
+  &:empty {
+    /* Easier than fighting CSS layers with display: flex !important */
+    height: 0;
+    padding: 0;
+  }
 }
 
 .request-group-per-appointment .request {

--- a/app/components/aeon/appointment_selection_component.html.erb
+++ b/app/components/aeon/appointment_selection_component.html.erb
@@ -1,22 +1,22 @@
 <% if existing_appointment? %>
-<div class="selected-appointment d-flex flex-row">
-  <div class="w-50 border-end">
-    <h4>Current</h4>
-    <%= render AppointmentTimeRangeComponent.new(appointment: @appointment) %>
+<div class="banner d-flex flex-row p-3">
+  <div class="w-50">
+    <h4 class="mb-1">Current</h4>
+    <div class="fw-normal"><%= render AppointmentTimeRangeComponent.new(appointment: @appointment) %></div>
   </div>
-  <div class="ms-3">
-    <h4>
+  <div class="ps-3 border-start">
+    <h4 class="mb-1">
       New
     </h4>
-    <div data-appointment-target="selection">
-      Select date <%= 'and time' unless @appointment.reading_room&.day_only_appointments? %>
+    <div class="text-digital-blue-dark" data-appointment-target="selection">
+      <span class="fw-normal">
+        Select date <%= 'and time' unless @appointment.reading_room&.day_only_appointments? %>
+      </span>
     </div>
   </div>
 </div>
 <% else %>
   <% unless @appointment.reading_room&.day_only_appointments? %>
-    <div class="selected-appointment d-flex flex-row" data-appointment-target="selection">
-      Select date and time
-    </div>
+    <div class="banner d-flex flex-row text-digital-blue-dark" data-appointment-target="selection"></div>
   <% end %>
 <% end %>

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -61,7 +61,7 @@ export default class extends Controller {
     return `
      ${startDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/Los_Angeles' })} -
      ${ endDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/Los_Angeles' }) }
-     `;
+     `.toLowerCase();
   }
 
   updateFormStatus() {

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <%= render AlertComponent.new(type: :info) do %>
-      <ul class="mb-0">
+      <ul class="mb-0 ps-4">
         <li>An appointment must be scheduled at least <%= @appointment.reading_room.appointment_min_lead_days %> business days in advance to access items.</li>
         <li><%= @appointment.reading_room.name %> is open <%= @appointment.reading_room.human_readable_hours %>.</li>
       </ul>

--- a/spec/components/aeon/appointment_selection_component_spec.rb
+++ b/spec/components/aeon/appointment_selection_component_spec.rb
@@ -13,13 +13,11 @@ RSpec.describe Aeon::AppointmentSelectionComponent, type: :component do
     end
 
     it 'renders existing appointment time and date and placeholder for date to be selected' do
-      within('.selected-appointment') do
-        expect(page).to have_css('h4', text: 'Current')
-        expect(page).to have_text('Mar 11, 2024')
-        expect(page).to have_no_text('1:00 PM -  1:15 PM')
-        expect(page).to have_css('h4', text: 'New')
-        expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date')
-      end
+      expect(page).to have_css('h4', text: 'Current')
+      expect(page).to have_text('Mar 11, 2024')
+      expect(page).to have_no_text('1:00 pm - 1:15 pm')
+      expect(page).to have_css('h4', text: 'New')
+      expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date')
     end
   end
 
@@ -32,17 +30,15 @@ RSpec.describe Aeon::AppointmentSelectionComponent, type: :component do
     end
 
     it 'renders existing appointment time and date and placeholder for date to be selected' do
-      within('.selected-appointment') do
-        expect(page).to have_css('h4', text: 'Current')
-        expect(page).to have_text('Mar 11, 2024')
-        expect(page).to have_text('1:00 PM -  1:15 PM')
-        expect(page).to have_css('h4', text: 'New')
-        expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date and time')
-      end
+      expect(page).to have_css('h4', text: 'Current')
+      expect(page).to have_text('Mar 11, 2024')
+      expect(page).to have_text('1:00 pm - 1:15 pm')
+      expect(page).to have_css('h4', text: 'New')
+      expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date and time')
     end
   end
 
-  context 'with new appointment for reading room with date and time' do
+  context 'with a new appointment for reading room with date and time' do
     let(:appointment) { Aeon::Appointment.new }
 
     before do
@@ -50,10 +46,10 @@ RSpec.describe Aeon::AppointmentSelectionComponent, type: :component do
       render_inline(described_class.new(appointment:))
     end
 
-    it 'renders only the selection placeholder to be hidden' do
+    it 'renders the selection placeholder with no text' do
       expect(page).to have_no_text('Current')
       expect(page).to have_no_text('New')
-      expect(page).to have_css('div[data-appointment-target="selection"]', text: 'Select date and time')
+      expect(page).to have_css('div[data-appointment-target="selection"]')
     end
   end
 


### PR DESCRIPTION

<img width="820" height="261" alt="Screenshot 2026-05-22 at 5 06 47 PM" src="https://github.com/user-attachments/assets/377666a7-aab4-4eaf-92a6-87c220104f89" />

<img width="817" height="274" alt="Screenshot 2026-05-22 at 5 11 48 PM" src="https://github.com/user-attachments/assets/581efffd-2ff5-4d3e-a316-4d7af27f833f" />

<img width="821" height="236" alt="Screenshot 2026-05-22 at 5 07 29 PM" src="https://github.com/user-attachments/assets/ea48b635-184d-4454-8046-9e85e098b866" />

Some small details from the [designs](https://www.figma.com/design/sqzYVhfRgn3nMArUAdrs0n/My-Account---Requests?node-id=5163-73819&t=Q1zpv0PnVGjNsmdQ-4), all of which I believe are intentional (e.g., not showing the banner in some circumstances, lighter font weight for the placeholder before selection, etc).

I did deviate by changing from uppercase AM/PM to lowercase. Darcy has a mix in the designs and the devs have otherwise consolidated on lowercase (which seems to be more common in our apps?). 