### PR TITLE
fix min date to take reading room policy into account for fallback, update date picker component to take appointment as variable instead of form

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.html.erb
+++ b/app/components/aeon/appointment_date_picker_component.html.erb
@@ -1,33 +1,35 @@
 <div class="mb-3">
-  <%= form.label :date, class: 'd-block fw-semibold redesign-required-label' %>
-  <div class="position-relative" <%= tag.attributes(controller_data) %>>
-    <%= form.hidden_field :date, data: { "date-picker-target": "input", action: "change->appointment#refreshAvailability" } %>
-    <div data-date-picker-target="announce"
-         aria-live="polite"
-         aria-atomic="true"
-         class="visually-hidden"></div>
-    <button type="button"
-            class="btn btn-outline-secondary w-100 text-start"
-            data-date-picker-target="display"
-            data-action="click->date-picker#toggle"
-      aria-haspopup="dialog"
-      aria-expanded="false">Select a date</button>
-    <div class="date-picker-popup mt-1"
-         data-date-picker-target="calendar"
-         role="dialog"
-         aria-modal="true"
-         aria-labelledby="date-picker-month-label"
-         hidden>
-      <div class="d-flex justify-content-between align-items-center mb-2">
-        <button type="button" class="btn btn-sm btn-light" data-date-picker-target="prevBtn" data-action="click->date-picker#prevMonth" aria-label="Previous month">&#8249;</button>
-        <strong id="date-picker-month-label" data-date-picker-target="monthLabel"></strong>
-        <button type="button" class="btn btn-sm btn-light" data-date-picker-target="nextBtn" data-action="click->date-picker#nextMonth" aria-label="Next month">&#8250;</button>
-      </div>
-      <div data-date-picker-target="grid"></div>
-      <div class="date-picker-legend d-flex align-items-center mt-2 small" data-date-picker-target="legend">
-        <span class="date-picker-dot flex-shrink-0 me-2" aria-hidden="true"></span>
-        <span class="text-muted">Existing appointment</span>
+  <%= fields_for appointment do |form| %>
+    <%= form.label :date, class: 'd-block fw-semibold redesign-required-label' %>
+    <div class="position-relative" <%= tag.attributes(controller_data) %>>
+      <%= form.hidden_field :date, data: { "date-picker-target": "input", action: "change->appointment#refreshAvailability" } %>
+      <div data-date-picker-target="announce"
+          aria-live="polite"
+          aria-atomic="true"
+          class="visually-hidden"></div>
+      <button type="button"
+              class="btn btn-outline-secondary w-100 text-start"
+              data-date-picker-target="display"
+              data-action="click->date-picker#toggle"
+        aria-haspopup="dialog"
+        aria-expanded="false">Select a date</button>
+      <div class="date-picker-popup mt-1"
+          data-date-picker-target="calendar"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="date-picker-month-label"
+          hidden>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <button type="button" class="btn btn-sm btn-light" data-date-picker-target="prevBtn" data-action="click->date-picker#prevMonth" aria-label="Previous month">&#8249;</button>
+          <strong id="date-picker-month-label" data-date-picker-target="monthLabel"></strong>
+          <button type="button" class="btn btn-sm btn-light" data-date-picker-target="nextBtn" data-action="click->date-picker#nextMonth" aria-label="Next month">&#8250;</button>
+        </div>
+        <div data-date-picker-target="grid"></div>
+        <div class="date-picker-legend d-flex align-items-center mt-2 small" data-date-picker-target="legend">
+          <span class="date-picker-dot flex-shrink-0 me-2" aria-hidden="true"></span>
+          <span class="text-muted">Existing appointment</span>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -7,18 +7,24 @@ module Aeon
   #   <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
   #   <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: ['2026-05-01'], marked: ['2026-05-10']) %>
   class AppointmentDatePickerComponent < ViewComponent::Base
-    attr_reader :form, :disabled, :marked
+    attr_reader :appointment, :disabled, :marked
 
-    def initialize(form:, disabled: [], marked: [])
-      @form = form
+    delegate :reading_room, to: :appointment
+
+    def initialize(appointment:, disabled: [], marked: [])
+      @appointment = appointment
       @disabled = disabled
       @marked = marked
     end
 
     def min
-      appointment = form.object
-      next_start = appointment.reading_room&.next_appointment&.start_time
-      next_start&.to_date&.iso8601 || Time.zone.today.iso8601
+      next_start&.to_date&.iso8601
+    end
+
+    def next_start
+      return Time.zone.today unless reading_room
+
+      reading_room.next_appointment&.start_time || reading_room.appointment_min_lead_days&.days&.from_now
     end
 
     def controller_data

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/default.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/default.html.erb
@@ -1,3 +1,1 @@
-<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
-  <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
-<% end %>
+<%= render Aeon::AppointmentDatePickerComponent.new(appointment: Aeon::Appointment.new) %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_disabled_days.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_disabled_days.html.erb
@@ -6,6 +6,4 @@
   range = ((today + 20)..(today + 22)).to_a
   disabled = (individual + range).map(&:iso8601)
 %>
-<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
-  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: disabled) %>
-<% end %>
+<%= render Aeon::AppointmentDatePickerComponent.new(appointment: Aeon::Appointment.new, disabled: disabled) %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_marked_days.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_marked_days.html.erb
@@ -2,6 +2,4 @@
   today = Time.zone.today.beginning_of_month
   marked = [today + 2, today + 5, today + 9, today + 14].map(&:iso8601)
 %>
-<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
-  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, marked: marked) %>
-<% end %>
+<%= render Aeon::AppointmentDatePickerComponent.new(appointment: Aeon::Appointment.new, marked: marked) %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_min_date.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_min_date.html.erb
@@ -3,7 +3,7 @@
                                        time_zone_id: 'Pacific Standard Time', min_appointment_length: 30,
                                        max_appointment_length: 480, appointment_padding: 0,
                                        appointment_increment: 15, last_modified_time: Time.zone.now,
-                                       sites: ['SPECUA'], open_hours: [], policies: [])
+                                       sites: ['SPECUA'], open_hours: [], policies: [Aeon::ReadingRoomPolicy.new(appointment_min_lead_days: 10)])
   next_appt = Aeon::Appointment.new(id: nil, username: nil, reading_room_id: 5,
                                     start_time: 2.weeks.from_now, stop_time: 2.weeks.from_now + 1.hour,
                                     name: nil, available_to_proxies: false, appointment_status: nil,
@@ -14,6 +14,5 @@
                                       appointment_status: nil, reading_room: reading_room,
                                       creation_date: nil)
 %>
-<%= form_with(model: appointment, url: '#') do |f| %>
-  <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
-<% end %>
+
+<%= render Aeon::AppointmentDatePickerComponent.new(appointment:) %>

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb
@@ -3,6 +3,5 @@
   # Disable all Saturdays (wday 6) and Sundays (wday 0) for the next 3 months
   weekends = (today .. today + 90).select { |d| d.wday == 0 || d.wday == 6 }.map(&:iso8601)
 %>
-<%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
-  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: weekends) %>
-<% end %>
+
+<%= render Aeon::AppointmentDatePickerComponent.new(appointment: Aeon::Appointment.new, disabled: weekends) %>

--- a/spec/components/aeon/appointment_date_picker_component_spec.rb
+++ b/spec/components/aeon/appointment_date_picker_component_spec.rb
@@ -3,22 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
-  subject(:component) { described_class.new(form:, disabled:, marked:) }
+  subject(:component) { described_class.new(appointment:, disabled:, marked:) }
 
-  let(:appointment) { build(:aeon_appointment, reading_room: nil) }
+  let(:aeon_client) { instance_double(AeonClient, available_appointments: []) }
+  let(:appointment) { build(:aeon_appointment) }
   let(:disabled) { [] }
   let(:marked) { [] }
-  let(:form) do
-    lookup_context = ActionView::LookupContext.new([])
-    view = ActionView::Base.new(lookup_context, {}, nil)
-    view.extend(Rails.application.routes.url_helpers)
-    ActionView::Helpers::FormBuilder.new(:aeon_appointment, appointment, view, {})
+
+  before do
+    allow(AeonClient).to receive(:new).and_return(aeon_client)
+    allow(appointment.reading_room).to receive(:available_appointments).and_return([])
+    render_inline(component)
   end
 
-  before { render_inline(component) }
-
-  it 'sets data-date-picker-min-value to today when no reading room is present' do
-    expect(page).to have_css("[data-date-picker-min-value='#{Time.zone.today.iso8601}']")
+  it 'sets data-date-picker-min-value to today when no next appointment is present' do
+    expect(page).to have_css("[data-date-picker-min-value='#{5.days.from_now.to_date.iso8601}']")
   end
 
   context 'with disabled dates' do


### PR DESCRIPTION
I found this when looking at #3712. I think? it might fix it but won't know until we test after 5pm pacific. At the very least it should go in because our min should not be today if there is no next appointment. Use hide white space to review.