### PR TITLE
Scope Aeon request `activity_id` activity references to Activities only

### DIFF
--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -9,7 +9,7 @@ module Aeon
     attr_accessor :appointment, :appointment_id
 
     # activity attributes
-    attr_accessor :activity_type, :activity_id
+    attr_accessor :activity_id
 
     # identifiers
     attr_accessor :call_number, :ead_number, :reference_number, :site
@@ -30,7 +30,6 @@ module Aeon
     def self.from_dynamic(dyn) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       photoduplication_date = dyn['photoduplicationDate'].presence
       new(
-        activity_type: dyn.dig('requestFor', 'type'),
         activity_id: (dyn.dig('requestFor', 'reference')&.to_i if dyn.dig('requestFor', 'type') == 'Activity'),
         appointment: dyn['appointment'] ? Appointment.from_dynamic(dyn['appointment']) : nil,
         appointment_id: dyn['appointmentID'],

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -31,7 +31,7 @@ module Aeon
       photoduplication_date = dyn['photoduplicationDate'].presence
       new(
         activity_type: dyn.dig('requestFor', 'type'),
-        activity_id: dyn.dig('requestFor', 'reference')&.to_i,
+        activity_id: (dyn.dig('requestFor', 'reference')&.to_i if dyn.dig('requestFor', 'type') == 'Activity'),
         appointment: dyn['appointment'] ? Appointment.from_dynamic(dyn['appointment']) : nil,
         appointment_id: dyn['appointmentID'],
         call_number: dyn['callNumber'],


### PR DESCRIPTION
There are two other reference types requests can be associated with through this mechanism. It looks like we don't really use them in production, but I don't see any reason not to guard against it.