### PR TITLE
Cache `active_only: false` Aeon requests_for calls

### DIFF
--- a/app/jobs/warmup_aeon_activities_job.rb
+++ b/app/jobs/warmup_aeon_activities_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+##
+# Rails Job to enqueue request cache warmups for every user attached to any Aeon activity.
+class WarmupAeonActivitiesJob < ApplicationJob
+  queue_as :default
+  retry_on Faraday::ConnectionFailed
+
+  def perform
+    usernames = aeon_client.activities.flat_map(&:users).map(&:username).uniq
+    usernames.each_with_index do |username, index|
+      WarmupAeonRequestsJob.set(wait: (index * 5).seconds).perform_later(username)
+    end
+  end
+
+  delegate :aeon_client, to: :Current
+end

--- a/app/jobs/warmup_aeon_requests_job.rb
+++ b/app/jobs/warmup_aeon_requests_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+##
+# Rails Job to refresh the cached Aeon requests for a single user.
+class WarmupAeonRequestsJob < ApplicationJob
+  queue_as :default
+  retry_on Faraday::ConnectionFailed
+
+  def perform(username)
+    aeon_client.warmup_requests_for(username:)
+  end
+
+  delegate :aeon_client, to: :Current
+end

--- a/app/models/aeon/queue.rb
+++ b/app/models/aeon/queue.rb
@@ -62,6 +62,10 @@ module Aeon
       completed_queue_names&.include?(queue_name)
     end
 
+    def inactive?
+      inactive_queue_names&.include?(queue_name)
+    end
+
     private
 
     def cancelled_queue_names
@@ -74,6 +78,10 @@ module Aeon
 
     def draft_queue_names
       Settings.aeon.queue_names.draft[type]
+    end
+
+    def inactive_queue_names
+      Settings.aeon.queue_names.inactive[type]
     end
   end
 end

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -192,6 +192,10 @@ module Aeon
       @web_request_form != 'single'
     end
 
+    def aeon_inactive_status?
+      transaction_queue&.inactive? || photoduplication_queue&.inactive?
+    end
+
     private
 
     def within_persist_completed_request_as_submitted_period?

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -2,6 +2,8 @@
 
 # Client for the Aeon API
 class AeonClient
+  include Requests
+
   class ApiError < StandardError; end
   class NotFoundError < ApiError; end
 
@@ -39,15 +41,6 @@ class AeonClient
 
   def activities_for(username:)
     activities&.select { |activity| activity.users.map(&:username).include?(username) }
-  end
-
-  # Fetch requests for a user by their Aeon username
-  # @param username [String] the user's Aeon username
-  # @return [Array<Aeon::Request>]
-  def requests_for(username:, active_only: false)
-    response = get("Users/#{CGI.escape(username)}/requests", params: { activeOnly: active_only })
-
-    handle_response(response, as_class: Aeon::Request, not_found: [])
   end
 
   # Submit a new request to Aeon
@@ -283,20 +276,25 @@ class AeonClient
     DEFAULT_HEADERS.merge({ 'X-AEON-API-KEY': @api_key })
   end
 
-  def handle_response(faraday_response, as_class: nil, not_found: nil) # rubocop:disable Metrics/MethodLength
+  def handle_response(faraday_response, as_class: nil, not_found: nil)
     if faraday_response.success?
       body = faraday_response.body
-      return yield body unless as_class
+      return yield body if block_given?
+      return body unless as_class
 
-      if body.is_a?(Array)
-        Array.wrap(body).map { |data| as_class.from_dynamic(data) }
-      else
-        as_class.from_dynamic(body)
-      end
+      objects_from_response(body, as_class:)
     elsif faraday_response.status == 404
       not_found
     else
       raise ApiError, "Aeon API error: #{faraday_response.status}"
+    end
+  end
+
+  def objects_from_response(response, as_class:)
+    if response.is_a?(Array)
+      Array.wrap(response).map { |data| as_class.from_dynamic(data) }
+    else
+      as_class.from_dynamic(response)
     end
   end
 end

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -43,28 +43,6 @@ class AeonClient
     activities.select { |activity| activity.users.map(&:username).include?(username) }
   end
 
-  # Submit a new request to Aeon
-  # @param aeon_payload [AeonClient::RequestData]
-  def create_request(aeon_payload)
-    response = post('Requests/create', aeon_payload.as_json.compact)
-
-    handle_response(response, as_class: Aeon::Request)
-  end
-
-  # Submit a request patch to Aeon
-  # @param aeon_payload [AeonClient::RequestData]
-  def update_request(transaction_number:, aeon_payload:)
-    response = patch("Requests/#{transaction_number}", aeon_payload)
-
-    handle_response(response, as_class: Aeon::Request)
-  end
-
-  def update_request_route(transaction_number:, status:)
-    response = post("Requests/#{transaction_number}/route", { newStatus: status })
-
-    handle_response(response, as_class: Aeon::Request)
-  end
-
   def appointments_for(username:, context: 'both', pending_only: true)
     response = get("Users/#{CGI.escape(username)}/appointments", params: { context: context, pendingOnly: pending_only })
 
@@ -154,66 +132,6 @@ class AeonClient
       false
     end
   end.new
-
-  RequestData = Data.define(:call_number, :document_type, :ead_number, :for_publication, :format,
-                            :item_author, :item_citation, :item_date, :item_info1, :item_info2, :appointment_id,
-                            :item_info3, :item_info4, :item_info5, :item_number, :item_subtitle, :item_title, :item_volume,
-                            :location, :web_request_form, :activity_id,
-                            :reference_number, :shipping_option, :site, :special_request, :system_id, :username) do
-    def omission = '…'
-
-    def as_json # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-      {
-        appointmentId: appointment_id&.to_i,
-        callNumber: call_number&.truncate(255, omission:),
-        eadNumber: ead_number&.truncate(255, omission:),
-        forPublication: for_publication,
-        format: format&.truncate(255, omission:),
-        itemAuthor: item_author&.truncate(255, omission:),
-        itemCitation: item_citation&.truncate(255, omission:),
-        itemDate: item_date&.truncate(50, omission:),
-        itemInfo1: item_info1&.truncate(255, omission:),
-        itemInfo2: item_info2&.truncate(255, omission:),
-        itemInfo3: item_info3&.truncate(255, omission:),
-        itemInfo4: item_info4&.truncate(255, omission:),
-        itemInfo5: item_info5&.truncate(255, omission:),
-        itemNumber: item_number&.truncate(50, omission:),
-        itemSubTitle: item_subtitle&.truncate(255, omission:),
-        itemTitle: item_title&.truncate(255, omission:),
-        itemVolume: item_volume&.truncate(255, omission:),
-        location: location&.truncate(255, omission:),
-        referenceNumber: reference_number&.truncate(50, omission:),
-        shippingOption: shipping_option&.truncate(255, omission:),
-        site: site,
-        specialRequest: special_request&.truncate(255, omission:),
-        system_id: system_id,
-        username: username&.truncate(50, omission:),
-        webRequestForm: web_request_form&.truncate(100, omission:) || 'SUL Requests',
-        requestFor: request_for
-      }.reject { |_k, v| v == UNSET }
-    end
-
-    def request_for
-      return nil if activity_id.nil?
-      return UNSET if activity_id.blank? || activity_id == UNSET
-
-      { type: 'Activity', reference: activity_id }
-    end
-
-    def as_patch_json
-      as_json.except(:webRequestForm).map do |k, v|
-        if v.nil?
-          { op: 'remove', path: "/#{k}" }
-        else
-          { op: 'replace', path: "/#{k}", value: v }
-        end
-      end
-    end
-
-    def self.with_defaults
-      new(**members.index_with(UNSET), web_request_form: 'SUL Requests')
-    end
-  end
 
   UserData = Data.define(:address, :address2, :city, :country, :email_address, :first_name, :last_name,
                          :phone, :sso, :state_or_province, :zip_code) do

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -36,11 +36,11 @@ class AeonClient
 
   def activities
     response = get('Activities')
-    handle_response(response, as_class: Aeon::Activity)
+    handle_response(response, as_class: Aeon::Activity, not_found: [])
   end
 
   def activities_for(username:)
-    activities&.select { |activity| activity.users.map(&:username).include?(username) }
+    activities.select { |activity| activity.users.map(&:username).include?(username) }
   end
 
   # Submit a new request to Aeon

--- a/app/services/aeon_client/requests.rb
+++ b/app/services/aeon_client/requests.rb
@@ -5,6 +5,28 @@ class AeonClient
   module Requests
     extend ActiveSupport::Concern
 
+    # Submit a new request to Aeon
+    # @param aeon_payload [AeonClient::RequestData]
+    def create_request(aeon_payload)
+      response = post('Requests/create', aeon_payload.as_json.compact)
+
+      handle_response(response, as_class: Aeon::Request)
+    end
+
+    # Submit a request patch to Aeon
+    # @param aeon_payload [AeonClient::RequestData]
+    def update_request(transaction_number:, aeon_payload:)
+      response = patch("Requests/#{transaction_number}", aeon_payload)
+
+      handle_response(response, as_class: Aeon::Request)
+    end
+
+    def update_request_route(transaction_number:, status:)
+      response = post("Requests/#{transaction_number}/route", { newStatus: status })
+
+      handle_response(response, as_class: Aeon::Request)
+    end
+
     def requests_for(username:)
       merged = merge_request_responses(
         all: cached_all_raw_requests_for(username:),
@@ -15,6 +37,66 @@ class AeonClient
 
     def warmup_requests_for(username:)
       cached_all_raw_requests_for(username:, force: true)
+    end
+
+    RequestData = Data.define(:call_number, :document_type, :ead_number, :for_publication, :format,
+                              :item_author, :item_citation, :item_date, :item_info1, :item_info2, :appointment_id,
+                              :item_info3, :item_info4, :item_info5, :item_number, :item_subtitle, :item_title, :item_volume,
+                              :location, :web_request_form, :activity_id,
+                              :reference_number, :shipping_option, :site, :special_request, :system_id, :username) do
+      def omission = '…'
+
+      def as_json # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+        {
+          appointmentId: appointment_id&.to_i,
+          callNumber: call_number&.truncate(255, omission:),
+          eadNumber: ead_number&.truncate(255, omission:),
+          forPublication: for_publication,
+          format: format&.truncate(255, omission:),
+          itemAuthor: item_author&.truncate(255, omission:),
+          itemCitation: item_citation&.truncate(255, omission:),
+          itemDate: item_date&.truncate(50, omission:),
+          itemInfo1: item_info1&.truncate(255, omission:),
+          itemInfo2: item_info2&.truncate(255, omission:),
+          itemInfo3: item_info3&.truncate(255, omission:),
+          itemInfo4: item_info4&.truncate(255, omission:),
+          itemInfo5: item_info5&.truncate(255, omission:),
+          itemNumber: item_number&.truncate(50, omission:),
+          itemSubTitle: item_subtitle&.truncate(255, omission:),
+          itemTitle: item_title&.truncate(255, omission:),
+          itemVolume: item_volume&.truncate(255, omission:),
+          location: location&.truncate(255, omission:),
+          referenceNumber: reference_number&.truncate(50, omission:),
+          shippingOption: shipping_option&.truncate(255, omission:),
+          site: site,
+          specialRequest: special_request&.truncate(255, omission:),
+          system_id: system_id,
+          username: username&.truncate(50, omission:),
+          webRequestForm: web_request_form&.truncate(100, omission:) || 'SUL Requests',
+          requestFor: request_for
+        }.reject { |_k, v| v == UNSET }
+      end
+
+      def request_for
+        return nil if activity_id.nil?
+        return UNSET if activity_id.blank? || activity_id == UNSET
+
+        { type: 'Activity', reference: activity_id }
+      end
+
+      def as_patch_json
+        as_json.except(:webRequestForm).map do |k, v|
+          if v.nil?
+            { op: 'remove', path: "/#{k}" }
+          else
+            { op: 'replace', path: "/#{k}", value: v }
+          end
+        end
+      end
+
+      def self.with_defaults
+        new(**members.index_with(UNSET), web_request_form: 'SUL Requests')
+      end
     end
 
     private

--- a/app/services/aeon_client/requests.rb
+++ b/app/services/aeon_client/requests.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class AeonClient
+  # Request handling for Aeon Client
+  module Requests
+    extend ActiveSupport::Concern
+
+    def requests_for(username:)
+      merged = merge_request_responses(
+        all: cached_all_raw_requests_for(username:),
+        active: raw_requests_for(username:, active_only: true)
+      )
+      merged.map { |data| Aeon::Request.from_dynamic(data) }
+    end
+
+    def warmup_requests_for(username:)
+      cached_all_raw_requests_for(username:, force: true)
+    end
+
+    private
+
+    def raw_requests_for(username:, active_only: false)
+      response = get("Users/#{CGI.escape(username)}/requests", params: { activeOnly: active_only })
+
+      handle_response(response, as_class: nil, not_found: [])
+    end
+
+    # Aeon requests are not deleted after completion, they only accumulate.
+    # Fetching all requests (active_only: false) can take 10+s for power users.
+    # Our notion of "active" requests deviates from Aeon's, but in ways where we can accept some staleness:
+    # - We persist digitization requests as "active" for a period of time after delivery
+    # - We consider "Awaiting Future Request Processing" as an active state, Aeon does not
+    def cached_all_raw_requests_for(username:, force: false)
+      Rails.cache.fetch("aeon/users/#{username}/requests", expires_in: 4.hours, force:) do
+        raw_requests_for(username:, active_only: false)
+      end
+    end
+
+    def merge_request_responses(all:, active:)
+      all.index_by { |r| r['transactionNumber'] }
+         .merge(active.index_by { |r| r['transactionNumber'] })
+         .values
+    end
+  end
+end

--- a/app/services/aeon_client/requests.rb
+++ b/app/services/aeon_client/requests.rb
@@ -10,7 +10,7 @@ class AeonClient
     def create_request(aeon_payload)
       response = post('Requests/create', aeon_payload.as_json.compact)
 
-      handle_response(response, as_class: Aeon::Request)
+      expire_requests_cache(request: handle_response(response, as_class: Aeon::Request))
     end
 
     # Submit a request patch to Aeon
@@ -18,13 +18,13 @@ class AeonClient
     def update_request(transaction_number:, aeon_payload:)
       response = patch("Requests/#{transaction_number}", aeon_payload)
 
-      handle_response(response, as_class: Aeon::Request)
+      expire_requests_cache(request: handle_response(response, as_class: Aeon::Request))
     end
 
     def update_request_route(transaction_number:, status:)
       response = post("Requests/#{transaction_number}/route", { newStatus: status })
 
-      handle_response(response, as_class: Aeon::Request)
+      expire_requests_cache(request: handle_response(response, as_class: Aeon::Request))
     end
 
     def requests_for(username:)
@@ -113,15 +113,29 @@ class AeonClient
     # - We persist digitization requests as "active" for a period of time after delivery
     # - We consider "Awaiting Future Request Processing" as an active state, Aeon does not
     def cached_all_raw_requests_for(username:, force: false)
-      Rails.cache.fetch("aeon/users/#{username}/requests", expires_in: 4.hours, force:) do
+      Rails.cache.fetch(requests_cache_key(username:), expires_in: 4.hours, force:) do
         raw_requests_for(username:, active_only: false)
       end
+    end
+
+    def requests_cache_key(username:)
+      "aeon/users/#{username}/requests"
     end
 
     def merge_request_responses(all:, active:)
       all.index_by { |r| r['transactionNumber'] }
          .merge(active.index_by { |r| r['transactionNumber'] })
          .values
+    end
+
+    def expire_requests_cache(request:)
+      # If the request would be picked up by the `active_only: true` option in requests_for
+      # we don't need to expire the cache.
+      return request unless request.aeon_inactive_status?
+
+      # Any time a request moves from no status(new)/active/inactive to inactive, the cache is stale
+      Rails.cache.delete(requests_cache_key(username: request.username))
+      request
     end
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,7 @@
 every 1.day, roles: :production_cron  do
   rake 'data_removal:remove_old_requests'
 end
+
+every 4.hours, roles: :production_cron do
+  runner 'WarmupAeonActivitiesJob.perform_later'
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -416,6 +416,19 @@ aeon:
     draft:
       transaction:
         - Awaiting User Review
+    inactive:
+      photoduplication:
+        - Order Finished
+        - Order Cancelled by User
+        - Order Cancelled by Staff
+      transaction:
+        - Awaiting Future Request Processing
+        - Awaiting User Review
+        - Request In Processing
+        - Cancelled by User
+        - Cancelled by Staff
+        - Submitted by User
+        - Request Finished
 
 RECAPTCHA:
   SITE_KEY: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy

--- a/spec/services/aeon_client_spec.rb
+++ b/spec/services/aeon_client_spec.rb
@@ -69,11 +69,22 @@ RSpec.describe AeonClient do
   end
 
   describe '#requests_for' do
+    let(:json_headers) { { 'Content-Type' => 'application/json' } }
+
+    def request_payload(transaction_number:, **overrides)
+      {
+        transactionNumber: transaction_number,
+        creationDate: '2024-01-01T12:00:00Z',
+        transactionDate: '2024-01-01T12:00:00Z',
+        username: 'jdoe'
+      }.merge(overrides)
+    end
+
     it 'returns an array of requests for the user' do
       stub_request(:get, 'https://aeon.example.com/api/Users/jdoe/requests?activeOnly=false')
-        .to_return(status: 200, body: [{ transactionNumber: '123', creationDate: '2024-01-01T12:00:00Z',
-                                         transactionDate: '2024-01-01T12:00:00Z',
-                                         username: 'jdoe' }].to_json, headers: { 'Content-Type' => 'application/json' })
+        .to_return(status: 200, body: [request_payload(transaction_number: '123')].to_json, headers: json_headers)
+      stub_request(:get, 'https://aeon.example.com/api/Users/jdoe/requests?activeOnly=true')
+        .to_return(status: 200, body: [].to_json, headers: json_headers)
 
       requests = client.requests_for(username: 'jdoe')
 
@@ -84,11 +95,37 @@ RSpec.describe AeonClient do
 
     it 'returns an empty array if the API returns a 404' do
       stub_request(:get, 'https://aeon.example.com/api/Users/jdoe/requests?activeOnly=false')
-        .to_return(status: 404, body: { error: 'No requests found' }.to_json, headers: { 'Content-Type' => 'application/json' })
+        .to_return(status: 404, body: { error: 'No requests found' }.to_json, headers: json_headers)
+      stub_request(:get, 'https://aeon.example.com/api/Users/jdoe/requests?activeOnly=true')
+        .to_return(status: 404, body: { error: 'No requests found' }.to_json, headers: json_headers)
 
       requests = client.requests_for(username: 'jdoe')
 
       expect(requests).to eq([])
+    end
+
+    it 'merges active and all responses, preferring the active version on collision' do
+      stub_request(:get, 'https://aeon.example.com/api/Users/jdoe/requests?activeOnly=false')
+        .to_return(status: 200,
+                   body: [
+                     request_payload(transaction_number: '1', transactionStatus: 'stale'),
+                     request_payload(transaction_number: '2', transactionStatus: 'completed-only-in-all')
+                   ].to_json,
+                   headers: json_headers)
+      stub_request(:get, 'https://aeon.example.com/api/Users/jdoe/requests?activeOnly=true')
+        .to_return(status: 200,
+                   body: [
+                     request_payload(transaction_number: '1', transactionStatus: 'fresh'),
+                     request_payload(transaction_number: '3', transactionStatus: 'only-in-active')
+                   ].to_json,
+                   headers: json_headers)
+
+      by_number = client.requests_for(username: 'jdoe').index_by(&:transaction_number)
+
+      expect(by_number.keys).to contain_exactly('1', '2', '3')
+      expect(by_number['1'].transaction_status).to eq('fresh')
+      expect(by_number['2'].transaction_status).to eq('completed-only-in-all')
+      expect(by_number['3'].transaction_status).to eq('only-in-active')
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,8 @@ RSpec.configure do |config|
       to_return(status: 404, body: "", headers: {})
     stub_request(:get, %r{#{Settings.aeon.api_url}/Activities}).
       to_return(status: 200, body: [], headers: {})
+    stub_request(:get, %r{#{Settings.aeon.api_url}/Queues}).
+      to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
   end
 
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Here's a thought I'm kicking around regarding the slow Aeon API call for users with a huge number of historic requests (ME). I think it's...kinda bad? 😄 

It does make requests & activities usable for me. It'd be more convincing if I could reheat the cache on request operations, not just invalidate it. The various bulk operations make this difficult. Maybe caching the response is the wrong approach.

Won't work out of the box, we'd need to pick a `cache_store` other than `:memory_store` so the jobs and the aeon_client can share the same cache.