### PR TITLE
allow disabled day names for date picker

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -7,11 +7,12 @@ module Aeon
   #   <%= render Aeon::AppointmentDatePickerComponent.new(form: f) %>
   #   <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: ['2026-05-01'], marked: ['2026-05-10']) %>
   class AppointmentDatePickerComponent < ViewComponent::Base
-    attr_reader :form, :disabled, :marked
+    attr_reader :form, :disabled, :marked, :disabled_daynames
 
-    def initialize(form:, disabled: [], marked: [])
+    def initialize(form:, disabled: [], marked: [], disabled_daynames: [])
       @form = form
       @disabled = disabled
+      @disabled_daynames = disabled_daynames
       @marked = marked
     end
 
@@ -22,8 +23,8 @@ module Aeon
     end
 
     def controller_data
-      attrs = { controller: 'date-picker' }
-      attrs[:'date-picker-min-value'] = min if min.present?
+      attrs = { controller: 'date-picker', date_picker_min_value: min }
+      attrs[:'date-picker-disabled-daynames-value'] = disabled_daynames.to_json if disabled_daynames.any?
       attrs[:'date-picker-disabled-value'] = disabled.to_json if disabled.any?
       attrs[:'date-picker-marked-value'] = marked.to_json if marked.any?
       { data: attrs }

--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -4,6 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 //
 // Data attributes on the controller element:
 //   data-date-picker-disabled-value  JSON array of ISO dates to disable, e.g. '["2026-04-24","2026-04-27"]'
+//   data-date-picker-disabled-daynames-value JSON array of daynames to disable, e.g. '["Saturday", "Sunday"]'
 //   data-date-picker-marked-value    JSON array of ISO dates to mark with a dot, e.g. '["2026-04-23"]'
 //   data-date-picker-min-value       ISO date string; any date before this is disabled, e.g. '"2026-04-23"'
 //
@@ -15,9 +16,10 @@ import { Controller } from "@hotwired/stimulus"
 //   grid        element where the day buttons are rendered
 export default class extends Controller {
   static targets = ["input", "calendar", "display", "monthLabel", "grid", "announce", "prevBtn", "nextBtn", "legend"]
-  static values = { disabled: Array, marked: Array, min: String }
+  static values = { disabled: Array, marked: Array, min: String, disabledDaynames: Array}
 
   connect() {
+    this.disabledDayInts = this.disabledDaynamesValue.map(name => this.dayToInt(name))
     const initial = this.inputTarget.value
     let seed = initial ? new Date(`${initial}T00:00:00`) : new Date()
     // If no date is selected but a minValue exists in a future month (e.g. the earliest
@@ -33,6 +35,11 @@ export default class extends Controller {
     this.renderCalendar()
     document.addEventListener("click", this.#handleOutsideClick)
     this.element.addEventListener("keydown", this.#handleKeydown)
+  }
+
+  dayToInt(day) {
+    let dayToIntMapping = { Sunday: 0, Monday: 1, Tuesday: 2, Wednesday: 3, Thursday: 4, Friday: 5, Saturday: 6}
+    return dayToIntMapping[day]
   }
 
   disconnect() {
@@ -125,18 +132,15 @@ export default class extends Controller {
     const tbody = table.createTBody()
     rows.slice(1).forEach(weekDays => {
       const tr = tbody.insertRow()
-      weekDays.forEach(day => {
+      weekDays.forEach((day, index) => {
         const td = tr.insertCell()
         if (day === null) return
-
         const isoDate = [
           year,
           String(month + 1).padStart(2, "0"),
           String(day).padStart(2, "0")
         ].join("-")
 
-        const isDisabled = this.disabledValue.includes(isoDate) ||
-          (this.minValue && isoDate < this.minValue)
         const isMarked = this.markedValue.includes(isoDate)
         const isSelected = isoDate === selected
 
@@ -151,7 +155,7 @@ export default class extends Controller {
         ].join(" ")
         btn.dataset.date = isoDate
         btn.dataset.action = "click->date-picker#selectDay"
-        btn.disabled = isDisabled
+        btn.disabled = this.#isDateDisabled(isoDate, index)
         btn.setAttribute("aria-pressed", String(isSelected))
         btn.tabIndex = isoDate === this.#toIsoDate(this.focusedDate) ? 0 : -1
         btn.textContent = day
@@ -212,9 +216,9 @@ export default class extends Controller {
     ].join("-")
   }
 
-  #isDateDisabled(isoDate) {
+  #isDateDisabled(isoDate, index) {
     return this.disabledValue.includes(isoDate) ||
-      (this.minValue && isoDate < this.minValue)
+      (this.minValue && isoDate < this.minValue) || this.disabledDayInts.includes(index)
   }
 
   #handleOutsideClick = (event) => {
@@ -257,7 +261,7 @@ export default class extends Controller {
 
     // Skip over disabled dates (guard against all dates being disabled)
     let guard = 0
-    while (this.#isDateDisabled(this.#toIsoDate(candidate)) && guard++ < 60) {
+    while (this.#isDateDisabled(this.#toIsoDate(candidate), candidate.getDay()) && guard++ < 60) {
       candidate.setDate(candidate.getDate() + step)
     }
     if (guard >= 60) return

--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -39,6 +39,10 @@ module Aeon
       )
     end
 
+    def closed_days
+      Date::DAYNAMES - open_hours.map(&:day_name)
+    end
+
     def appointment_item_limit
       Settings.aeon.item_limits[sites.first]
     end

--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb
@@ -1,8 +1,3 @@
-<%
-  today = Time.zone.today
-  # Disable all Saturdays (wday 6) and Sundays (wday 0) for the next 3 months
-  weekends = (today .. today + 90).select { |d| d.wday == 0 || d.wday == 6 }.map(&:iso8601)
-%>
 <%= form_with(model: Aeon::Appointment.new, url: '#') do |f| %>
-  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled: weekends) %>
+  <%= render Aeon::AppointmentDatePickerComponent.new(form: f, disabled_daynames: ["Saturday", "Sunday"]) %>
 <% end %>

--- a/spec/components/aeon/appointment_date_picker_component_spec.rb
+++ b/spec/components/aeon/appointment_date_picker_component_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
-  subject(:component) { described_class.new(form:, disabled:, marked:) }
+  subject(:component) { described_class.new(form:, disabled:, marked:, disabled_daynames:) }
 
   let(:appointment) { build(:aeon_appointment, reading_room: nil) }
   let(:disabled) { [] }
+  let(:disabled_daynames) { [] }
   let(:marked) { [] }
   let(:form) do
     lookup_context = ActionView::LookupContext.new([])
@@ -26,6 +27,14 @@ RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
 
     it 'encodes disabled dates as JSON on the controller element' do
       expect(page).to have_css("[data-date-picker-disabled-value='#{disabled.to_json}']")
+    end
+  end
+
+  context 'with disabled daynames' do
+    let(:disabled_daynames) { %w[Monday Tuesday] }
+
+    it 'encodes disabled dates as JSON on the controller element' do
+      expect(page).to have_css("[data-date-picker-disabled-daynames-value='#{disabled_daynames.to_json}']")
     end
   end
 

--- a/spec/features/aeon_date_picker_spec.rb
+++ b/spec/features/aeon_date_picker_spec.rb
@@ -163,4 +163,25 @@ RSpec.describe 'Date picker keyboard navigation', :js do
       expect(focused_date).to eq((today + 3).iso8601)
     end
   end
+
+  describe 'disabled weekends' do
+    before { visit '/lookbook/preview/aeon/appointment_date_picker/with_weekends_disabled' }
+
+    it 'weekends are disabled and ArrowRight skips a disabled date and lands on the next enabled date' do
+      open_picker
+      weekends = (today..(today + 30)).select { |d| [0, 6].include?(d.wday) }.map(&:iso8601)
+      weekends.each do |weekend|
+        expect(page).to have_css("[data-date='#{weekend}'][disabled]")
+      end
+
+      # arrow right enough to go over a weekend. So if it is Wed (3). 7-3 = 4, arrow right 4 times.
+      # that would go over Thu, Fri, (Skip Sat, Sun), Mon, Tues.
+      # We are using 7 instead of 6 because if the test runs on Sunday it won't arrow over.
+      (7 - today.wday).times do
+        grid_send(:arrow_right)
+      end
+
+      expect(focused_date).to eq((today + (9 - today.wday)).iso8601)
+    end
+  end
 end


### PR DESCRIPTION
closes #3405 

Switches from mapping 3 months of Saturdays and Sundays:
https://github.com/sul-dlss/sul-requests/blob/f8f9334d432b3f3f268ac4e84be523c901a4c657/spec/component_previews/aeon/appointment_date_picker_component_preview/with_weekends_disabled.html.erb#L3-L5

To switching to user being able to pass just the day into a variable. i.e. ['Monday', 'Tuesday']

It also adds a closed_day function to reading room https://github.com/sul-dlss/sul-requests/pull/3731/changes#diff-e4f2af2a3a95cbb75ea17d98a616301837544d1ace4b2c76a60b557229060d9fR42
﻿﻿ 