### PR TITLE
don't use red for date picker button

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.html.erb
+++ b/app/components/aeon/appointment_date_picker_component.html.erb
@@ -7,7 +7,7 @@
          aria-atomic="true"
          class="visually-hidden"></div>
     <button type="button"
-            class="btn btn-outline-secondary w-100 text-start"
+            class="btn border-black w-100 text-start"
             data-date-picker-target="display"
             data-action="click->date-picker#toggle"
       aria-haspopup="dialog"


### PR DESCRIPTION
Before:
<img width="754" height="336" alt="Screenshot 2026-06-02 at 5 07 24 PM" src="https://github.com/user-attachments/assets/c462b39a-304d-4a50-b4c6-3cdd82456a23" />
After:
<img width="759" height="340" alt="Screenshot 2026-06-02 at 5 07 13 PM" src="https://github.com/user-attachments/assets/64c041c3-8ad2-43b5-8ce7-cec70e5f99cf" />
