### PR TITLE
Rename outdated 'updated_request' var name

### DIFF
--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -51,7 +51,7 @@ class AeonRequestsController < ApplicationController
     respond_to do |format|
       format.turbo_stream { update_turbo_stream }
       format.html do
-        aeon_requests_path = updated_request.draft? ? aeon_requests_path(kind: 'drafts') : aeon_requests_path(kind: 'submitted')
+        aeon_requests_path = @updated_aeon_request.draft? ? aeon_requests_path(kind: 'drafts') : aeon_requests_path(kind: 'submitted')
         redirect_to aeon_requests_path, notice: 'Request was successfully updated.'
       end
     end


### PR DESCRIPTION
Variable introduced by 8f236f9

I missed the ivar conversion in ffbe467

22eb704 touches near it, and c1e0a28 does the rename