### PR TITLE
Restore styling of EAD search results pill

### DIFF
--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -79,17 +79,17 @@
                      data-action="input->ead-search#onInput keydown->ead-search#onKeydown">
               <div class="ead-search-overlay d-none position-absolute top-50 end-0 translate-middle-y d-flex align-items-center gap-2 pe-2"
                    data-ead-search-target="countPill">
-                <span class="small rounded-pill bg-stanford-10-black d-inline-flex align-items-center px-2 fw-semibold"
+                <span class="small rounded-pill bg-stanford-10-black d-inline-flex align-items-center px-2 py-0 fw-semibold"
                       role="status" aria-live="polite">
-                  <button type="button" class="btn btn-sm btn-link p-0 text-digital-blue"
+                  <button type="button" class="btn btn-sm btn-link p-0 text-digital-blue border-0"
                           aria-label="Previous match"
                           data-ead-search-target="prevButton"
-                          data-action="click->ead-search#prev"><i class="bi bi-arrow-left-short"></i></button>
+                          data-action="click->ead-search#prev"><i class="bi bi-arrow-left-short fs-6"></i></button>
                   <span class="mx-2" data-ead-search-target="countText"></span>
-                  <button type="button" class="btn btn-sm btn-link p-0 text-digital-blue"
+                  <button type="button" class="btn btn-sm btn-link p-0 text-digital-blue border-0"
                           aria-label="Next match"
                           data-ead-search-target="nextButton"
-                          data-action="click->ead-search#next"><i class="bi bi-arrow-right-short"></i></button>
+                          data-action="click->ead-search#next"><i class="bi bi-arrow-right-short fs-6"></i></button>
                 </span>
                 <button type="button" class="btn btn-sm btn-link p-0 text-body"
                         aria-label="Clear search"


### PR DESCRIPTION
This drifted as we standardized the pill styling.

Before:
<img width="620" height="195" alt="Screenshot 2026-06-05 at 8 27 58 AM" src="https://github.com/user-attachments/assets/fe50a796-5d5b-47d4-acc1-1fd5ab4d9cc7" />

After:
<img width="616" height="198" alt="Screenshot 2026-06-05 at 8 26 38 AM" src="https://github.com/user-attachments/assets/e8f195c6-d927-44b6-8305-7a9be28d84de" />
