### PR TITLE
fix min_date component view

### DIFF
--- a/spec/component_previews/aeon/appointment_date_picker_component_preview/with_min_date.html.erb
+++ b/spec/component_previews/aeon/appointment_date_picker_component_preview/with_min_date.html.erb
@@ -3,7 +3,9 @@
                                        time_zone_id: 'Pacific Standard Time', min_appointment_length: 30,
                                        max_appointment_length: 480, appointment_padding: 0,
                                        appointment_increment: 15, last_modified_time: Time.zone.now,
-                                       sites: ['SPECUA'], open_hours: [], policies: [])
+                                       sites: ['SPECUA'],
+                                       open_hours: [Aeon::ReadingRoomOpenHours.new(day_of_week: 1, day_name: 'Monday', open_time: Time.zone.parse('09:00'), close_time: Time.zone.parse('17:00'))],
+                                       policies: [])
   next_appt = Aeon::Appointment.new(id: nil, username: nil, reading_room_id: 5,
                                     start_time: 2.weeks.from_now, stop_time: 2.weeks.from_now + 1.hour,
                                     name: nil, available_to_proxies: false, appointment_status: nil,


### PR DESCRIPTION
I am looking at if we can do this better and set all these variables in the rb file and use factories but it is not working correctly so this will work for now.

Problem: on min date view all dates are disabled because no open hours are listed.

Before: 
<img width="596" height="491" alt="Screenshot 2026-06-05 at 1 42 52 PM" src="https://github.com/user-attachments/assets/a00814ac-2ddd-4d90-9457-3a0ff9a902d3" />

After:
<img width="603" height="400" alt="Screenshot 2026-06-05 at 1 42 39 PM" src="https://github.com/user-attachments/assets/5f813415-4b39-49aa-91c8-9e403a3ba2c1" />
