### PR TITLE
make duration options accessible

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -572,7 +572,7 @@ label.btn-close {
 }
 
 /* This can't go inline or display: none for when the turbo-frame is loading won't work */
-.appointment-slots, .duration-selectors {
+.appointment-slots {
   display: flex;
 }
 
@@ -597,7 +597,7 @@ label.btn-close {
     margin-top: -1rem;
   }
 
-  fieldset > *:not(legend):not(.duration-selectors) {
+  fieldset > *:not(legend) {
     display: none;
   }
 }
@@ -625,13 +625,13 @@ label.btn-close {
 .appointment-form {
   --bs-border-color: var(--stanford-50-black);
 
-  .btn-check:checked + .btn {
+  .selected-duration {
     --bs-border-color: var(--stanford-digital-blue);
     background-color: var(--stanford-digital-blue);
     color: white;
   }
 
-  .btn-check:checked + .btn::before {
+  .selected-duration::before {
     content: "\f633"; /* check-lg icon */
     display: inline-block;
     font-family: "bootstrap-icons";

--- a/app/components/aeon/appointment_duration_selector_component.html.erb
+++ b/app/components/aeon/appointment_duration_selector_component.html.erb
@@ -2,11 +2,12 @@
   <legend class="fs-6 fw-semibold redesign-required-label">Duration</legend>
 
   <div class="d-flex flex-wrap gap-3">
+  <%= form.hidden_field :duration, tabindex: 0, class: 'btn-check', value: selected %>
+
   <% [30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours].each do |duration| %>
-    <span class="duration-selector" data-appointment-target="duration" data-seconds="<%= duration %>">
-      <%= form.radio_button :duration, duration.to_i, class: 'btn-check', checked: selected == duration.to_i, data: { action: 'appointment#applyDurationFilter' } %>
-      <%= form.label "duration_#{duration.to_i}", duration.inspect.sub('minutes', 'min'), class: 'btn border px-1' %>
-    </span>
+    <button data-action='appointment#selectDuration' class="duration-selector btn border px-1" data-appointment-target="duration" data-seconds="<%= duration %>">
+       <%= duration.inspect.sub('minutes', 'min') %>
+    </button>
   <% end %>
   </div>
 </fieldset>

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -73,9 +73,19 @@ export default class extends Controller {
     }
   }
 
+  selectDuration(e) {
+    e.preventDefault();
+    this.element.querySelector('.selected-duration')?.classList.remove('selected-duration')
+    e.currentTarget.classList.add('selected-duration')
+    this.element.querySelector("[name='aeon_appointment[duration]']").value = e.currentTarget.dataset.seconds
+    this.applyDurationFilter();
+  }
+
   applyDurationFilter() {
     const formData = new FormData(this.element);
     const apptDuration = formData.get('aeon_appointment[duration]');
+    if (apptDuration < 1) return;
+
     this.updateFormStatus();
 
     this.element.querySelectorAll('[name="aeon_appointment[start_time]"]:not([type="hidden"])').forEach((radio) => {

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -6,7 +6,7 @@
         <%= f.hidden_field :duration, value: @available_appointments.first.maximum_appointment_length.to_i %>
       <% end %>
     <% else %>
-      <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, selected:  params['duration'].to_i) %>
+      <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, selected: params['duration'].to_i) %>
       <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments_on_selected_date.count %>">
         <fieldset class="mb-3" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>


### PR DESCRIPTION
Before tab would skip duration options. Now it works
<img width="666" height="285" alt="Screenshot 2026-06-05 at 5 31 45 PM" src="https://github.com/user-attachments/assets/2481bb3a-58af-408b-82ad-b77ce6585b0f" />
