### PR TITLE
Improve the responsiveness of the appointment option

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -899,11 +899,8 @@ label.btn-close {
     --bs-btn-active-bg: white;
   }
 
-  button.dropdown-toggle {
-    min-width: 100%;
-    @media (min-width: 576px) {
-      min-width: 19.8rem; /* Barely fits longer case like "Jun 30,2026 * 11:00 am - 12:45 pm (10 items)" */
-    }
+  .appointment-option .label-value {
+    white-space: normal;
   }
 
   .selected, li:has(input:checked)  {
@@ -919,6 +916,14 @@ label.btn-close {
       left: 0.3rem;
       margin-top:0.5rem;
     }
+  }
+}
+
+.custom-select .dropdown-toggle,
+.appointment-option {
+  min-width: 100%;
+  @media (min-width: 768px) {
+    min-width: 21rem; /* Barely fits longer case like "Jun 30,2026 * 11:00 am - 12:45 pm (10 items)" */
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -903,6 +903,13 @@ label.btn-close {
     white-space: normal;
   }
 
+  .dropdown-toggle {
+    min-width: 100%;
+    @media (min-width: 768px) {
+      min-width: 21rem; /* Barely fits longer case like "Jun 30,2026 * 11:00 am - 12:45 pm (10 items)" */
+    }
+  }
+
   .selected, li:has(input:checked)  {
     background-color: var(--bs-primary-bg-subtle);
     &::before {
@@ -916,14 +923,6 @@ label.btn-close {
       left: 0.3rem;
       margin-top:0.5rem;
     }
-  }
-}
-
-.custom-select .dropdown-toggle,
-.appointment-option {
-  min-width: 100%;
-  @media (min-width: 768px) {
-    min-width: 21rem; /* Barely fits longer case like "Jun 30,2026 * 11:00 am - 12:45 pm (10 items)" */
   }
 }
 

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -22,7 +22,7 @@
   <%= fields_for base_name, object do |f| %>
     <div class="appt-select d-flex flex-wrap align-items-center column-gap-2 row-gap-1">
       <div class="fs-6 mb-0 w-100 form-label fw-semibold redesign-required-label possibly-visually-hidden-appointments-label">Appointment</div>
-      <div class="dropdown custom-select" data-controller="appointment-select" data-action="change->appointment-select#updateSelected input->appointment-select#updateSelected appointment-select:change@document->appointment-select#updateItemCounts">
+      <div class="dropdown custom-select flex-grow-1 flex-md-grow-0" data-controller="appointment-select" data-action="change->appointment-select#updateSelected input->appointment-select#updateSelected appointment-select:change@document->appointment-select#updateItemCounts">
         <%= f.hidden_field :appointment_id, class: 'visually-hidden', data: { 'appointment-select-target': :input, 'required-for-submit': true } %>
         <%= button_tag 'Select appointment', class: 'py-1 btn border dropdown-toggle text-start d-flex align-items-center justify-content-between', type: 'button', data: { bs_toggle: 'dropdown', appointment_select_target: 'button' }, aria: { expanded: false }, disabled: selectable_appointments.blank? %>
         <menu class="dropdown-menu appt-dropdown w-100">

--- a/app/components/aeon/appointment_option_component.html.erb
+++ b/app/components/aeon/appointment_option_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.li class: 'position-relative', data: @data.merge('sort-key' => appointment.sort_key.to_s, value: appointment.id) do %>
+<%= tag.li class: 'appointment-option position-relative', data: @data.merge('sort-key' => appointment.sort_key.to_s, value: appointment.id) do %>
   <%= button_tag(class: 'dropdown-item p-0 ps-4 pe-2 py-2 my-1', name: name, data: { action: data_action }, value: appointment.id, disabled: at_limit?) do %>
       <span class="label-value">
         <%= render AppointmentTimeRangeComponent.new(appointment:) %>

--- a/app/views/aeon_appointments/_draft_aeon_requests.html.erb
+++ b/app/views/aeon_appointments/_draft_aeon_requests.html.erb
@@ -1,4 +1,4 @@
-<aside class="col-lg-4 offcanvas-lg offcanvas-bottom offcanvas-sm-start overflow-auto" tabindex="-1" id="draft_aeon_requests_sidebar" aria-modal="true" role="dialog">
+<aside class="col-xl-4 offcanvas-xl offcanvas-bottom offcanvas-sm-start overflow-auto" tabindex="-1" id="draft_aeon_requests_sidebar" aria-modal="true" role="dialog">
   <turbo-frame src="<%= aeon_requests_path(kind: 'drafts', variant: 'sidebar', filter: 'reading_room', sort: 'title') %>" id="aeon-requests-frame" class="d-block mt-3" data-turbo="false">
     <div class="d-flex align-items-center justify-content-center" style="height: 200px;">
       <div class="spinner-border" role="status">

--- a/app/views/aeon_appointments/index.html.erb
+++ b/app/views/aeon_appointments/index.html.erb
@@ -1,11 +1,11 @@
 <div class="container appointments-index">
   <div id="new-appt-alert"></div>
   <div class="row">
-    <div class="col-lg-8 pe-5">
+    <div class="col-xl-8 pe-5">
       <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap gap-2">
         <h1>Reading room appointments</h1>
         <div class="d-flex flex-wrap gap-2 align-items-baseline">
-          <button class="btn btn-outline-primary d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#draft_aeon_requests_sidebar" aria-controls="draft_aeon_requests_sidebar">
+          <button class="btn btn-outline-primary d-xl-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#draft_aeon_requests_sidebar" aria-controls="draft_aeon_requests_sidebar">
             Saved for later
           </button>
           <%= link_to 'Create new appointment', new_aeon_appointment_path, class: 'btn btn-primary', data: { action: 'modal#open' } %>
@@ -15,7 +15,7 @@
   </div>
 
   <div class="row">
-    <div class="col-lg-8 pe-5">
+    <div class="col-xl-8 pe-5">
       <turbo-frame id="aeon_appointments">
         <%= render Aeon::AppointmentComponent.with_collection(@appointments) %>
       </turbo-frame>


### PR DESCRIPTION
This:
* lets the appointment option wrap on the request form
* changes the width of the appointment select at smaller sizes (ever so slightly wider than Darcy's designs at the larger end of the medium? breakpoint)
* collapses the aside on the appointments page one breakpoint earlier, which I think reflects our 'long title' reality. I'd love a better solution for this but IDK 🤷‍♂️ 

I'd like to do this to avoid this:
<img width="361" height="319" alt="Screenshot 2026-06-05 at 4 44 24 PM" src="https://github.com/user-attachments/assets/d86e72dd-fe30-468b-be20-0ff746bc35ef" />

and the overflow on the counter here:
<img width="343" height="204" alt="Screenshot 2026-06-05 at 4 46 04 PM" src="https://github.com/user-attachments/assets/43d5da20-38e6-4393-975f-b1f22e77d53b" />

and this clipping:
<img width="385" height="414" alt="Screenshot 2026-06-05 at 4 45 17 PM" src="https://github.com/user-attachments/assets/b748d955-62d7-4821-a54b-94157a2b147b" />


After:
<img width="281" height="263" alt="Screenshot 2026-06-05 at 4 41 14 PM" src="https://github.com/user-attachments/assets/ed796998-2590-4992-b2d8-fbbe9be40e82" />
<img width="349" height="219" alt="Screenshot 2026-06-05 at 4 41 28 PM" src="https://github.com/user-attachments/assets/5b371333-c126-4fd7-8926-2313d17dd9bf" />
<img width="488" height="216" alt="Screenshot 2026-06-05 at 4 41 43 PM" src="https://github.com/user-attachments/assets/aa87671e-edd9-4165-9f64-ed06c629ea4d" />
<img width="642" height="232" alt="Screenshot 2026-06-05 at 4 41 50 PM" src="https://github.com/user-attachments/assets/19e923da-c85f-4d18-be61-7d393c95f98e" />
<img width="595" height="224" alt="Screenshot 2026-06-05 at 4 42 00 PM" src="https://github.com/user-attachments/assets/02e566ac-a830-4531-aef1-8f5a84db6d11" />
<img width="830" height="218" alt="Screenshot 2026-06-05 at 4 42 09 PM" src="https://github.com/user-attachments/assets/b06c56f3-3ef3-4c40-8252-d7d3342d0954" />
<img width="434" height="404" alt="Screenshot 2026-06-05 at 4 52 22 PM" src="https://github.com/user-attachments/assets/5e3bf2db-8b54-438b-8142-7b5876ad304c" />
