### PR TITLE
Clamp date picker search to min/max boundaries

### DIFF
--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -265,12 +265,18 @@ export default class extends Controller {
     // Skip over disabled dates (guard against all dates being disabled)
     let guard = 0
     while (this.#isDateDisabled(this.#toIsoDate(candidate), candidate.getDay())) {
+      // When outside the min/max bounds, clamp to the boundary if we're stepping
+      // toward the valid range; otherwise no enabled date exists in this direction.
       if (this.minValue && this.#toIsoDate(candidate) < this.minValue) {
-        return;
+        if (step < 0) return;
+        candidate = new Date(this.minValue + "T00:00:00")
+        continue
       }
 
       if (this.maxValue && this.#toIsoDate(candidate) > this.maxValue) {
-        return;
+        if (step > 0) return;
+        candidate = new Date(this.maxValue + "T00:00:00")
+        continue
       }
 
       if (guard++ >= maximumDatesToExamine) return;


### PR DESCRIPTION
I think this is doing what we want and avoids this:

<img width="536" height="385" alt="Screenshot 2026-06-08 at 2 53 59 PM" src="https://github.com/user-attachments/assets/16acfc9b-325f-49d7-adf0-e658105a77a2" />
