### PR TITLE
Move the duration component out of the available appointments turbo frame

### DIFF
--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -34,9 +34,9 @@
         <%= f.time_field :stop_time, required: true %>
       </div>
     <% else %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
-        <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
+      <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
 
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
         <fieldset class="mb-3">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
           <% if @appointment.reading_room_id && @appointment.date %>

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -6,7 +6,6 @@
         <%= f.hidden_field :duration, value: @available_appointments.first.maximum_appointment_length.to_i %>
       <% end %>
     <% else %>
-      <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @reading_room, selected:  params['duration'].to_i) %>
       <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments_on_selected_date.count %>">
         <fieldset class="mb-3" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>


### PR DESCRIPTION
We're not changing what we're displaying, so I'm not sure there's any benefit to reloading it?