### PR TITLE
Suppress open hours for closed locations.

### DIFF
--- a/app/components/aeon/appointment_date_time_component.html.erb
+++ b/app/components/aeon/appointment_date_time_component.html.erb
@@ -1,8 +1,10 @@
 <span><i class="bi bi-calendar <%= icon_class %>"></i><%= l(appointment.start_time, format: :date_only) %></span>
 <span>
-  <% if appointment.reading_room && appointment.reading_room.day_only_appointments? %>
-    <% if show_open_hours? %>
+  <% if appointment.reading_room && appointment.reading_room.day_only_appointments? && show_open_hours? %>
+    <% if appointment.start_time != appointment.stop_time %>
       <i class="bi bi-clock <%= icon_class %>"></i>Open hours: <%= l(appointment.start_time, format: :time_only) %> - <%= l(appointment.stop_time, format: :time_only) %>
+    <% else %>
+      <i class="bi bi-clock <%= icon_class %>"></i>No public hours
     <% end %>
   <% else %>
     <i class="bi bi-clock <%= icon_class %>"></i><%= l(appointment.start_time, format: :time_only) %> - <%= l(appointment.stop_time, format: :time_only) %>


### PR DESCRIPTION
This case probably doesn't happen after we have client + server side validation, but I'm sure it's possible for admins to create appointments like this anyway 🤷‍♂️  

<img width="612" height="259" alt="Screenshot 2026-06-09 at 09 51 10" src="https://github.com/user-attachments/assets/5dc52f99-850a-49f4-a972-4a88751870a8" />
