### PR TITLE
Make the date picker form styling consistent with other elements 

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.html.erb
+++ b/app/components/aeon/appointment_date_picker_component.html.erb
@@ -1,36 +1,34 @@
-<div class="mb-3">
-  <%= form.label key, class: 'd-block form-label mb-0 fw-semibold redesign-required-label' %>
-  <%= tag.div class: 'position-relative', data: controller_data do %>
-    <%= form.hidden_field key, data: { "date-picker-target": "input" }, autocomplete: false %>
-    <div data-date-picker-target="announce"
-         aria-live="polite"
-         aria-atomic="true"
-         class="visually-hidden"></div>
-    <button type="button"
-            class="form-control w-100 text-start text-nowrap d-inline-flex justify-content-between"
-            data-date-picker-target="button"
-            data-action="click->date-picker#toggle"
-      aria-haspopup="dialog"
-      aria-expanded="false">
-      <span data-date-picker-target="selectedValue">Select a date</span>
-      <i class="bi bi-calendar ms-2" aria-hidden="true"></i>
-    </button>
-    <div class="date-picker-popup mt-1"
-         data-date-picker-target="calendar"
-         role="dialog"
-         aria-modal="true"
-         aria-labelledby="date-picker-month-label"
-         hidden>
-      <div class="d-flex justify-content-between align-items-center mb-2">
-        <button type="button" class="btn btn-sm btn-light" data-date-picker-target="prevBtn" data-action="click->date-picker#prevMonth" aria-label="Previous month">&#8249;</button>
-        <strong id="date-picker-month-label" data-date-picker-target="monthLabel"></strong>
-        <button type="button" class="btn btn-sm btn-light" data-date-picker-target="nextBtn" data-action="click->date-picker#nextMonth" aria-label="Next month">&#8250;</button>
-      </div>
-      <div data-date-picker-target="grid"></div>
-      <div class="date-picker-legend d-flex align-items-center mt-2 small" data-date-picker-target="legend">
-        <span class="date-picker-dot flex-shrink-0 me-2" aria-hidden="true"></span>
-        <span class="text-muted">Existing appointment</span>
-      </div>
+<%= tag.div class: 'position-relative', data: controller_data do %>
+  <%= form.hidden_field key, id: nil, data: { "date-picker-target": "input" }, autocomplete: false %>
+  <div data-date-picker-target="announce"
+        aria-live="polite"
+        aria-atomic="true"
+        class="visually-hidden"></div>
+  <button type="button"
+          id="<%= form.object_name %>_<%= key %>"
+          class="form-control w-100 text-start text-nowrap d-inline-flex justify-content-between"
+          data-date-picker-target="button"
+          data-action="click->date-picker#toggle"
+    aria-haspopup="dialog"
+    aria-expanded="false">
+    <span data-date-picker-target="selectedValue">Select a date</span>
+    <i class="bi bi-calendar ms-2" aria-hidden="true"></i>
+  </button>
+  <div class="date-picker-popup mt-1"
+        data-date-picker-target="calendar"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="date-picker-month-label"
+        hidden>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <button type="button" class="btn btn-sm btn-light" data-date-picker-target="prevBtn" data-action="click->date-picker#prevMonth" aria-label="Previous month">&#8249;</button>
+      <strong id="date-picker-month-label" data-date-picker-target="monthLabel"></strong>
+      <button type="button" class="btn btn-sm btn-light" data-date-picker-target="nextBtn" data-action="click->date-picker#nextMonth" aria-label="Next month">&#8250;</button>
     </div>
-  <% end %>
-</div>
+    <div data-date-picker-target="grid"></div>
+    <div class="date-picker-legend d-flex align-items-center mt-2 small" data-date-picker-target="legend">
+      <span class="date-picker-dot flex-shrink-0 me-2" aria-hidden="true"></span>
+      <span class="text-muted">Existing appointment</span>
+    </div>
+  </div>
+<% end %>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -13,6 +13,7 @@
     <% end %>
 
     <div class="mb-3">
+      <%= f.label :date, class: "form-label fw-semibold redesign-required-label" %>
       <div class="d-flex align-items-center gap-3">
         <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f, reading_room: @appointment.reading_room, data: { action: 'change->appointment#refreshAvailability change->appointment#updateBanner', 'date-picker-marked-value': @appointments.select { |x| x.reading_room_id == @appointment.reading_room_id }.map(&:date).map(&:iso8601) }) %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>


### PR DESCRIPTION
... the container on the form already has the spacing.

<img width="570" height="329" alt="Screenshot 2026-06-09 at 11 08 26" src="https://github.com/user-attachments/assets/5ccc9e9a-4074-469b-af9d-2d9eaca27a1d" />
