### PR TITLE
disable day only reading room appointments if there is an existing ap…

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -48,10 +48,16 @@ module Aeon
       end
     end
 
+    def disabled_days
+      return closures_dates.map(&:iso8601) unless data[:'date-picker-marked-value'] && reading_room&.day_only_appointments?
+
+      closures_dates.map(&:iso8601) + data[:'date-picker-marked-value']
+    end
+
     def controller_data
       data.merge(controller: "#{data[:controller]} date-picker").reverse_merge('date-picker-min-value': min,
                                                                                'date-picker-max-value': max,
-                                                                               'date-picker-disabled-value': closures_dates.map(&:iso8601),
+                                                                               'date-picker-disabled-value': disabled_days,
                                                                                'date-picker-open-days-value': open_days)
     end
   end


### PR DESCRIPTION
…pointment

closes #3679 

I made the decision to keep the existing appointment to nudge the user if they are trying to make an appointment for a day they already have an appointment. 
<img width="810" height="553" alt="Screenshot 2026-06-09 at 2 18 17 PM" src="https://github.com/user-attachments/assets/8da63da2-4a43-415b-9de0-85df9f0202d5" />
