### PR TITLE
Trim existing appointments from available Aeon appointment times

### DIFF
--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -45,9 +45,12 @@ class AeonReadingRoomsController < ApplicationController
   def own_appointment_conflicts
     return [] unless current_user&.aeon
 
-    excluded_id = params[:appointment_id]&.to_i
     current_user.aeon.appointments
-                .reject { |a| a.id == excluded_id }
+                .select { |a| a.reading_room_id == @reading_room.id && a.id != excluded_appointment_id }
                 .map { |a| a.start_time...a.stop_time }
+  end
+
+  def excluded_appointment_id
+    params[:appointment_id]&.to_i
   end
 end

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -31,8 +31,23 @@ class AeonReadingRoomsController < ApplicationController
 
   def load_appointments
     @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
-    @available_appointments = @reading_room.available_appointments(@date, include_next_available: true)
+    @available_appointments = available_appointments_without_conflicts
     @available_appointments_on_selected_date = @available_appointments.select { |x| x.start_time.to_date == @date }
     @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
+  end
+
+  def available_appointments_without_conflicts
+    @reading_room
+      .available_appointments(@date, include_next_available: true)
+      .filter_map { |slot| slot.trimmed_for(own_appointment_conflicts) }
+  end
+
+  def own_appointment_conflicts
+    return [] unless current_user&.aeon
+
+    excluded_id = params[:appointment_id]&.to_i
+    current_user.aeon.appointments
+                .reject { |a| a.id == excluded_id }
+                .map { |a| a.start_time...a.stop_time }
   end
 end

--- a/app/models/aeon/available_appointment.rb
+++ b/app/models/aeon/available_appointment.rb
@@ -9,5 +9,25 @@ module Aeon
         maximum_appointment_length: dyn['maximumAppointmentLengthMinutes'].minutes
       )
     end
+
+    def trimmed_for(conflicts)
+      return self if conflicts.empty?
+      return nil if conflicts.any? { |c| c.cover?(start_time) }
+
+      truncate_to(earliest_conflict_in_window(conflicts))
+    end
+
+    private
+
+    def earliest_conflict_in_window(conflicts)
+      slot_end = start_time + maximum_appointment_length
+      conflicts.map(&:begin).select { |t| t > start_time && t < slot_end }.min
+    end
+
+    def truncate_to(boundary)
+      return self unless boundary
+
+      with(maximum_appointment_length: (boundary - start_time).to_i.seconds)
+    end
   end
 end

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id) }) do |f| %>
+<%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id, appointment_id: (@appointment.id if @appointment.persisted?)) }) do |f| %>
   <%= render Aeon::AppointmentSelectionComponent.new(appointment: @appointment) %>
   <div class="modal-body">
     <div>
@@ -22,7 +22,7 @@
 
     <% if @appointment&.reading_room&.day_only_appointments? %>
       <%# if it's a day-only appointment, we still use the turboframe to check if the reading room is open at all, but we don't need any of the other controls. %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date) %>">
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date, appointment_id: (@appointment.id if @appointment.persisted?)) %>">
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
       </turbo-frame>
     <% elsif @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
@@ -37,7 +37,7 @@
     <% else %>
       <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
 
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time), appointment_id: (@appointment.id if @appointment.persisted?)) if @appointment.reading_room_id %>">
         <fieldset class="mb-3">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
           <% if @appointment.reading_room_id && @appointment.date %>

--- a/spec/features/add_items_spec.rb
+++ b/spec/features/add_items_spec.rb
@@ -57,9 +57,8 @@ RSpec.describe 'Add items modal', :js do
   let(:appointment) { build(:aeon_appointment, start_time: 1.week.from_now) }
 
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   before do

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -28,9 +28,8 @@ RSpec.describe 'Appointments', :js do
                     available_appointments:)
   end
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   before do

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe 'Requesting an item from an EAD', :js do
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, saved_for_later?: false, valid?: true) }
 
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   let(:activities_for) do

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   end
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, saved_for_later?: false, valid?: true) }
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   let(:appointments) do

--- a/spec/models/aeon/available_appointment_spec.rb
+++ b/spec/models/aeon/available_appointment_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::AvailableAppointment do
+  describe '.from_dynamic' do
+    subject(:slot) do
+      described_class.from_dynamic(
+        'utcStartTime' => '2026-04-13T17:00:00Z',
+        'maximumAppointmentLengthMinutes' => 240
+      )
+    end
+
+    it 'parses the start time and converts the length to a duration' do
+      expect(slot).to have_attributes(
+        start_time: Time.zone.parse('2026-04-13T17:00:00Z'),
+        maximum_appointment_length: 240.minutes
+      )
+    end
+  end
+
+  describe '#trimmed_for' do
+    subject(:slot) do
+      described_class.new(
+        start_time: Time.zone.parse('2026-04-13T10:00:00-07:00'),
+        maximum_appointment_length: 4.hours
+      )
+    end
+
+    context 'when no conflicts are given' do
+      it 'returns itself' do
+        expect(slot.trimmed_for([])).to eq slot
+      end
+    end
+
+    context 'when conflicts do not touch the slot window' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T16:00:00-07:00')...Time.zone.parse('2026-04-13T17:00:00-07:00')
+      end
+
+      it 'returns itself' do
+        expect(slot.trimmed_for([conflict])).to eq slot
+      end
+    end
+
+    context 'when the slot start falls inside a conflict' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T09:30:00-07:00')...Time.zone.parse('2026-04-13T10:30:00-07:00')
+      end
+
+      it 'returns nil' do
+        expect(slot.trimmed_for([conflict])).to be_nil
+      end
+    end
+
+    context 'when a conflict begins inside the slot window' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T11:00:00-07:00')...Time.zone.parse('2026-04-13T12:00:00-07:00')
+      end
+
+      it 'trims the maximum length to end at the conflict start' do
+        trimmed = slot.trimmed_for([conflict])
+        expect(trimmed.start_time).to eq slot.start_time
+        expect(trimmed.maximum_appointment_length).to eq 1.hour
+      end
+    end
+
+    context 'when multiple conflicts begin inside the slot window' do
+      let(:earlier) do
+        Time.zone.parse('2026-04-13T11:00:00-07:00')...Time.zone.parse('2026-04-13T11:30:00-07:00')
+      end
+      let(:later) do
+        Time.zone.parse('2026-04-13T13:00:00-07:00')...Time.zone.parse('2026-04-13T14:00:00-07:00')
+      end
+
+      it 'trims to the earliest conflict' do
+        trimmed = slot.trimmed_for([later, earlier])
+        expect(trimmed.maximum_appointment_length).to eq 1.hour
+      end
+    end
+
+    context 'with a conflict ending exactly at the slot start (back-to-back)' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T09:00:00-07:00')...Time.zone.parse('2026-04-13T10:00:00-07:00')
+      end
+
+      it 'returns itself' do
+        expect(slot.trimmed_for([conflict])).to eq slot
+      end
+    end
+
+    context 'with a conflict beginning exactly at the slot end' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T14:00:00-07:00')...Time.zone.parse('2026-04-13T15:00:00-07:00')
+      end
+
+      it 'returns itself' do
+        expect(slot.trimmed_for([conflict])).to eq slot
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #3166

* No server side validation. Easy enough to add, but I think that'd take another Aeon API call and I'm not sure if that's worth it.
* ~~Currently this is a "user can't be in two places at once" approach, not scoped to a particular reading room~~