### PR TITLE
Add a model to handle logic of disabled Aeon reading room days

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -8,12 +8,13 @@ module Aeon
   #   <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f,
   #             data: { 'date-picker-disabled-value': ['2026-05-01'], 'date-picker-marked-value': ['2026-05-10'] }) %>
   class AppointmentDatePickerComponent < ViewComponent::Base
-    attr_reader :key, :form, :reading_room, :data
+    attr_reader :key, :form, :reading_room, :user_appointments, :data
 
-    def initialize(key, form: nil, reading_room: nil, data: {})
+    def initialize(key, form: nil, reading_room: nil, user_appointments: [], data: {})
       @key = key
       @form = form
       @reading_room = reading_room || form.object.reading_room
+      @user_appointments = user_appointments
       @data = data
     end
 
@@ -48,11 +49,23 @@ module Aeon
       end
     end
 
+    # Dates where the user's existing appointments leave no gap long enough
+    # for a new appointment of at least the room's minimum length.
+    def dates_with_no_room
+      return [] unless reading_room && max
+
+      AvailabilityCalendar.new(reading_room:, user_appointments:).dates_with_no_room(Date.parse(min)..Date.parse(max))
+    end
+
+    def disabled_dates
+      (closures_dates + dates_with_no_room).map(&:iso8601).uniq
+    end
+
     def controller_data
       data.merge(controller: "#{data[:controller]} date-picker").reverse_merge('date-picker-today-value': Time.zone.today.iso8601,
                                                                                'date-picker-min-value': min,
                                                                                'date-picker-max-value': max,
-                                                                               'date-picker-disabled-value': closures_dates.map(&:iso8601),
+                                                                               'date-picker-disabled-value': disabled_dates,
                                                                                'date-picker-open-days-value': open_days)
     end
   end

--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -35,22 +35,8 @@ module Aeon
       reading_room&.open_hours&.map(&:day_name) || Date::DAYNAMES
     end
 
-    # Dates where a closure covers the entire span of open hours for that day.
-    def closures_dates # rubocop:disable Metrics/AbcSize
-      return [] if reading_room&.closures.blank?
-
-      reading_room.closures.flat_map do |closure|
-        closure.start_date.to_date.upto(closure.end_date.to_date).to_a.select do |date|
-          hours_on_day = reading_room.open_hours_on(date)
-          next if hours_on_day.nil?
-
-          closure.cover?(hours_on_day.range_on(date))
-        end
-      end
-    end
-
-    # Dates where the user's existing appointments leave no gap long enough
-    # for a new appointment of at least the room's minimum length.
+    # Dates with no usable gap in open hours, given the user's appointments
+    # and the reading room's closures.
     def dates_with_no_room
       return [] unless reading_room && max
 
@@ -58,7 +44,7 @@ module Aeon
     end
 
     def disabled_dates
-      (closures_dates + dates_with_no_room).map(&:iso8601).uniq
+      dates_with_no_room.map(&:iso8601)
     end
 
     def controller_data

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -45,9 +45,12 @@ class AeonReadingRoomsController < ApplicationController
   def own_appointment_conflicts
     return [] unless current_user&.aeon
 
-    excluded_id = params[:appointment_id]&.to_i
     current_user.aeon.appointments
-                .reject { |a| a.id == excluded_id }
+                .select { |a| a.reading_room_id == @reading_room.id && a.id != excluded_appointment_id }
                 .map { |a| a.start_time...a.stop_time }
+  end
+
+  def excluded_appointment_id
+    params[:appointment_id]&.to_i
   end
 end

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -31,8 +31,23 @@ class AeonReadingRoomsController < ApplicationController
 
   def load_appointments
     @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
-    @available_appointments = @reading_room.available_appointments(@date, include_next_available: true)
+    @available_appointments = available_appointments_without_conflicts
     @available_appointments_on_selected_date = @available_appointments.select { |x| x.start_time.to_date == @date }
     @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
+  end
+
+  def available_appointments_without_conflicts
+    @reading_room
+      .available_appointments(@date, include_next_available: true)
+      .filter_map { |slot| slot.trimmed_for(own_appointment_conflicts) }
+  end
+
+  def own_appointment_conflicts
+    return [] unless current_user&.aeon
+
+    excluded_id = params[:appointment_id]&.to_i
+    current_user.aeon.appointments
+                .reject { |a| a.id == excluded_id }
+                .map { |a| a.start_time...a.stop_time }
   end
 end

--- a/app/models/aeon/availability_calendar.rb
+++ b/app/models/aeon/availability_calendar.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Computes which dates in a range have no room left for another booking,
+  # given a user's existing appointments and the reading room's closures.
+  #
+  # A date has "no room" when the longest free gap inside the reading room's
+  # open hours is shorter than the room's minimum appointment length.
+  class AvailabilityCalendar
+    def initialize(reading_room:, user_appointments: [])
+      @reading_room = reading_room
+      @user_appointments = user_appointments
+    end
+
+    def dates_with_no_room(date_range)
+      return [] unless reading_room
+
+      date_range.select { |date| no_room?(date) }
+    end
+
+    def no_room?(date)
+      hours = reading_room.open_hours_on(date)
+      # No open hours means nothing to block out
+      return false unless hours
+
+      open_range = hours.range_on(date)
+      conflicts = conflicts_on(date, open_range)
+      return false if conflicts.empty?
+
+      largest_gap_seconds(open_range, conflicts) < min_appointment_seconds
+    end
+
+    private
+
+    attr_reader :reading_room, :user_appointments
+
+    def conflicts_on(date, open_range)
+      ranges = appointment_ranges_on(date) + closure_ranges_in(open_range)
+      ranges.select { |r| r.begin < open_range.end && r.end > open_range.begin }
+    end
+
+    def appointment_ranges_on(date)
+      user_appointments.select { |a| a.date == date }.map { |a| a.start_time..a.stop_time }
+    end
+
+    def closure_ranges_in(open_range)
+      (reading_room.closures || []).filter_map { |c| c.range if c.range.overlap?(open_range) }
+    end
+
+    def largest_gap_seconds(open_range, conflicts)
+      open_end = open_range.end
+      cursor = open_range.begin
+      largest = 0
+      merge_ranges(conflicts.sort_by(&:begin)).each do |c|
+        gap = [c.begin, open_end].min - cursor
+        largest = gap if gap > largest
+        cursor = [cursor, c.end].max
+        break if cursor >= open_end
+      end
+      [open_end - cursor, largest].max
+    end
+
+    def merge_ranges(sorted)
+      sorted.each_with_object([]) do |r, merged|
+        if merged.last && merged.last.end >= r.begin
+          merged[-1] = merged.last.begin..[merged.last.end, r.end].max
+        else
+          merged << r
+        end
+      end
+    end
+
+    def min_appointment_seconds
+      (reading_room.min_appointment_length || 0) * 60
+    end
+  end
+end

--- a/app/models/aeon/availability_calendar.rb
+++ b/app/models/aeon/availability_calendar.rb
@@ -15,7 +15,7 @@ module Aeon
     def dates_with_no_room(date_range)
       return [] unless reading_room
 
-      date_range.select { |date| no_room?(date) }
+      candidate_dates(date_range).select { |date| no_room?(date) }.sort
     end
 
     def no_room?(date)
@@ -33,6 +33,19 @@ module Aeon
     private
 
     attr_reader :reading_room, :user_appointments
+
+    # An open date can only have no room if at least one conflict touches it.
+    def candidate_dates(date_range)
+      (appointment_dates + closure_dates).uniq.select { |d| date_range.cover?(d) }
+    end
+
+    def appointment_dates
+      user_appointments.map(&:date)
+    end
+
+    def closure_dates
+      (reading_room.closures || []).flat_map { |c| c.start_date.to_date.upto(c.end_date.to_date).to_a }
+    end
 
     def conflicts_on(date, open_range)
       ranges = appointment_ranges_on(date) + closure_ranges_in(open_range)

--- a/app/models/aeon/available_appointment.rb
+++ b/app/models/aeon/available_appointment.rb
@@ -9,5 +9,25 @@ module Aeon
         maximum_appointment_length: dyn['maximumAppointmentLengthMinutes'].minutes
       )
     end
+
+    def trimmed_for(conflicts)
+      return self if conflicts.empty?
+      return nil if conflicts.any? { |c| c.cover?(start_time) }
+
+      truncate_to(earliest_conflict_in_window(conflicts))
+    end
+
+    private
+
+    def earliest_conflict_in_window(conflicts)
+      slot_end = start_time + maximum_appointment_length
+      conflicts.map(&:begin).select { |t| t > start_time && t < slot_end }.min
+    end
+
+    def truncate_to(boundary)
+      return self unless boundary
+
+      with(maximum_appointment_length: (boundary - start_time).to_i.seconds)
+    end
   end
 end

--- a/app/models/aeon/reading_room_closures.rb
+++ b/app/models/aeon/reading_room_closures.rb
@@ -10,8 +10,6 @@ module Aeon
       )
     end
 
-    delegate :cover?, to: :range
-
     def range
       start_date..end_date
     end

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -15,7 +15,8 @@
     <div class="mb-3">
       <%= f.label :date, class: "form-label fw-semibold redesign-required-label" %>
       <div class="d-flex align-items-center gap-3">
-        <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f, reading_room: @appointment.reading_room, data: { action: 'change->appointment#refreshAvailability change->appointment#updateBanner', 'date-picker-marked-value': @appointments.select { |x| x.reading_room_id == @appointment.reading_room_id }.map(&:date).map(&:iso8601) }) %>
+        <% same_room_appointments = @appointments.select { |x| x.reading_room_id == @appointment.reading_room_id && x.id != @appointment.id } %>
+        <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f, reading_room: @appointment.reading_room, user_appointments: same_room_appointments, data: { action: 'change->appointment#refreshAvailability change->appointment#updateBanner', 'date-picker-marked-value': same_room_appointments.map(&:date).map(&:iso8601) }) %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>
       </div>
     </div>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id) }) do |f| %>
+<%= form_with(model: @appointment, class: "appointment-form", data: { controller: 'appointment', 'appointment-availability-route-value': available_aeon_reading_room_url(id: @appointment.reading_room_id, appointment_id: (@appointment.id if @appointment.persisted?)) }) do |f| %>
   <%= render Aeon::AppointmentSelectionComponent.new(appointment: @appointment) %>
   <div class="modal-body">
     <div>
@@ -22,7 +22,7 @@
 
     <% if @appointment&.reading_room&.day_only_appointments? %>
       <%# if it's a day-only appointment, we still use the turboframe to check if the reading room is open at all, but we don't need any of the other controls. %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date) %>">
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date, appointment_id: (@appointment.id if @appointment.persisted?)) %>">
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
       </turbo-frame>
     <% elsif @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
@@ -37,7 +37,7 @@
     <% else %>
       <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
 
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
+      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time), appointment_id: (@appointment.id if @appointment.persisted?)) if @appointment.reading_room_id %>">
         <fieldset class="mb-3">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
           <% if @appointment.reading_room_id && @appointment.date %>

--- a/spec/components/aeon/appointment_date_picker_component_spec.rb
+++ b/spec/components/aeon/appointment_date_picker_component_spec.rb
@@ -62,4 +62,24 @@ RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
       expect(page).to have_no_css('[data-date-picker-marked-value]')
     end
   end
+
+  context 'with a reading room that has a full-day closure' do
+    subject(:component) { described_class.new(:date, form:, reading_room:) }
+
+    # Pick a Monday safely inside the picker's [min, max] window.
+    let(:closure_date) { Date.current.next_occurring(:monday) + 2.weeks }
+    let(:reading_room) do
+      rr = build(:aeon_reading_room,
+                 closures: [Aeon::ReadingRoomClosures.new(
+                   start_date: closure_date.in_time_zone.beginning_of_day,
+                   end_date: closure_date.in_time_zone.end_of_day
+                 )])
+      allow(rr).to receive(:next_appointment).and_return(nil)
+      rr
+    end
+
+    it 'includes the closure date in the disabled-value' do
+      expect(page).to have_css("[data-date-picker-disabled-value*='#{closure_date.iso8601}']")
+    end
+  end
 end

--- a/spec/features/add_items_spec.rb
+++ b/spec/features/add_items_spec.rb
@@ -57,9 +57,8 @@ RSpec.describe 'Add items modal', :js do
   let(:appointment) { build(:aeon_appointment, start_time: 1.week.from_now) }
 
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   before do

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -28,9 +28,8 @@ RSpec.describe 'Appointments', :js do
                     available_appointments:)
   end
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   before do

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe 'Requesting an item from an EAD', :js do
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, saved_for_later?: false, valid?: true) }
 
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   let(:activities_for) do

--- a/spec/features/searchworks_aeon_request_spec.rb
+++ b/spec/features/searchworks_aeon_request_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe 'Creating an Aeon patron request in the redesign', :js do
   end
   let(:created_request) { instance_double(Aeon::Request, id: 123, transaction_number: 'abc123', submitted?: true, saved_for_later?: false, valid?: true) }
   let(:available_appointments) do
-    [instance_double(Aeon::AvailableAppointment,
-                     start_time: DateTime.new(2026, 2, 19),
-                     maximum_appointment_length: 210.minutes)]
+    [Aeon::AvailableAppointment.new(start_time: DateTime.new(2026, 2, 19),
+                                    maximum_appointment_length: 210.minutes)]
   end
 
   let(:appointments) do

--- a/spec/models/aeon/availability_calendar_spec.rb
+++ b/spec/models/aeon/availability_calendar_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::AvailabilityCalendar do
+  subject(:calendar) { described_class.new(reading_room:, user_appointments:) }
+
+  # Monday 2026-06-15, reading room is open 9:00-16:45 PT (7h 45m)
+  let(:reading_room) { build(:aeon_reading_room) }
+  let(:user_appointments) { [] }
+  let(:date) { Date.parse('2026-06-15') }
+
+  before { allow(reading_room).to receive(:closures).and_return([]) }
+
+  describe '#no_room?' do
+    context 'with no conflicts or closures' do
+      it { expect(calendar.no_room?(date)).to be false }
+    end
+
+    context 'when the room is not open on the date' do
+      # Sunday, no open hours
+      let(:date) { Date.parse('2026-06-14') }
+
+      it { expect(calendar.no_room?(date)).to be false }
+    end
+
+    context 'when a single appointment covers the entire open range' do
+      let(:user_appointments) do
+        [build(:aeon_appointment, reading_room: reading_room,
+                                  start_time: Time.zone.parse('2026-06-15T09:00:00-07:00'),
+                                  stop_time: Time.zone.parse('2026-06-15T16:45:00-07:00'))]
+      end
+
+      it { expect(calendar.no_room?(date)).to be true }
+    end
+
+    context 'when conflicts leave a gap shorter than the minimum length' do
+      # min_appointment_length is 30 minutes. Leave only a 15-minute window.
+      let(:user_appointments) do
+        [
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T09:00:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T09:15:00-07:00')),
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T09:30:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T16:45:00-07:00'))
+        ]
+      end
+
+      it { expect(calendar.no_room?(date)).to be true }
+    end
+
+    context 'when conflicts leave a gap at least as long as the minimum length' do
+      # Leave exactly 30 minutes in the middle.
+      let(:user_appointments) do
+        [
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T09:00:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T12:00:00-07:00')),
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T12:30:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T16:45:00-07:00'))
+        ]
+      end
+
+      it { expect(calendar.no_room?(date)).to be false }
+    end
+
+    context 'when conflicts overlap each other' do
+      # Two overlapping conflicts should be merged before measuring gaps.
+      let(:user_appointments) do
+        [
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T09:00:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T13:00:00-07:00')),
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T12:00:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T16:45:00-07:00'))
+        ]
+      end
+
+      it { expect(calendar.no_room?(date)).to be true }
+    end
+
+    context 'when conflicts fall outside the open range' do
+      # Conflicts at 7-8 AM and 6-7 PM, fully outside the 9:00-16:45 window.
+      let(:user_appointments) do
+        [
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T07:00:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T08:00:00-07:00')),
+          build(:aeon_appointment, reading_room: reading_room,
+                                   start_time: Time.zone.parse('2026-06-15T18:00:00-07:00'),
+                                   stop_time: Time.zone.parse('2026-06-15T19:00:00-07:00'))
+        ]
+      end
+
+      it { expect(calendar.no_room?(date)).to be false }
+    end
+
+    context 'when a partial closure leaves no room' do
+      let(:closure) do
+        Aeon::ReadingRoomClosures.new(
+          start_date: Time.zone.parse('2026-06-15T09:00:00-07:00'),
+          end_date: Time.zone.parse('2026-06-15T16:30:00-07:00')
+        )
+      end
+
+      before { allow(reading_room).to receive(:closures).and_return([closure]) }
+
+      it 'considers the closure when measuring gaps' do
+        expect(calendar.no_room?(date)).to be true
+      end
+    end
+  end
+
+  describe '#dates_with_no_room' do
+    let(:date_range) { Date.parse('2026-06-15')..Date.parse('2026-06-19') }
+    let(:user_appointments) do
+      # Block 6/15 (Mon) entirely; leave 6/16 (Tue) open
+      [build(:aeon_appointment, reading_room: reading_room,
+                                start_time: Time.zone.parse('2026-06-15T09:00:00-07:00'),
+                                stop_time: Time.zone.parse('2026-06-15T16:45:00-07:00'))]
+    end
+
+    it 'returns only the dates that have no room' do
+      expect(calendar.dates_with_no_room(date_range)).to eq [Date.parse('2026-06-15')]
+    end
+
+    context 'with no reading room' do
+      let(:reading_room) { nil }
+
+      it 'returns an empty list' do
+        expect(calendar.dates_with_no_room(date_range)).to eq []
+      end
+    end
+  end
+end

--- a/spec/models/aeon/availability_calendar_spec.rb
+++ b/spec/models/aeon/availability_calendar_spec.rb
@@ -134,5 +134,35 @@ RSpec.describe Aeon::AvailabilityCalendar do
         expect(calendar.dates_with_no_room(date_range)).to eq []
       end
     end
+
+    context 'with a closure that spans dates outside the range' do
+      let(:date_range) { Date.parse('2026-06-15')..Date.parse('2026-06-22') }
+      let(:user_appointments) { [] }
+      let(:closure) do
+        Aeon::ReadingRoomClosures.new(
+          start_date: Time.zone.parse('2026-06-22T09:00:00-07:00'),
+          end_date: Time.zone.parse('2026-06-29T16:45:00-07:00')
+        )
+      end
+
+      before { allow(reading_room).to receive(:closures).and_return([closure]) }
+
+      it 'only returns closure dates within the range' do
+        expect(calendar.dates_with_no_room(date_range)).to eq [Date.parse('2026-06-22')]
+      end
+    end
+
+    context 'with an appointment on a date outside the range' do
+      let(:date_range) { Date.parse('2026-06-15')..Date.parse('2026-06-15') }
+      let(:user_appointments) do
+        [build(:aeon_appointment, reading_room: reading_room,
+                                  start_time: Time.zone.parse('2026-06-22T09:00:00-07:00'),
+                                  stop_time: Time.zone.parse('2026-06-22T16:45:00-07:00'))]
+      end
+
+      it 'ignores it' do
+        expect(calendar.dates_with_no_room(date_range)).to eq []
+      end
+    end
   end
 end

--- a/spec/models/aeon/available_appointment_spec.rb
+++ b/spec/models/aeon/available_appointment_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::AvailableAppointment do
+  describe '.from_dynamic' do
+    subject(:slot) do
+      described_class.from_dynamic(
+        'utcStartTime' => '2026-04-13T17:00:00Z',
+        'maximumAppointmentLengthMinutes' => 240
+      )
+    end
+
+    it 'parses the start time and converts the length to a duration' do
+      expect(slot).to have_attributes(
+        start_time: Time.zone.parse('2026-04-13T17:00:00Z'),
+        maximum_appointment_length: 240.minutes
+      )
+    end
+  end
+
+  describe '#trimmed_for' do
+    subject(:slot) do
+      described_class.new(
+        start_time: Time.zone.parse('2026-04-13T10:00:00-07:00'),
+        maximum_appointment_length: 4.hours
+      )
+    end
+
+    context 'when no conflicts are given' do
+      it 'returns itself' do
+        expect(slot.trimmed_for([])).to eq slot
+      end
+    end
+
+    context 'when conflicts do not touch the slot window' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T16:00:00-07:00')...Time.zone.parse('2026-04-13T17:00:00-07:00')
+      end
+
+      it 'returns itself' do
+        expect(slot.trimmed_for([conflict])).to eq slot
+      end
+    end
+
+    context 'when the slot start falls inside a conflict' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T09:30:00-07:00')...Time.zone.parse('2026-04-13T10:30:00-07:00')
+      end
+
+      it 'returns nil' do
+        expect(slot.trimmed_for([conflict])).to be_nil
+      end
+    end
+
+    context 'when a conflict begins inside the slot window' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T11:00:00-07:00')...Time.zone.parse('2026-04-13T12:00:00-07:00')
+      end
+
+      it 'trims the maximum length to end at the conflict start' do
+        trimmed = slot.trimmed_for([conflict])
+        expect(trimmed.start_time).to eq slot.start_time
+        expect(trimmed.maximum_appointment_length).to eq 1.hour
+      end
+    end
+
+    context 'when multiple conflicts begin inside the slot window' do
+      let(:earlier) do
+        Time.zone.parse('2026-04-13T11:00:00-07:00')...Time.zone.parse('2026-04-13T11:30:00-07:00')
+      end
+      let(:later) do
+        Time.zone.parse('2026-04-13T13:00:00-07:00')...Time.zone.parse('2026-04-13T14:00:00-07:00')
+      end
+
+      it 'trims to the earliest conflict' do
+        trimmed = slot.trimmed_for([later, earlier])
+        expect(trimmed.maximum_appointment_length).to eq 1.hour
+      end
+    end
+
+    context 'with a conflict ending exactly at the slot start (back-to-back)' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T09:00:00-07:00')...Time.zone.parse('2026-04-13T10:00:00-07:00')
+      end
+
+      it 'returns itself' do
+        expect(slot.trimmed_for([conflict])).to eq slot
+      end
+    end
+
+    context 'with a conflict beginning exactly at the slot end' do
+      let(:conflict) do
+        Time.zone.parse('2026-04-13T14:00:00-07:00')...Time.zone.parse('2026-04-13T15:00:00-07:00')
+      end
+
+      it 'returns itself' do
+        expect(slot.trimmed_for([conflict])).to eq slot
+      end
+    end
+  end
+end


### PR DESCRIPTION
Contains https://github.com/sul-dlss/sul-requests/pull/3785

Maintains the date picker interface of specifying open days and closed days. Given that, I'm on the fence about the name `AvailabilityCalendar` but have no better names in mind at the moment.

Maybe I need to go one step further and push `open_days` into it as well...