### PR TITLE
Ignore the Aeon stub code in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,16 @@ module SULRequests
     # Load all request types automatically
     config.autoload_paths += %W(#{config.root}/app/mailers/factories #{config.root}/app/models/abilities)
 
+    # Ignore the stub Aeon client code in production
+    if Rails.env.production?
+      Rails.autoloaders.main.ignore(
+        "#{config.root}/app/models/aeon_record.rb",
+        "#{config.root}/app/models/stub_aeon_client.rb",
+        "#{config.root}/app/models/stub_aeon_client",
+        "#{config.root}/app/controllers/stub_aeon_client"
+      )
+    end
+
     config.time_zone = 'Pacific Time (US & Canada)'
 
     config.scanning_library_proxy = { 'SCAN' => 'GREEN' }


### PR DESCRIPTION
```
[ E 2026-06-12 08:48:48.5615 1275003/T4d age/Cor/App/Implementation.cpp:218 ]: Could not spawn process for application /opt/app/requests/requests/current: The application encountered the following error: The `aeon` database is not configured for the `production` environment.
```

It's this or add config for the Aeon database in prod?