### PR TITLE
Manage the add items button state when items are saved-for-later + added to appointments

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1280,3 +1280,8 @@ label.btn-close {
 .hidden-if-peers:only-child {
   display: block;
 }
+
+.add-items-button[data-disabled] {
+  display: none;
+  pointer-events: none;
+}

--- a/app/components/aeon/appointment_component.html.erb
+++ b/app/components/aeon/appointment_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new id: dom_id(appointment) do |c| %>
+<%= render CardComponent.new id: dom_id(appointment), data: { 'appointments-list-target': 'appointment' } do |c| %>
   <% c.with_title do %>
     <h2 class="card-title mb-0 h4 d-flex gap-3">
       <%= render Aeon::AppointmentDateTimeComponent.new(appointment: appointment, location: appointment.reading_room.name) %>
@@ -33,7 +33,7 @@
 
   <% c.with_footer do %>
     <%= render Aeon::AppointmentLimitComponent.from_appointment(appointment) %>
-    <%= link_to "Add items", items_path, class: 'btn btn-outline-primary btn-sm', data: { action: 'modal#open' } unless add_item_disabled? %>
+    <%= link_to "Add items", items_path, class: 'btn btn-outline-primary btn-sm add-items-button', data: { action: 'modal#open', disabled: (true if eligible_saved_for_later_requests.none?), reading_room_id: reading_room_id } if add_item_allowed? %>
   <% end %>
 
   <% c.with_post do %>

--- a/app/components/aeon/appointment_component.rb
+++ b/app/components/aeon/appointment_component.rb
@@ -6,20 +6,20 @@ module Aeon
     attr_reader :appointment
 
     delegate :current_user, to: :helpers
+    delegate :reading_room_id, to: :appointment
 
     def initialize(appointment:)
       @appointment = appointment
     end
 
-    def add_item_disabled?
-      return true unless helpers.can?(:update, appointment) && saved_for_later?
-      return false unless appointment.reading_room.appointment_item_limit
+    def add_item_allowed?
+      return false unless helpers.can?(:update, appointment)
 
-      appointment.requests.count >= appointment.reading_room.appointment_item_limit
+      appointment.reading_room.appointment_item_limit.nil? || appointment.requests.count < appointment.reading_room.appointment_item_limit
     end
 
-    def saved_for_later?
-      @saved_for_later ||= current_user.aeon.requests.saved_for_later.for_reading_room(@appointment.reading_room)
+    def eligible_saved_for_later_requests
+      @eligible_saved_for_later_requests ||= current_user.aeon.requests.saved_for_later.for_reading_room(@appointment.reading_room)
     end
 
     def items_path

--- a/app/components/aeon/request_group_brief_component.rb
+++ b/app/components/aeon/request_group_brief_component.rb
@@ -15,7 +15,7 @@ module Aeon
     end
 
     def data
-      { title: }.merge(@data)
+      { title:, reading_room_id: requests.first.reading_room&.id }.merge(@data)
     end
   end
 end

--- a/app/javascript/controllers/appointments_list_controller.js
+++ b/app/javascript/controllers/appointments_list_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["appointment"]
+
+  connect() {
+    this.subscribeToNewSavedRequests()
+  }
+
+  appointmentTargetConnected(el) {
+    this.toggleAddItemsButtonState(el)
+  }
+
+  subscribeToNewSavedRequests() {
+    this.observer = new MutationObserver((mutations) => {
+      this.toggleAddItemsButtonState()
+    });
+
+    this.observer.observe(document.querySelector("#saved_for_later_aeon_requests_sidebar"), {
+      childList: true, subtree: true
+    });
+  }
+
+  disconnect() {
+    this.observer.disconnect();
+  }
+
+  toggleAddItemsButtonState(el = this.element) {
+    const requestGroups = document.querySelectorAll("#saved_for_later_aeon_requests_sidebar .request-group[data-reading-room-id]")
+    const requestGroupReadingRoomIds = Array.from(requestGroups).map(group => group.dataset.readingRoomId);
+
+    el.querySelectorAll(".add-items-button").forEach(button => {
+      if (requestGroupReadingRoomIds.includes(button.dataset.readingRoomId)) {
+        delete button.dataset.disabled
+      } else {
+        button.dataset.disabled = true
+      }
+    });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import AccordionFormController from "./accordion_form_controller"
 application.register("accordion-form", AccordionFormController)
 
+import AppointmentsListController from "./appointments_list_controller"
+application.register("appointments-list", AppointmentsListController)
+
 import PatronRequestController from "./patron_request_controller"
 application.register("patron-request", PatronRequestController)
 

--- a/app/views/aeon_appointments/index.html.erb
+++ b/app/views/aeon_appointments/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container appointments-index">
+<div class="container appointments-index" data-controller="appointments-list">
   <div id="new-appt-alert"></div>
   <div class="row">
     <div class="col-xl-8 pe-5">

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -129,14 +129,17 @@ RSpec.describe 'Appointments', :js do
     it 'moves the request into saved for later' do
       within "#aeon_request_#{submitted_request.id}" do
         click_on 'Save for later'
+        expect(page).to have_no_link 'Add items'
       end
 
       within '#saved_for_later_aeon_requests_sidebar' do
         expect(page).to have_css "#aeon_request_#{submitted_request.id}"
       end
+
       within '#aeon_appointments' do
         expect(page).to have_no_css "#aeon_request_#{submitted_request.id}"
         expect(page).to have_text 'No items have been requested for this appointment.'
+        expect(page).to have_link 'Add items'
       end
     end
   end


### PR DESCRIPTION
There's probably a better way to do this, but there's a couple funky things going on:

- the add item button is request-specific (maybe it should be a form so we can toggle the button state, but our modal code only handles links...)
- we're doing some data fetching in the `Aeon::AppointmentComponent` that makes it awkward to inject updated request information into the logic (starting cleanup in #3811)

Maybe some refactoring is in order, but at least things will mostly work.