### PR TITLE
Use placeholder required fields for client-side validation.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1348,3 +1348,10 @@ label.btn-close {
     width: auto;
   }
 }
+
+.required-placeholder {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}

--- a/app/components/aeon/appointment_duration_selector_component.html.erb
+++ b/app/components/aeon/appointment_duration_selector_component.html.erb
@@ -4,7 +4,7 @@
   <div class="d-flex flex-wrap gap-3">
   <% options.each do |duration| %>
     <span class="duration-selector" data-appointment-target="duration" data-seconds="<%= duration %>">
-      <%= form.radio_button :duration, duration.to_i, class: 'btn-check', checked: selected == duration.to_i, data: { action: 'appointment#applyDurationFilter' } %>
+      <%= form.radio_button :duration, duration.to_i, class: 'btn-check', checked: selected == duration.to_i, required: true, data: { action: 'appointment#applyDurationFilter' } %>
       <%= form.label "duration_#{duration.to_i}", duration.inspect.sub('minutes', 'min'), class: 'btn border px-1' %>
     </span>
   <% end %>

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -31,7 +31,22 @@ export default class extends Controller {
     url.searchParams.append('selected', startTime);
     url.searchParams.append('duration', apptDuration);
 
+    this.availabilityTarget.replaceChildren(this.availabilityPlaceholder);
     this.availabilityTarget.src = url.toString();
+  }
+
+  get availabilityPlaceholder() {
+    const label = document.createElement('label');
+    label.classList.add('visually-hidden-focusable required-placeholder');
+    label.textContent = 'Loading avaiable appointments.';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.classList.add('visually-hidden-focusable');
+    input.name = 'aeon_appointment[start_time]';
+    input.required = true;
+    label.appendChild(input);
+
+    return label;
   }
 
   updateBanner() {

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -30,6 +30,11 @@
       <%# if it's a day-only appointment, we still use the turboframe to check if the reading room is open at all, but we don't need any of the other controls. %>
       <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date, appointment_id: @appointment.id) %>">
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
+
+        <label class="visually-hidden-focusable required-placeholder">
+          Checking avaiable appointments
+          <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
+        </label>
       </turbo-frame>
     <% elsif @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
       <div class="mb-3">
@@ -60,6 +65,10 @@
 
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
         <div class="selection-message">Select a date and duration to see available appointments.</div>
+        <label class="visually-hidden-focusable required-placeholder">
+          Loading avaiable appointments.
+          <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
+        </label>
       </turbo-frame>
     <% end %>
     <% if @appointment.requests.any? %>

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -21,9 +21,11 @@
       </div>
     <% end %>
     <% if params[:date] && next_appt = @available_appointments.find { |x| x.start_time.to_date > @date } %>
-      <div>
-        There are no appointments on <%= l(@date, format: :short) %>. The next available appointment is on <%= l(next_appt.start_time, format: :date_only) %>.
-      </div>
+      <div>There are no appointments on <%= l(@date, format: :short) %>. The next available appointment is on <%= l(next_appt.start_time, format: :date_only) %>.</div>
+      <label class="visually-hidden-focusable required-placeholder">
+        No avaiable appointments.
+        <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
+      </label>
     <% end %>
   </turbo-frame>
   <turbo-frame id="earliest_appointment">


### PR DESCRIPTION
Future work could include:
- finessing the label language to make sense in context, or
- add some custom form validation to provide that context / place the validation on the right form element / etc