### PR TITLE
Reload the saved requests sidebar when we cancel an appointment.

### DIFF
--- a/app/views/aeon_appointments/destroy.turbo_stream.erb
+++ b/app/views/aeon_appointments/destroy.turbo_stream.erb
@@ -1,3 +1,7 @@
 <%= turbo_stream.remove(@appointment) %>
 
 <%= turbo_stream.remove_all ".dropdown [data-value='#{@appointment.id}']" %>
+
+<%= turbo_stream.replace('saved_for_later_aeon_requests_sidebar') do %>
+  <%= render 'saved_for_later_aeon_requests' %>
+<% end unless params['cancel_items'] == 'true' %>


### PR DESCRIPTION
... at least as a first step. turbo-replacing the entire thing seems a little annoying right now.