### PR TITLE
Don't attempt to update the item counts if we're not in that context.

### DIFF
--- a/app/javascript/controllers/appointment_select_controller.js
+++ b/app/javascript/controllers/appointment_select_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
   }
 
   updateItemCounts() {
+    if (!this.element.closest('#reading-accordion')) return;
     this.element.querySelectorAll('[data-count]').forEach(option => {
       const baseCount = parseInt(option.dataset.count);
 


### PR DESCRIPTION
This fixes a javascript error on the edit requests modal.