### PR TITLE
Display validation errors for appointments.

### DIFF
--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -11,28 +11,22 @@ class AeonAppointmentsController < ApplicationController
   before_action :load_appointment, only: [:edit, :update, :destroy, :items]
   before_action :build_appointment, only: [:new, :create]
   before_action :load_reading_rooms, only: [:new]
+  before_action :set_request_variant
 
   def index
     authorize! :read, Aeon::Appointment
-
-    request.variant = :sidebar if params[:variant] == 'sidebar'
   end
 
   def new
     authorize! :create, Aeon::Appointment
-
-    request.variant = :modal if params[:modal]
   end
 
   def edit
     authorize! :update, @appointment
-
-    request.variant = :modal if params[:modal]
   end
 
   def create # rubocop:disable Metrics/AbcSize
     authorize! :create, @appointment
-    request.variant = :modal if params[:modal]
 
     render :new, status: :unprocessable_content and return unless @appointment.save
 
@@ -46,9 +40,8 @@ class AeonAppointmentsController < ApplicationController
     end
   end
 
-  def update # rubocop:disable Metrics/AbcSize
+  def update
     authorize! :update, @appointment
-    request.variant = :modal if params[:modal]
 
     @appointment.assign_attributes(name: appointment_params[:name], start_time: start_time_param, stop_time: stop_time_param)
     render :edit, status: :unprocessable_content and return unless @appointment.save
@@ -80,6 +73,11 @@ class AeonAppointmentsController < ApplicationController
   end
 
   private
+
+  def set_request_variant
+    request.variant = :modal if params[:modal]
+    request.variant = :sidebar if params[:variant] == 'sidebar'
+  end
 
   def load_reading_rooms
     @reading_rooms = Aeon::ReadingRoom.all

--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -32,8 +32,9 @@ class AeonAppointmentsController < ApplicationController
 
   def create # rubocop:disable Metrics/AbcSize
     authorize! :create, @appointment
+    request.variant = :modal if params[:modal]
 
-    return head :unprocessable_content unless @appointment.save
+    render :new, status: :unprocessable_content and return unless @appointment.save
 
     @other_reading_room_appointments = (@appointments + [@appointment]).select do |appt|
       appt.reading_room.id == @appointment.reading_room.id && can?(:update, appt)
@@ -45,11 +46,12 @@ class AeonAppointmentsController < ApplicationController
     end
   end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     authorize! :update, @appointment
+    request.variant = :modal if params[:modal]
 
     @appointment.assign_attributes(name: appointment_params[:name], start_time: start_time_param, stop_time: stop_time_param)
-    return head :unprocessable_content unless @appointment.save
+    render :edit, status: :unprocessable_content and return unless @appointment.save
 
     respond_to do |format|
       format.turbo_stream { render turbo_stream: turbo_stream.refresh(request_id: nil) }

--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -31,7 +31,7 @@ class AeonAppointmentsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
-    authorize! :create, Aeon::Appointment
+    authorize! :create, @appointment
 
     return head :unprocessable_content unless @appointment.save
 

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -96,9 +96,14 @@ module Aeon
       errors.add(:stop_time, 'must be after start time') if stop_time <= start_time
     end
 
-    def within_open_hours
+    def within_open_hours # rubocop:disable Metrics/AbcSize
       hours = reading_room.open_hours_on(start_time)
-      return errors.add(:start_time, 'is outside reading room hours') unless hours
+
+      unless hours
+        return errors.add(:date, 'is outside reading room hours') if reading_room.day_only_appointments?
+
+        return errors.add(:start_time, 'is outside reading room hours')
+      end
 
       range = hours.range_on(start_time.to_date)
       errors.add(:start_time, 'is outside reading room hours') if start_time < range.begin || stop_time > range.end
@@ -107,7 +112,11 @@ module Aeon
     def not_during_closure
       return unless reading_room.closures.any? { |c| c.range.overlap?(start_time..stop_time) }
 
-      errors.add(:start_time, 'is during a reading room closure')
+      if reading_room.day_only_appointments?
+        errors.add(:date, 'is during a reading room closure')
+      else
+        errors.add(:start_time, 'is during a reading room closure')
+      end
     end
   end
 end

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -19,6 +19,11 @@
         <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f, reading_room: @appointment.reading_room, data: { action: 'change->appointment#refreshAvailability change->appointment#updateBanner', 'date-picker-marked-value': @appointments.for_reading_room(@appointment.reading_room).map(&:date).map(&:iso8601) }) %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>
       </div>
+      <% if f.object.errors[:date].any? %>
+        <p class="error-message text-cardinal mt-1">
+          <%= f.object.errors.full_messages_for(:date).join(", ") %>
+        </p>
+      <% end %>
     </div>
 
     <% if @appointment&.reading_room&.day_only_appointments? %>
@@ -38,6 +43,11 @@
     <% else %>
       <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
 
+      <% if f.object.errors[:start_time].any? %>
+        <p class="error-message text-danger">
+          <%= f.object.errors.full_messages_for(:start_time).join(", ") %>
+        </p>
+      <% end %>
       <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, appointment_id: @appointment.id, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
         <fieldset class="mb-3 radio-button-group">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>


### PR DESCRIPTION
... without spending a lot of time making them look right (in theory, we shouldn't let users get themselves in an invalid state 🤷‍♂️ )

(with a placeholder validation message:)
<img width="363" height="237" alt="Screenshot 2026-06-16 at 09 22 47" src="https://github.com/user-attachments/assets/93a52ba3-c12d-4932-bfd4-5b1633316956" />

