### PR TITLE
Disable existing day only appointments in date picker

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -8,12 +8,13 @@ module Aeon
   #   <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f,
   #             data: { 'date-picker-disabled-value': ['2026-05-01'], 'date-picker-marked-value': ['2026-05-10'] }) %>
   class AppointmentDatePickerComponent < ViewComponent::Base
-    attr_reader :key, :form, :reading_room, :data
+    attr_reader :appointments, :key, :form, :reading_room, :data
 
-    def initialize(key, form: nil, reading_room: nil, data: {})
+    def initialize(key, appointments: [], form: nil, reading_room: nil, data: {})
       @key = key
       @form = form
       @reading_room = reading_room || form.object.reading_room
+      @appointments = appointments
       @data = data
     end
 
@@ -48,12 +49,29 @@ module Aeon
       end
     end
 
+    def scheduled_day_only_appointments
+      return [] unless reading_room&.day_only_appointments?
+
+      appointments.map(&:date)
+    end
+
+    def marked_dates
+      appointments.map { |appt| appt.date.iso8601 }.presence
+    end
+
+    def disabled_dates
+      (closures_dates + scheduled_day_only_appointments).map(&:iso8601).presence
+    end
+
     def controller_data
-      data.merge(controller: "#{data[:controller]} date-picker").reverse_merge('date-picker-today-value': Time.zone.today.iso8601,
-                                                                               'date-picker-min-value': min,
-                                                                               'date-picker-max-value': max,
-                                                                               'date-picker-disabled-value': closures_dates.map(&:iso8601),
-                                                                               'date-picker-open-days-value': open_days)
+      data.merge(controller: "#{data[:controller]} date-picker").reverse_merge(
+        'date-picker-today-value': Time.zone.today.iso8601,
+        'date-picker-min-value': min,
+        'date-picker-max-value': max,
+        'date-picker-disabled-value': disabled_dates,
+        'date-picker-marked-value': marked_dates,
+        'date-picker-open-days-value': open_days
+      )
     end
   end
 end

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -15,7 +15,7 @@
     <div class="mb-3">
       <%= f.label :date, class: "form-label fw-semibold redesign-required-label" %>
       <div class="d-flex align-items-center gap-3">
-        <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f, reading_room: @appointment.reading_room, data: { action: 'change->appointment#refreshAvailability change->appointment#updateBanner', 'date-picker-marked-value': @appointments.for_reading_room(@appointment.reading_room).map(&:date).map(&:iso8601) }) %>
+        <%= render Aeon::AppointmentDatePickerComponent.new(:date, form: f, reading_room: @appointment.reading_room, appointments: @appointments.for_reading_room(@appointment.reading_room), data: { action: 'change->appointment#refreshAvailability change->appointment#updateBanner' }) %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>
       </div>
     </div>

--- a/spec/components/aeon/appointment_date_picker_component_spec.rb
+++ b/spec/components/aeon/appointment_date_picker_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
                                        'date-picker-open-days-value': open_days })
   end
 
+  let(:aeon_client) { instance_double(AeonClient, available_appointments: [], closures: []) }
   let(:appointment) { build(:aeon_appointment, reading_room: nil) }
   let(:disabled) { nil }
   let(:open_days) { nil }
@@ -21,7 +22,10 @@ RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
     ActionView::Helpers::FormBuilder.new(:aeon_appointment, appointment, view, {})
   end
 
-  before { render_inline(component) }
+  before do
+    allow(Current).to receive(:aeon_client).and_return(aeon_client)
+    render_inline(component)
+  end
 
   it 'sets data-date-picker-min-value to today when no reading room is present' do
     expect(page).to have_css("[data-date-picker-min-value='#{Time.zone.today.iso8601}']")
@@ -60,6 +64,42 @@ RSpec.describe Aeon::AppointmentDatePickerComponent, type: :component do
   context 'without marked dates' do
     it 'omits the marked value attribute' do
       expect(page).to have_no_css('[data-date-picker-marked-value]')
+    end
+  end
+
+  describe 'existing appointments' do
+    subject(:component) { described_class.new(:date, form:, appointments:) }
+
+    let(:sites) { ['SPECUA'] }
+    let(:reading_room) { build(:aeon_reading_room, sites:) }
+    let(:appointment) { build(:aeon_appointment, reading_room:) }
+    let(:appointments) do
+      [build(:aeon_appointment, reading_room:, start_time: Time.zone.parse('2026-06-10T09:00:00'),
+                                stop_time: Time.zone.parse('2026-06-10T16:45:00'))]
+    end
+
+    context 'when the room books day-only appointments' do
+      let(:sites) { ['SPECUA'] }
+
+      it 'disables the dates the user already has an appointment on' do
+        expect(page).to have_css("[data-date-picker-disabled-value='#{%w[2026-06-10].to_json}']")
+      end
+
+      it 'still marks those dates so the user sees their existing appointment' do
+        expect(page).to have_css("[data-date-picker-marked-value='#{%w[2026-06-10].to_json}']")
+      end
+    end
+
+    context 'when the room books slotted appointments' do
+      let(:sites) { ['ARS'] }
+
+      it 'marks the dates the user already has an appointment on' do
+        expect(page).to have_css("[data-date-picker-marked-value='#{%w[2026-06-10].to_json}']")
+      end
+
+      it 'does not disable those dates' do
+        expect(page).to have_no_css('[data-date-picker-disabled-value]')
+      end
     end
   end
 end


### PR DESCRIPTION
@dnoneill what do you think about pushing https://github.com/sul-dlss/sul-requests/pull/3775 a bit further like this?

I was trying to convert https://github.com/sul-dlss/sul-requests/pull/3790 after we went a different direction with `AppointmentDeconflictionService`, but I came to the conclusion that it's not worth the effort to pre-compute "fully booked" non-day-only reading room appointments (a rare case), so I think you're correct we should just handle the day only disables for now.

We've already got domain specifics in the date picker, so I feel like we should go one way or another. If we're keeping it Aeon specific, I like bringing `marked_dates` inside.

The non-day-only case would be better handled by live availability, which I'll poke at next.