### PR TITLE
Fetch reading room availability in date picker

### DIFF
--- a/app/components/aeon/appointment_date_picker_component.html.erb
+++ b/app/components/aeon/appointment_date_picker_component.html.erb
@@ -30,5 +30,11 @@
       <span class="date-picker-dot flex-shrink-0 me-2" aria-hidden="true"></span>
       <span class="text-muted">Existing appointment</span>
     </div>
+    <div class="small text-muted mt-2" data-date-picker-target="availabilityStatus" aria-live="polite" hidden>
+      <div class="d-flex align-items-center justify-content-center">
+        <div class="spinner-border spinner-border-sm me-2" aria-hidden="true"></div>
+        <span>Fetching availability…</span>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/components/aeon/appointment_date_picker_component.rb
+++ b/app/components/aeon/appointment_date_picker_component.rb
@@ -34,18 +34,14 @@ module Aeon
       reading_room&.open_hours&.map(&:day_name) || Date::DAYNAMES
     end
 
-    # Dates where a closure covers the entire span of open hours for that day.
-    def closures_dates # rubocop:disable Metrics/AbcSize
-      return [] if reading_room&.closures.blank?
+    def closures_dates
+      reading_room&.fully_closed_dates || []
+    end
 
-      reading_room.closures.flat_map do |closure|
-        closure.start_date.to_date.upto(closure.end_date.to_date).to_a.select do |date|
-          hours_on_day = reading_room.open_hours_on(date)
-          next if hours_on_day.nil?
+    def availability_url
+      return if reading_room.nil? || !Settings.aeon.date_picker_availability_enabled
 
-          closure.cover?(hours_on_day.range_on(date))
-        end
-      end
+      helpers.unavailable_dates_aeon_reading_room_path(reading_room.id, appointment_id: form&.object&.id)
     end
 
     def disabled_days
@@ -59,7 +55,8 @@ module Aeon
                                                                                'date-picker-min-value': min,
                                                                                'date-picker-max-value': max,
                                                                                'date-picker-disabled-value': disabled_days,
-                                                                               'date-picker-open-days-value': open_days)
+                                                                               'date-picker-open-days-value': open_days,
+                                                                               'date-picker-availability-url-value': availability_url)
     end
   end
 end

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -7,7 +7,7 @@ class AeonReadingRoomsController < ApplicationController
   include AeonController
 
   before_action :load_reading_room
-  before_action :load_appointments
+  before_action :load_appointments, only: :available
 
   def available
     @selected_time = params[:selected]
@@ -18,7 +18,33 @@ class AeonReadingRoomsController < ApplicationController
     end
   end
 
+  def unavailable_dates
+    month = Date.strptime(params.expect(:month), '%Y-%m')
+    dates = bookable_dates_in(month).reject do |date|
+      deconflict(@reading_room.available_appointments(date)).any?
+    end
+    render json: { month: params[:month], unavailable_dates: dates.map(&:iso8601) }
+  end
+
   private
+
+  def bookable_dates_in(month)
+    closed = @reading_room.fully_closed_dates.to_set
+    month.all_month.select { |date| @reading_room.open_hours_on(date) && closed.exclude?(date) }
+  end
+
+  def deconflict(available_appointments)
+    Aeon::AppointmentDeconflictionService.new(
+      available_appointments:,
+      existing_appointments: existing_appointments_for_deconfliction
+    ).call
+  end
+
+  def existing_appointments_for_deconfliction
+    current_user.aeon.appointments
+                .for_reading_room(@reading_room)
+                .reject { |a| a.id == params[:appointment_id].to_i }
+  end
 
   def load_reading_room
     @reading_room = Aeon::ReadingRoom.find(params.expect(:id))
@@ -27,14 +53,7 @@ class AeonReadingRoomsController < ApplicationController
   def load_appointments
     @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
     @available_appointments = @reading_room.available_appointments(@date, include_next_available: true)
-    @available_appointments_on_selected_date = available_appointments_without_conflicts(@available_appointments)
+    @available_appointments_on_selected_date = deconflict(@available_appointments)
     @appointment_lengths = @available_appointments_on_selected_date.map(&:maximum_appointment_length)
-  end
-
-  def available_appointments_without_conflicts(available_appointments)
-    existing_appointments = current_user.aeon.appointments
-                                        .for_reading_room(@reading_room)
-                                        .reject { |a| a.id == params[:appointment_id].to_i }
-    Aeon::AppointmentDeconflictionService.new(available_appointments:, existing_appointments:).call
   end
 end

--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -3,23 +3,26 @@ import { Controller } from "@hotwired/stimulus"
 // Custom date picker.
 //
 // Data attributes on the controller element:
-//   data-date-picker-disabled-value  JSON array of ISO dates to disable, e.g. '["2026-04-24","2026-04-27"]'
-//   data-date-picker-open-days-value JSON array of daynames to enable, e.g. '["Monday", "Tuesday"]'
-//   data-date-picker-min-value       ISO date string; any date before this is disabled, e.g. '"2026-04-23"'
-//   data-date-picker-max-value       ISO date string; any date after this is disabled, e.g. '"2027-03-01"'
-//   data-date-picker-marked-value    JSON array of ISO dates to mark with a dot, e.g. '["2026-04-23"]'
+//   data-date-picker-disabled-value         JSON array of ISO dates to disable, e.g. '["2026-04-24","2026-04-27"]'
+//   data-date-picker-open-days-value        JSON array of daynames to enable, e.g. '["Monday", "Tuesday"]'
+//   data-date-picker-min-value              ISO date string; any date before this is disabled, e.g. '"2026-04-23"'
+//   data-date-picker-max-value              ISO date string; any date after this is disabled, e.g. '"2027-03-01"'
+//   data-date-picker-marked-value           JSON array of ISO dates to mark with a dot, e.g. '["2026-04-23"]'
+//   data-date-picker-availability-url-value Optional URL probed per visible month for { unavailable_dates }
 //
 // Targets:
-//   input         hidden <input> that holds the selected ISO date value
-//   button        clickable element (button/span) that shows the formatted date and opens/closes the calendar
-//   selectedValue the selected value as displayed in the button
-//   calendar      the popup wrapper div
-//   monthLabel    element where the current month/year label is rendered
-//   grid          element where the day buttons are rendered
+//   input              hidden <input> that holds the selected ISO date value
+//   button             clickable element (button/span) that shows the formatted date and opens/closes the calendar
+//   selectedValue      the selected value as displayed in the button
+//   calendar           the popup wrapper div
+//   monthLabel         element where the current month/year label is rendered
+//   grid               element where the day buttons are rendered
+//   availabilityStatus optional element shown while a month's availability is being fetched
 export default class extends Controller {
-  static targets = ["input", "calendar", "button", "selectedValue", "monthLabel", "grid", "announce", "prevBtn", "nextBtn", "legend"]
+  static targets = ["input", "calendar", "button", "selectedValue", "monthLabel", "grid", "announce", "prevBtn", "nextBtn", "legend", "availabilityStatus"]
   static values = {
     disabled: Array, marked: Array, min: String, max: String, openDays: Array, year: Number, month: Number, focused: String,
+    availabilityUrl: String,
     today: {
       type: String,
       default: new Date().toISOString().slice(0, 10) // "YYYY-MM-DD"
@@ -28,6 +31,8 @@ export default class extends Controller {
 
   connect() {
     const initial = this.inputTarget.value ? this.inputTarget.value : null
+
+    this.monthStatus = new Map() // key -> "pending" | "done"
 
     // set the initially focused value to the selected day, or the first available day
     this.focusedValue = initial || this.#toIsoDate(this.nextEnabledDateOnOrAfter(new Date(this.todayValue), 1));
@@ -198,9 +203,53 @@ export default class extends Controller {
         this.focusedValue = focusedBtn.dataset.datePickerDateParam
       }
     }
+
+    this.#fetchMonthAvailability(year, month)
+    this.#fetchMonthAvailability(...this.#nextMonth(year, month))
+    this.#updateAvailabilityStatus()
   }
 
   // --- private ---
+
+  #nextMonth(year, month) {
+    return month === 11 ? [year + 1, 0] : [year, month + 1]
+  }
+
+  async #fetchMonthAvailability(year, month) {
+    const key = `${year}-${String(month + 1).padStart(2, "0")}`
+    if (!this.availabilityUrlValue || this.monthStatus.has(key)) return
+    this.monthStatus.set(key, "pending")
+    this.#updateAvailabilityStatus()
+
+    try {
+      const additions = await this.#requestUnavailableDates(key)
+      if (additions.length > 0) {
+        this.disabledValue = [...new Set([...this.disabledValue, ...additions])]
+        this.renderCalendar()
+      }
+      this.monthStatus.set(key, "done")
+    } catch (e) {
+      this.monthStatus.delete(key)
+      throw e
+    } finally {
+      this.#updateAvailabilityStatus()
+    }
+  }
+
+  async #requestUnavailableDates(monthKey) {
+    const sep = this.availabilityUrlValue.includes("?") ? "&" : "?"
+    const url = `${this.availabilityUrlValue}${sep}month=${monthKey}`
+    const res = await fetch(url, { headers: { Accept: "application/json" } })
+    if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${url}`)
+    const data = await res.json()
+    return data.unavailable_dates || []
+  }
+
+  #updateAvailabilityStatus() {
+    if (!this.hasAvailabilityStatusTarget) return
+    const visibleKey = `${this.yearValue}-${String(this.monthValue + 1).padStart(2, "0")}`
+    this.availabilityStatusTarget.hidden = this.monthStatus.get(visibleKey) !== "pending"
+  }
 
   #formatDisplay(isoDate) {
     const [y, m, d] = isoDate.split("-").map(Number)

--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -69,6 +69,16 @@ module Aeon
       open_hours.find { |h| h.day_of_week == date.wday }
     end
 
+    # Dates where a closure covers the entire span of open hours for that day.
+    def fully_closed_dates
+      @fully_closed_dates ||= closures.flat_map do |closure|
+        closure.start_date.to_date.upto(closure.end_date.to_date).select do |date|
+          hours_on_day = open_hours_on(date)
+          hours_on_day && closure.cover?(hours_on_day.range_on(date))
+        end
+      end
+    end
+
     OpenHoursDisplay = Data.define(:day_range, :hours)
 
     # Returns a human-readable set of open hours for the reading room that generally combines sequential days

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -123,9 +123,8 @@ class AeonClient
   end
 
   def reading_rooms
-    @reading_rooms ||= begin
+    @reading_rooms ||= Rails.cache.fetch('aeon/reading_rooms', expires_in: 5.minutes) do
       response = get('ReadingRooms')
-
       handle_response(response, as_class: Aeon::ReadingRoom, not_found: [])
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
   resources :aeon_reading_rooms, only: [] do
     member do
       get 'available', to: 'aeon_reading_rooms#available', as: :available
+      get 'unavailable_dates', to: 'aeon_reading_rooms#unavailable_dates', as: :unavailable_dates
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -384,6 +384,7 @@ aeon_archives_url: https://stanford.aeon.atlas-sys.com/logon?Action=10&Form=31
 aeon:
   api_url: https://stanford-dev.aeon.atlas-sys.com/aeonapi
   api_key: ~
+  date_picker_availability_enabled: true
   days_to_persist_completed_digital_requests_as_submitted: 3
   directions:
     SPECUA: 'Located on the second floor of Green Library'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -24,3 +24,6 @@ features:
 folio:
   okapi_url: 'http://example.com'
   graphql_url: 'http://example.com'
+
+aeon:
+  date_picker_availability_enabled: false


### PR DESCRIPTION
If you're quick you'll see a placeholder loading indicator:
<img width="482" height="708" alt="Screenshot 2026-06-16 at 3 13 51 PM" src="https://github.com/user-attachments/assets/7748dfae-b79c-426d-92bf-e712a59eb6f1" />

Here's one where the 25th gets disabled as a result:
<img width="325" height="385" alt="Screenshot 2026-06-16 at 3 34 01 PM" src="https://github.com/user-attachments/assets/559429b1-d552-43cc-b120-431ce8618cc2" />

* Cache Aeon `ReadingRooms` response for 5 minutes (open hours, policies)
* ~~Provide a way to get `User#appointments` without augmenting them with requests. Nice when we need it, but it adds overhead to the availability calls (10+ seconds for me :cry:)~~ Fixed by https://github.com/sul-dlss/sul-requests/pull/3834
* Pull the closed days logic out of the date picker component and into the reading room controller
* Let the reading room controller tell us unavailable dates for a given month for the user
* Eagerly fetch the current month's and next month's unavailable dates. Fetch 1 subsequent month as the user arrives on the month prior

It's not _fast_ (2-3 seconds) but it starts the initial fetch before the user has opened the picker, so in practice it feels fine to me.

To give you an idea:
```
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-17 -> 200 (85ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-18 -> 200 (164ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-21 -> 200 (85ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-22 -> 200 (100ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-23 -> 200 (87ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-24 -> 200 (116ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-25 -> 200 (105ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-28 -> 200 (86ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-29 -> 200 (91ms)
[AeonClient] GET ReadingRooms/1/AvailableAppointments/2026-09-30 -> 200 (100ms) 
```