### PR TITLE
Defer requests loading by passing the user object to Aeon::Appointment…

### DIFF
--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -8,6 +8,8 @@ module Aeon
     attr_accessor :id, :username, :reading_room_id, :start_time, :stop_time,
                   :name, :appointment_status, :reading_room, :creation_date, :available_to_proxies
 
+    attr_reader :user
+
     validates :start_time, :stop_time, presence: true
     validate :stop_after_start,    if: -> { start_time && stop_time }
     validate :within_open_hours,   if: -> { reading_room && start_time && stop_time }
@@ -36,13 +38,19 @@ module Aeon
       reading_room_id.present?
     end
 
+    def user=(user)
+      @user = user
+      @requests = nil
+      @grouped_requests = nil
+    end
+
     def requests=(requests)
-      @requests = requests
+      @requests = requests.reject(&:cancelled?)
       @grouped_requests = nil
     end
 
     def requests
-      (@requests ||= []).reject(&:cancelled?)
+      @requests ||= (user&.requests&.for_appointment(self) || []).reject(&:cancelled?)
     end
 
     def grouped_requests

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -67,7 +67,7 @@ module Aeon
 
         # augment appointments with their requests
         appointments.each do |appointment|
-          appointment.requests = requests.for_appointment(appointment)
+          appointment.user = self
         end
 
         Aeon::AppointmentFinders.new(appointments.sort_by(&:sort_key).reject(&:cancelled?))


### PR DESCRIPTION
… instead of eagerly fetching requests.