### PR TITLE
Don't reload the appointment sidebar when e.g. re-sorting the request list

### DIFF
--- a/app/views/aeon_requests/_aeon_appointments.html.erb
+++ b/app/views/aeon_requests/_aeon_appointments.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame src="<%= aeon_appointments_path(variant: 'sidebar') %>" id="aeon-appointments-frame" class="d-block" data-turbo="false">
+<turbo-frame src="<%= aeon_appointments_path(variant: 'sidebar') %>" id="aeon-appointments-frame" class="d-block" data-turbo-permanent data-turbo="false">
   <div class="d-flex align-items-center justify-content-center" style="height: 200px;">
     <div class="spinner-border" role="status">
       <span class="visually-hidden">Loading...</span>


### PR DESCRIPTION
TODO:
- [ ] make sure the sidebar is updated when requests change on the appointments page too