### PR TITLE
Update Folio::LoanPolicy to just be the policy and not include any checkout information

### DIFF
--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -6,11 +6,7 @@ module Folio
     include Folio::FolioRecord
 
     attr_reader :record, :patron_type_id
-
-    delegate :too_soon_to_renew?,
-             :renewal_blocked_by_hold?,
-             :unseen_renewals_remaining,
-             to: :loan_policy
+    attr_writer :loan_policy
 
     delegate :loan_policy_interval,
              to: :loan_policy,
@@ -188,13 +184,22 @@ module Folio
       location&.contact_info
     end
 
+    def too_soon_to_renew?
+      loan_policy.too_soon_to_renew?(due_date)
+    end
+
+    def renewal_blocked_by_hold?
+      hold_queue_length.positive? && !loan_policy.renewals_allowed_with_open_holds?
+    end
+
+    def unseen_renewals_remaining
+      (loan_policy.unseen_renewals_allowed - renewal_count)
+    end
+
     private
 
     def loan_policy
-      @loan_policy ||= Folio::LoanPolicy.new(loan_policy: effective_loan_policy,
-                                             due_date:,
-                                             renewal_count:,
-                                             hold_queue_length:)
+      @loan_policy ||= Folio::LoanPolicy.new(loan_policy: effective_loan_policy)
     end
 
     def effective_loan_policy

--- a/app/models/folio/loan_policy.rb
+++ b/app/models/folio/loan_policy.rb
@@ -3,13 +3,10 @@
 module Folio
   # Loan policies applicable to a given checkout
   class LoanPolicy
-    attr_reader :loan_policy, :due_date, :renewal_count, :hold_queue_length
+    attr_reader :loan_policy
 
-    def initialize(loan_policy:, due_date:, renewal_count:, hold_queue_length:)
+    def initialize(loan_policy:)
       @loan_policy = loan_policy
-      @due_date = due_date
-      @renewal_count = renewal_count
-      @hold_queue_length = hold_queue_length
     end
 
     def name
@@ -25,15 +22,15 @@ module Folio
     end
 
     # Renewing would not extend the due date
-    def too_soon_to_renew?
-      due_date_after_renewal <= due_date
+    def too_soon_to_renew?(current_due_date)
+      due_date_after_renewal(due_date: current_due_date) <= current_due_date
     end
 
     # Unseen renewals are initiated by the patron online
-    def unseen_renewals_remaining
+    def unseen_renewals_allowed
       return Float::INFINITY if unlimited_renewals?
 
-      unseen_renewals_allowed - renewal_count
+      loan_policy.dig('renewalsPolicy', 'numberAllowed') || 0
     end
 
     # Seen renewals are initiated by the patron in person with library staff
@@ -45,13 +42,13 @@ module Folio
       loan_policy['description']
     end
 
-    def renewal_blocked_by_hold?
-      hold_queue_length.positive? && !renewals_allowed_with_open_holds?
+    def renewals_allowed_with_open_holds?
+      loan_policy.dig('requestManagement', 'holds', 'renewItemsWithRequest') || false
     end
 
     private
 
-    def due_date_after_renewal
+    def due_date_after_renewal(due_date:)
       if schedule_policy
         due_date_from_schedule || due_date
       elsif renewal_calculated_from_system_date?
@@ -138,14 +135,6 @@ module Folio
 
     def unlimited_renewals?
       loan_policy.dig('renewalsPolicy', 'unlimited') || false
-    end
-
-    def unseen_renewals_allowed
-      loan_policy.dig('renewalsPolicy', 'numberAllowed') || 0
-    end
-
-    def renewals_allowed_with_open_holds?
-      loan_policy.dig('requestManagement', 'holds', 'renewItemsWithRequest') || false
     end
   end
 end

--- a/spec/factories/folio.rb
+++ b/spec/factories/folio.rb
@@ -34,9 +34,7 @@ FactoryBot.define do
               'status' => { 'name' => 'Open' } } }
     end
 
-    loan_policy { nil }
-
-    initialize_with { new(record, nil, **attributes.except(:record)) }
+    initialize_with { new(record, nil) }
   end
 
   factory :checkout_with_recall, parent: :checkout do

--- a/spec/factories/loan_policies.rb
+++ b/spec/factories/loan_policies.rb
@@ -2,12 +2,6 @@
 
 FactoryBot.define do
   factory :grad_mono_loans, class: 'Folio::LoanPolicy' do
-    transient do
-      due_date { '2024-01-09T07:59:59.000+00:00' }
-      renewal_count { 3 }
-      hold_queue_length { 0 }
-    end
-
     loan_policy do
       { 'id' => '885a2bd0-35c7-497f-9dc6-462bebe837a3',
         'name' => '1qtr-3renew-7daygrace',
@@ -37,7 +31,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(loan_policy:, due_date: Time.zone.parse(due_date), renewal_count:, hold_queue_length:)
+      new(loan_policy:)
     end
   end
 end

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -60,12 +60,10 @@ RSpec.describe 'Checkout Page' do
 
   context 'when the checkout is renewable' do
     let(:loan_policy) do
-      build(:grad_mono_loans,
-            due_date: '2020-01-09T07:59:59.000+00:00',
-            renewal_count: 0)
+      build(:grad_mono_loans)
     end
 
-    it 'has a renewa button' do
+    it 'has a renewal button' do
       visit checkouts_path
 
       expect(page).to have_button 'Renew'

--- a/spec/features/renew_item_spec.rb
+++ b/spec/features/renew_item_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe 'Renew item', :js do
     allow(mock_client).to receive_messages(renew_item_by_id: api_response,
                                            renew_items: bulk_renew_response)
     allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
-    allow(Folio::LoanPolicy).to receive(:new).and_return(build(:grad_mono_loans,
-                                                               due_date: '2021-01-09T07:59:59.000+00:00',
-                                                               renewal_count: 0))
+    allow(Folio::LoanPolicy).to receive(:new).and_return(build(:grad_mono_loans))
 
     login_as(CurrentUser.new(username: 'stub_user', patron_key: 'ec52d62d-9f0e-4ea5-856f-a1accb0121d1', shibboleth: true))
     allow(Folio::Patron).to receive(:find_by).with(patron_key: 'ec52d62d-9f0e-4ea5-856f-a1accb0121d1').and_return(patron)

--- a/spec/models/folio/loan_policy_spec.rb
+++ b/spec/models/folio/loan_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Folio::LoanPolicy do
   subject(:folio_loan_policy) do
-    described_class.new(loan_policy:, due_date:, renewal_count:, hold_queue_length:)
+    described_class.new(loan_policy:)
   end
 
   let(:due_date) { nil }
@@ -60,13 +60,13 @@ RSpec.describe Folio::LoanPolicy do
       context 'when renewal would not extend the due date' do
         let(:due_date) { Date.parse('2024-07-02T06:59:59.000+00:00') }
 
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be true }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be true }
       end
 
       context 'when renewal would extend the due date' do
         let(:due_date) { Date.parse('2023-07-02T06:59:59.000+00:00') }
 
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be false }
       end
     end
 
@@ -105,7 +105,7 @@ RSpec.describe Folio::LoanPolicy do
       context 'when renewal would extend the due date' do
         let(:due_date) { Date.parse('2003-07-02T06:59:59.000+00:00') }
 
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be false }
       end
     end
 
@@ -123,13 +123,13 @@ RSpec.describe Folio::LoanPolicy do
       context 'when renewal would not extend the due date' do
         let(:due_date) { Date.parse('2024-07-02T06:59:59.000+00:00') }
 
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be true }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be true }
       end
 
       context 'when renewal would extend the due date' do
         let(:due_date) { Date.parse('2023-07-02T06:59:59.000+00:00') }
 
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be false }
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe Folio::LoanPolicy do
       let(:due_date) { Date.parse('2023-06-30T06:59:59.000+00:00') }
 
       context 'when renewal would not extend the due date' do
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be true }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be true }
       end
     end
 
@@ -163,18 +163,18 @@ RSpec.describe Folio::LoanPolicy do
       let(:due_date) { Date.parse('2024-07-02T06:59:59.000+00:00') }
 
       context 'when renewal would extend the due date' do
-        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+        it { expect(folio_loan_policy.too_soon_to_renew?(due_date)).to be false }
       end
     end
   end
 
-  describe '#unseen_renewals_remaining' do
+  describe '#unseen_renewals_allowed' do
     context 'when renewals are unlimited' do
       let(:loan_policy) do
         { 'renewalsPolicy' => { 'unlimited' => true } }
       end
 
-      it { expect(folio_loan_policy.unseen_renewals_remaining).to eq Float::INFINITY }
+      it { expect(folio_loan_policy.unseen_renewals_allowed).to eq Float::INFINITY }
     end
 
     context 'when renewals are limited' do
@@ -183,9 +183,8 @@ RSpec.describe Folio::LoanPolicy do
           { 'unlimited' => false,
             'numberAllowed' => 5 } }
       end
-      let(:renewal_count) { 3 }
 
-      it { expect(folio_loan_policy.unseen_renewals_remaining).to eq 2 }
+      it { expect(folio_loan_policy.unseen_renewals_allowed).to eq 5 }
     end
   end
 
@@ -207,7 +206,7 @@ RSpec.describe Folio::LoanPolicy do
       end
 
       it 'renewal is not blocked' do
-        expect(folio_loan_policy.renewal_blocked_by_hold?).to be false
+        expect(folio_loan_policy.renewals_allowed_with_open_holds?).to be true
       end
     end
 
@@ -218,15 +217,7 @@ RSpec.describe Folio::LoanPolicy do
       end
 
       it 'renewal is blocked' do
-        expect(folio_loan_policy.renewal_blocked_by_hold?).to be true
-      end
-
-      context 'when there are no holds' do
-        let(:hold_queue_length) { 0 }
-
-        it 'renewal is not blocked' do
-          expect(folio_loan_policy.renewal_blocked_by_hold?).to be false
-        end
+        expect(folio_loan_policy.renewals_allowed_with_open_holds?).to be false
       end
     end
   end


### PR DESCRIPTION
Intermingling the checkout data and the policy data makes updating the checkout after renewals a little annoying.