### PR TITLE
Handle renewals with turbo

### DIFF
--- a/app/components/checkout_component.html.erb
+++ b/app/components/checkout_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', data: { 'status-sort-value': checkout.sort_key(:status), 'due-date-sort-value': checkout.sort_key(:due_date), 'title-sort-value': checkout.sort_key(:title), 'author-sort-value': checkout.sort_key(:author), 'call-number-sort-value': checkout.sort_key(:call_number)  }) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(checkout), data: { 'status-sort-value': checkout.sort_key(:status), 'due-date-sort-value': checkout.sort_key(:due_date), 'title-sort-value': checkout.sort_key(:title), 'author-sort-value': checkout.sort_key(:author), 'call-number-sort-value': checkout.sort_key(:call_number)  }) do |c| %>
   <% c.with_title do %>
     <div class="d-flex flex-row gap-4 align-items-center">
       <div>Due: <span class="fw-semibold"><%= today_with_time_or_date(checkout.due_date, short_term: checkout.short_term_loan?) %></span></div>

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -19,16 +19,20 @@ class CheckoutsController < ApplicationController
   # GET /checkouts.json
   def index; end
 
-  def renew # rubocop:disable Metrics/AbcSize
-    @response = FolioClient.new.renew_item_by_id(patron_or_group.key, @checkout.item_id)
+  def renew # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    @response = FolioClient.new.renew_checkout(@checkout)
 
-    if @response.status.in?([200, 201])
-      flash[:success] = t 'mylibrary.renew_item.success_html', title: params['title']
-    else
-      flash[:error] = t 'mylibrary.renew_item.error_html', title: params['title']
+    respond_to do |format|
+      format.html do
+        if @response.success?
+          flash[:success] = t 'mylibrary.renew_item.success_html', title: params['title']
+        else
+          flash[:error] = t 'mylibrary.renew_item.error_html', title: params['title']
+        end
+        redirect_to checkouts_path
+      end
+      format.turbo_stream
     end
-
-    redirect_to checkouts_path
   end
 
   # Renew all eligible items for a patron
@@ -36,12 +40,17 @@ class CheckoutsController < ApplicationController
   # POST /checkouts/renew_eligible
   def renew_eligible
     eligible_renewals = @checkouts.select(&:renewable?)
-    response = FolioClient.new.renew_items(eligible_renewals)
+    @responses = eligible_renewals.map { |checkout| FolioClient.new.renew_checkout(checkout) }
 
-    bulk_renewal_success_flash(response)
-    bulk_renewal_error_flash(response)
+    respond_to do |format|
+      format.html do
+        bulk_renewal_success_flash(@responses.select(&:success?))
+        bulk_renewal_error_flash(@responses.reject(&:success?))
 
-    redirect_to checkouts_path(group: params[:group])
+        redirect_to checkouts_path
+      end
+      format.turbo_stream
+    end
   end
 
   private
@@ -60,19 +69,19 @@ class CheckoutsController < ApplicationController
     raise ActiveRecord::RecordNotFound, 'Checkout not found' if @checkout.nil?
   end
 
-  def bulk_renewal_success_flash(response)
-    return unless response[:success].any?
+  def bulk_renewal_success_flash(responses)
+    return unless responses.any?
 
-    flash[:success] = I18n.t('mylibrary.renew_all_items.success_html', count: response[:success].length) # rubocop:disable Rails/ActionControllerFlashBeforeRender
+    flash[:success] = I18n.t('mylibrary.renew_all_items.success_html', count: responses.length) # rubocop:disable Rails/ActionControllerFlashBeforeRender
   end
 
-  def bulk_renewal_error_flash(response)
-    return unless response[:error].any?
+  def bulk_renewal_error_flash(responses)
+    return unless responses.any?
 
     flash[:error] = I18n.t('mylibrary.renew_all_items.error_html', # rubocop:disable Rails/ActionControllerFlashBeforeRender
-                           count: response[:error].length,
-                           items: tag.ul(safe_join(response[:error].collect do |renewal|
-                                                     tag.li(renewal.title.truncate_words(7))
+                           count: responses.length,
+                           items: tag.ul(safe_join(responses.collect do |renewal|
+                                                     tag.li(renewal.checkout.title.truncate_words(7))
                                                    end, '')))
   end
 

--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -4,6 +4,7 @@ module Folio
   # ? FOLIO: Checkout = "Loan" in Folio - consider renaming for clarity
   class Checkout
     include Folio::FolioRecord
+    include ActiveModel::Model
 
     attr_reader :record, :patron_type_id
     attr_writer :loan_policy
@@ -21,9 +22,14 @@ module Folio
       @loan_policy = loan_policy
     end
 
+    def update(data = {})
+      self.class.new(record.deep_merge(data), patron_type_id, loan_policy:)
+    end
+
     def key
       record['id']
     end
+    alias id key
 
     def bib?
       record['item'].present?

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -280,16 +280,34 @@ class FolioClient
                        location_id: }.as_json)
   end
 
-  def renew_items(checkouts)
-    checkouts.each_with_object(success: [], error: []) do |checkout, status|
-      response = renew_item_by_id(checkout.patron_key, checkout.item_id)
+  def renew_checkout(checkout)
+    response = renew_item_by_id(checkout.patron_key, checkout.item_id)
 
-      case response.status
-      when 200
-        status[:success] << checkout
-      else
-        status[:error] << checkout
-      end
+    RenewCheckoutResponse.new(response, checkout)
+  end
+
+  # Response object for renewing a checkout, which brings together the FOLIO response
+  # and the checkout that was attempted to be renewed (which may not be obvious from the error response)
+  class RenewCheckoutResponse
+    attr_reader :response, :checkout
+
+    def initialize(response, checkout)
+      @response = response
+      @checkout = checkout
+    end
+
+    def success?
+      @response.status.in?([200, 201])
+    end
+
+    def body
+      JSON.parse(@response.body)
+    end
+
+    def updated_checkout
+      return unless success?
+
+      checkout.update('dueDate' => body['dueDate'], 'overdue' => false, 'details' => { 'renewalCount' => body['renewalCount'] })
     end
   end
 

--- a/app/views/checkouts/_renew_all_button.html.erb
+++ b/app/views/checkouts/_renew_all_button.html.erb
@@ -1,1 +1,14 @@
-<%# TODO %>
+<% if patron_or_group.checkouts.any?(&:renewable?) %>
+  <% if patron_or_group.can_renew? %>
+      <% renewable_count = patron_or_group.checkouts.count(&:renewable?) %>
+      <%= form_tag renew_eligible_checkouts_path, method: :post do %>
+        <%= button_tag class: 'btn btn-info mb-1',
+                        data: { turbo_submits_with: t('mylibrary.renew_all_items.in_progress_html', count: renewable_count) },
+                        type: 'submit' do %>
+          <%= sul_icon :'renew' %> Renew <%= pluralize(renewable_count, 'eligible item') %>
+        <% end %>
+      <% end %>
+  <% else %>
+    <button disabled class="btn btn-info mb-1"><%= sul_icon :'renew' %> Renewals blocked</button>
+  <% end %>
+<% end %>

--- a/app/views/checkouts/renew.turbo_stream.erb
+++ b/app/views/checkouts/renew.turbo_stream.erb
@@ -1,0 +1,14 @@
+<% if @response.success? %>
+  <%= turbo_stream.replace(dom_id(@response.checkout)) do %>
+    <%= render CheckoutComponent.new(checkout: @response.updated_checkout, patron: patron_or_group) %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.prepend('main') do %>
+  <% if @response.success? %>
+    <% success = I18n.t('mylibrary.renew_item.success_html', title: @response.checkout.title) %>
+  <% else %>
+    <% error = I18n.t('mylibrary.renew_item.error_html', title: @response.checkout.title) %>
+  <% end %>
+  <%= render 'shared/flashes', flash: { success: success, error: error} %>
+<% end %>

--- a/app/views/checkouts/renew_eligible.turbo_stream.erb
+++ b/app/views/checkouts/renew_eligible.turbo_stream.erb
@@ -1,0 +1,18 @@
+<% @responses.select(&:success?).each do |response| %>
+  <%= turbo_stream.replace(dom_id(response.checkout)) do %>
+    <%= render CheckoutComponent.new(checkout: response.updated_checkout, patron: patron_or_group) %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.prepend('main') do %>
+  <% success = I18n.t('mylibrary.renew_all_items.success_html', count: @responses.select(&:success?).length).html_safe if @responses.select(&:success?).any? %>
+  <% error_list = capture do %>
+  <ul>
+    <% @responses.reject(&:success?).each do |r| %>
+      <li><%= r.checkout.title.truncate_words(7) %></li>
+    <% end %>
+  </ul>
+  <% end %>
+  <% error = I18n.t('mylibrary.renew_all_items.error_html', count: @responses.reject(&:success?).length, items: error_list).html_safe if @responses.reject(&:success?).any? %>
+  <%= render 'shared/flashes', flash: { success: success, error: error} %>
+<% end %>

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe CheckoutsController do
   end
 
   describe '#renew' do
-    let(:api_response) { instance_double(Faraday::Response, status: 201) }
+    let(:api_response) { instance_double(FolioClient::RenewCheckoutResponse, success?: true, checkout: checkouts[0], updated_checkout: checkouts[0]) }
     let(:checkouts) { [instance_double(Folio::Checkout, item_id: '123', item_category_non_renewable?: false, sort_key: nil)] }
 
     before do
-      allow(mock_client).to receive(:renew_item_by_id).and_return(api_response)
+      allow(mock_client).to receive(:renew_checkout).and_return(api_response)
     end
 
     context 'when everything is good' do
@@ -72,7 +72,7 @@ RSpec.describe CheckoutsController do
     end
 
     context 'when the response is not 201' do
-      let(:api_response) { instance_double(Faraday::Response, status: 401) }
+      let(:api_response) { instance_double(FolioClient::RenewCheckoutResponse, success?: false, checkout: checkouts[0], updated_checkout: checkouts[0]) }
 
       it 'does not renew the item and sets flash messages' do
         post :renew, params: { id: '123' }
@@ -115,16 +115,19 @@ RSpec.describe CheckoutsController do
     end
 
     before do
-      allow(mock_client).to receive(:renew_items).and_return(api_response)
+      allow(mock_client).to receive(:renew_checkout).with(having_attributes(key: '1')).and_return(instance_double(FolioClient::RenewCheckoutResponse,
+                                                                                                                  success?: true,
+                                                                                                                  checkout: checkouts[0]))
+      allow(mock_client).to receive(:renew_checkout).with(having_attributes(key: '2')).and_return(instance_double(FolioClient::RenewCheckoutResponse,
+                                                                                                                  success?: false,
+                                                                                                                  checkout: checkouts[1]))
     end
 
     it 'sends renewal requests to Folio for eligible items' do
       post :renew_eligible
 
-      expect(mock_client).to have_received(:renew_items).with([
-                                                                having_attributes(key: '1'),
-                                                                having_attributes(key: '2')
-                                                              ])
+      expect(mock_client).to have_received(:renew_checkout).with(having_attributes(key: '1'))
+      expect(mock_client).to have_received(:renew_checkout).with(having_attributes(key: '2'))
     end
 
     context 'when successful' do

--- a/spec/features/renew_item_spec.rb
+++ b/spec/features/renew_item_spec.rb
@@ -16,10 +16,8 @@ RSpec.describe 'Renew item', :js do
     build(:service_points)
   end
 
-  let(:api_response) { instance_double(Faraday::Response, status: 201) }
-  let(:bulk_renew_response) do
-    { success: [instance_double(Folio::Checkout, key: '1', renewable?: true, item_id: '123', title: 'ABC')] }
-  end
+  let(:api_response) { instance_double(FolioClient::RenewCheckoutResponse, success?: true, checkout: patron.checkouts.first, updated_checkout: updated_checkout) }
+  let(:updated_checkout) { patron.checkouts.first.update('dueDate' => 2.years.from_now.iso8601) }
 
   before do
     # NOTE: tests that rely on LoanPolicy#due_date_after_renewal have to
@@ -27,29 +25,30 @@ RSpec.describe 'Renew item', :js do
     #       loan policy schedule date range.
     travel_to Time.zone.parse('2023-06-13T07:00:00.000+00:00')
     allow(FolioClient).to receive(:new).and_return(mock_client)
-    allow(mock_client).to receive_messages(renew_item_by_id: api_response,
-                                           renew_items: bulk_renew_response)
+    allow(mock_client).to receive_messages(renew_checkout: api_response)
     allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
     allow(Folio::LoanPolicy).to receive(:new).and_return(build(:grad_mono_loans))
 
+    patron.checkouts.each do |checkout|
+      allow(checkout).to receive(:loan_policy).and_return(build(:grad_mono_loans))
+    end
+
     login_as(CurrentUser.new(username: 'stub_user', patron_key: 'ec52d62d-9f0e-4ea5-856f-a1accb0121d1', shibboleth: true))
     allow(Folio::Patron).to receive(:find_by).with(patron_key: 'ec52d62d-9f0e-4ea5-856f-a1accb0121d1').and_return(patron)
+
+    allow(Settings.features).to receive(:requests_redesign).and_return(true)
   end
 
   it 'enabled through checkout page' do
-    skip 'Confirmation screen is going to be pretty different'
     visit checkouts_path
 
     within(first('ul.checkouts li')) do
-      click_on 'Expand'
-      first('.btn-renewable-submit').click
+      click_on 'Renew'
     end
     expect(page).to have_css '.flash_messages', text: 'Success!'
   end
 
   it 'has a button to renew all items' do
-    skip 'Mocking the response does not seem to work'
-
     visit checkouts_path
 
     click_on 'Renew 1 eligible item'

--- a/spec/services/folio_client_spec.rb
+++ b/spec/services/folio_client_spec.rb
@@ -18,19 +18,15 @@ RSpec.describe FolioClient do
     it { is_expected.not_to include 'pass' }
   end
 
-  describe '#renew_items' do
-    subject(:renew_items) { client.renew_items(checkouts) }
+  describe '#renew_checkout' do
+    subject(:response) { client.renew_checkout(checkout) }
 
-    let(:checkouts) do
-      [double(patron_key: '9af85395-3104-5fc9-88ab-15554765c2d2', item_id: '6d9a4f99-d144-51cf-92d7-3edbfc588abe'),
-       double(patron_key: '9af85395-3104-5fc9-88ab-15554765c2d2', item_id: 'cc3d8728-a6b9-45c4-ad0c-432873c3ae47')]
+    let(:checkout) do
+      double(patron_key: '9af85395-3104-5fc9-88ab-15554765c2d2', item_id: '6d9a4f99-d144-51cf-92d7-3edbfc588abe')
     end
+
     let(:record_one) do
       { 'item' => { 'itemId' => '6d9a4f99-d144-51cf-92d7-3edbfc588abe' },
-        'details' => { 'userId' => '9af85395-3104-5fc9-88ab-15554765c2d2' } }
-    end
-    let(:record_two) do
-      { 'item' => { 'itemId' => 'cc3d8728-a6b9-45c4-ad0c-432873c3ae47' },
         'details' => { 'userId' => '9af85395-3104-5fc9-88ab-15554765c2d2' } }
     end
 
@@ -39,18 +35,23 @@ RSpec.describe FolioClient do
         .with(body: { itemId: record_one.dig('item', 'itemId'), userId: record_one.dig('details', 'userId') },
               headers: { 'x-okapi-token': 'tokentokentoken', 'X-Okapi-Tenant': 'sul' })
         .to_return(body: {}.to_json, status: 200)
-
-      stub_request(:post, 'https://okapi.example.edu/circulation/renew-by-id')
-        .with(body: { itemId: record_two.dig('item', 'itemId'), userId: record_two.dig('details', 'userId') },
-              headers: { 'x-okapi-token': 'tokentokentoken', 'X-Okapi-Tenant': 'sul' })
-        .to_return(body: {}.to_json, status: 422)
     end
 
-    it 'groups the successful and failed renewal responses' do
-      expect(renew_items[:success].count).to eq 1
-      expect(renew_items[:success].first.item_id).to eq '6d9a4f99-d144-51cf-92d7-3edbfc588abe'
-      expect(renew_items[:error].count).to eq 1
-      expect(renew_items[:error].first.item_id).to eq 'cc3d8728-a6b9-45c4-ad0c-432873c3ae47'
+    context 'when the request fails' do
+      before do
+        stub_request(:post, 'https://okapi.example.edu/circulation/renew-by-id')
+          .with(body: { itemId: record_one.dig('item', 'itemId'), userId: record_one.dig('details', 'userId') },
+                headers: { 'x-okapi-token': 'tokentokentoken', 'X-Okapi-Tenant': 'sul' })
+          .to_return(body: {}.to_json, status: 422)
+      end
+
+      it 'returns a response object' do
+        expect(response).not_to be_success
+      end
+    end
+
+    it 'returns a response object' do
+      expect(response).to be_success
     end
   end
 


### PR DESCRIPTION
I suspect we're not keeping the flash message alert styling, but this keeps parity with the mylibrary implementation. When we know what the transition + error states looks like, we can fully remove the flash (and pseudo-flash) code .