### PR TITLE
Fix checkout spacing

### DIFF
--- a/app/components/checkout_component.html.erb
+++ b/app/components/checkout_component.html.erb
@@ -37,11 +37,11 @@
     <div class="d-flex justify-content-between gap-5">
       <div>
         <h3 class="mb-1 clamp clamp-3"><%= checkout.title %></h3>
-        <div class="d-flex flex-row flex-wrap position-relative justify-content-start gap-4">
+        <div class="d-flex flex-row flex-wrap position-relative justify-content-start gap-3 mb-1">
           <div>Call number: <%= checkout.call_number %></div>
-          <div class="mb-1 clamp clamp-1"><span class="visually-hidden">Author:</span><%= checkout.author %></div>
           <%= detail_link_to_searchworks(checkout.catkey) unless checkout.from_ill? %>
         </div>
+        <div class="mb-1 clamp clamp-1"><span class="visually-hidden">Author:</span><%= checkout.author %></div>
         <div><span class="visually-hidden">Library:</span>
           <%= checkout.library_name %> <%= mail_to(contact_email, safe_join([tag.i(class: 'bi bi-envelope me-1'), 'Contact']), class: 'su-underline ms-3') if contact_email %>
         </div>


### PR DESCRIPTION
After author was re-added, the view in searchworks link displayed below the author (instead of next to the call number as designed.)