### PR TITLE
align caret on dropdown navs, add text-decoration on hover

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1327,3 +1327,14 @@ label.btn-close {
   display: none;
   pointer-events: none;
 }
+
+.masthead .dropdown-toggle {
+  &:after {
+    vertical-align: middle!important; /* instead of default 0.255em */
+  }
+
+  &:hover {
+    text-decoration: var(--bs-link-hover-decoration);
+    text-underline-offset: 0.25rem;
+  }
+}


### PR DESCRIPTION
Before:
<img width="215" height="85" alt="Screenshot 2026-06-22 at 1 47 02 PM" src="https://github.com/user-attachments/assets/a4ae07b7-2db5-46ee-b76f-449b035079f6" />

After:

<img width="112" height="51" alt="Screenshot 2026-06-22 at 2 03 21 PM" src="https://github.com/user-attachments/assets/9c818f21-5e24-4f0b-b4d5-71ebc8e0bead" />

Figma:
<img width="120" height="53" alt="Screenshot 2026-06-22 at 1 59 51 PM" src="https://github.com/user-attachments/assets/2a5faf36-3274-4bb6-8e23-789db74f1570" />
