### PR TITLE
Add initial home page card and list views

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -965,3 +965,23 @@ summary .disclosure-icon::before {
   height: 0;
   overflow: hidden;
 }
+
+[data-pay-button]:disabled {
+  background-color: rgba(var(--stanford-digital-red-dark-rgb), 0.2);
+  color: rgba(140, 21, 21, 0.6);
+  border-color: transparent;
+  opacity: 1;
+}
+
+.home-cards > .card {
+  min-height: 196px;
+}
+
+.home-list .borrowed-items > li:last-child {
+  --bs-border-color: transparent;
+}
+
+[data-home-view="card"] [data-home-view-variant="list"],
+[data-home-view="list"] [data-home-view-variant="card"] {
+  display: none;
+}

--- a/app/assets/stylesheets/colors.css
+++ b/app/assets/stylesheets/colors.css
@@ -183,6 +183,10 @@ input[type="radio"] {
   color: var(--stanford-30-black);
 }
 
+.text-60-black {
+  color: var(--stanford-60-black);
+}
+
 .text-80-black {
   color: var(--stanford-80-black);
 }

--- a/app/components/appointment_time_range_component.rb
+++ b/app/components/appointment_time_range_component.rb
@@ -2,8 +2,9 @@
 
 # dropdown, confirmation screen appointment display
 class AppointmentTimeRangeComponent < ViewComponent::Base
-  def initialize(appointment:, show_hours: false, location: nil)
+  def initialize(appointment:, show_hours: false, location: nil, emphasize_date: false)
     @appointment = appointment
+    @emphasize_date = emphasize_date
     @show_hours = show_hours
     @location = location
   end
@@ -21,7 +22,7 @@ class AppointmentTimeRangeComponent < ViewComponent::Base
   end
 
   def call
-    values = [tag.span(date)]
+    values = [tag.span(date, class: ('fw-semibold' if @emphasize_date))]
     values << tag.span(time_range) if show_hours?
     values << tag.span(@location) if @location
 

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,6 +1,6 @@
-<%= tag.public_send element, class: %w[card bg-body-tertiary border-light-subtle shadow-sm mb-4] + classes, **tag_options do %>
+<%= tag.public_send element, class: (%w[card bg-body-tertiary border-light-subtle shadow-sm] + [margin_class].compact + classes), **tag_options do %>
   <%= pre %>
-  <div class="card-header d-flex justify-content-between align-items-center bg-body-tertiary">
+  <div class="<%= (%w[card-header d-flex justify-content-between align-items-center bg-body-tertiary] + header_classes).join(' ') %>">
     <%= title %>
     <% if actions? %>
       <div class="d-flex gap-2 align-items-center">

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -13,12 +13,14 @@ class CardComponent < ViewComponent::Base
   }
   renders_one :post
 
-  attr_reader :element, :classes, :tag_options
+  attr_reader :element, :classes, :header_classes, :margin_class, :tag_options
 
-  def initialize(element: 'div', classes: [], body_classes: [], **tag_options)
+  def initialize(element: 'div', classes: [], body_classes: [], header_classes: [], margin_class: 'mb-4', **tag_options) # rubocop:disable Metrics/ParameterLists
     @element = element
     @classes = Array(classes)
     @body_classes = Array(body_classes)
+    @header_classes = Array(header_classes)
+    @margin_class = margin_class
     @tag_options = tag_options
   end
 end

--- a/app/components/home/arrow_link_component.html.erb
+++ b/app/components/home/arrow_link_component.html.erb
@@ -1,0 +1,3 @@
+<%= link_to path, class: 'btn btn-link btn-sm ps-0 su-underline' do %>
+  <%= label %><i class="bi bi-arrow-right ms-1"></i>
+<% end %>

--- a/app/components/home/arrow_link_component.rb
+++ b/app/components/home/arrow_link_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Home
+  # Underlined link with a trailing right-arrow icon. Used inside home page cards.
+  class ArrowLinkComponent < ViewComponent::Base
+    attr_reader :label, :path
+
+    def initialize(label:, path:)
+      @label = label
+      @path = path
+    end
+  end
+end

--- a/app/components/home/fines_card_component.html.erb
+++ b/app/components/home/fines_card_component.html.erb
@@ -1,0 +1,20 @@
+<%= render Home::FlatCardComponent.new do |c| %>
+  <% c.with_title do %>
+    <i class="bi <%= icon %> text-60-black fs-4"></i>
+  <% end %>
+
+  <% c.with_actions do %>
+    <%= render Home::PayNowFormComponent.new(fines: fines, balance: balance, patron_key: patron_key) %>
+  <% end %>
+
+  <% c.with_body(classes: %w[pt-1]) do %>
+    <h2 class="mb-1"><%= title %></h2>
+    <% if empty? %>
+      <p class="mb-1">No fees or fines</p>
+      <%= render Home::ArrowLinkComponent.new(label: 'View past fees/fines', path: past_path) %>
+    <% else %>
+      <p class="mb-1"><span class="fw-semibold"><%= number_to_currency(balance) %></span> balance</p>
+      <%= render Home::ArrowLinkComponent.new(label: 'View details', path: path) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/home/fines_card_component.rb
+++ b/app/components/home/fines_card_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Home
+  # Fees & fines card for the card-view home page.
+  class FinesCardComponent < ViewComponent::Base
+    attr_reader :title, :icon, :fines, :balance, :patron_key, :path, :past_path
+
+    def initialize(title:, icon:, fines:, balance:, patron_key:, path:, past_path:) # rubocop:disable Metrics/ParameterLists
+      @title = title
+      @icon = icon
+      @fines = fines
+      @balance = balance
+      @patron_key = patron_key
+      @path = path
+      @past_path = past_path
+    end
+
+    def empty?
+      balance.to_f.zero?
+    end
+  end
+end

--- a/app/components/home/flat_card_component.rb
+++ b/app/components/home/flat_card_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Home
+  # Flat card preset (no shadow, no border, no outer margin) used by home page cards.
+  class FlatCardComponent < ::CardComponent
+    def initialize(**)
+      super(
+        classes: %w[shadow-none border-0 rounded-1],
+        header_classes: %w[border-bottom-0],
+        margin_class: nil,
+        **
+      )
+    end
+  end
+end

--- a/app/components/home/list_view/fines_card_component.html.erb
+++ b/app/components/home/list_view/fines_card_component.html.erb
@@ -1,0 +1,19 @@
+<%= render CardComponent.new(classes: %w[shadow-none border-0 rounded-1], header_classes: %w[border-0], margin_class: nil) do |c| %>
+  <% c.with_title do %>
+    <div class="d-flex align-items-center">
+      <i class="bi <%= icon %> text-60-black fs-4 me-3"></i>
+      <h2 class="mb-0"><%= title %></h2>
+    </div>
+  <% end %>
+
+  <% c.with_actions do %>
+    <span class="d-flex align-items-center gap-3">
+      <span><span class="fw-semibold"><%= number_to_currency(balance) %></span> balance</span>
+      <%= render Home::PayNowFormComponent.new(fines: fines, balance: balance, patron_key: patron_key, button_class: 'btn btn-xs btn-secondary') %>
+    </span>
+  <% end %>
+
+  <% c.with_footer(classes: %w[border-0 bg-transparent]) do %>
+    <%= render Home::ArrowLinkComponent.new(label: 'View details', path: path) %>
+  <% end %>
+<% end %>

--- a/app/components/home/list_view/fines_card_component.rb
+++ b/app/components/home/list_view/fines_card_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Home
+  module ListView
+    # Fees & fines card for the list-view home page.
+    class FinesCardComponent < ViewComponent::Base
+      attr_reader :title, :icon, :fines, :balance, :patron_key, :path
+
+      def initialize(title:, icon:, fines:, balance:, patron_key:, path:) # rubocop:disable Metrics/ParameterLists
+        @title = title
+        @icon = icon
+        @fines = fines
+        @balance = balance
+        @patron_key = patron_key
+        @path = path
+      end
+
+      def render? = balance.positive?
+    end
+  end
+end

--- a/app/components/home/list_view/summary_card_component.html.erb
+++ b/app/components/home/list_view/summary_card_component.html.erb
@@ -1,0 +1,23 @@
+<%= render CardComponent.new(classes: %w[home-list-card], margin_class: nil) do |c| %>
+  <% c.with_title do %>
+    <div class="d-flex align-items-center">
+      <i class="bi <%= icon %> text-60-black fs-4 me-3"></i>
+      <h2 class="mb-0"><%= title %></h2>
+    </div>
+  <% end %>
+
+  <% c.with_actions do %>
+    <%= render PillComponent.new(classes: %w[bg-stanford-20-black fw-light py-0]).with_content("#{count} #{pill_noun}") %>
+  <% end %>
+
+  <% c.with_body(classes: %w[bg-white pt-2 pb-0 px-2]) do %>
+    <% if status.present? %>
+      <p class="fw-semibold small text-digital-red-dark mb-2"><%= status %></p>
+    <% end %>
+    <%= items %>
+  <% end %>
+
+  <% c.with_footer do %>
+    <%= render Home::ArrowLinkComponent.new(label: view_all_label, path: view_all_path) %>
+  <% end %>
+<% end %>

--- a/app/components/home/list_view/summary_card_component.rb
+++ b/app/components/home/list_view/summary_card_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Home
+  module ListView
+    # Generic count-with-teaser card for the list-view home page.
+    class SummaryCardComponent < ViewComponent::Base
+      renders_one :items
+
+      attr_reader :title, :icon, :count, :pill_noun, :view_all_label, :view_all_path, :status
+
+      def initialize(title:, icon:, count:, view_all_label:, view_all_path:, pill_noun: 'total', status: nil) # rubocop:disable Metrics/ParameterLists
+        @title = title
+        @icon = icon
+        @count = count
+        @pill_noun = pill_noun
+        @view_all_label = view_all_label
+        @view_all_path = view_all_path
+        @status = status
+      end
+
+      def render? = count.positive?
+    end
+  end
+end

--- a/app/components/home/pay_now_form_component.html.erb
+++ b/app/components/home/pay_now_form_component.html.erb
@@ -1,0 +1,8 @@
+<%= form_tag payments_path, data: { turbo: false }, method: :post do %>
+  <%= hidden_field_tag :user_id, patron_key %>
+  <%= hidden_field_tag :amount, format('%.2f', balance) %>
+  <% fines.each do |fine| %>
+    <%= hidden_field_tag 'fine_ids[]', fine.key %>
+  <% end %>
+  <%= button_tag 'Pay now', type: 'submit', class: button_class, disabled: balance.zero?, data: { 'pay-button' => true } %>
+<% end %>

--- a/app/components/home/pay_now_form_component.rb
+++ b/app/components/home/pay_now_form_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Home
+  # Submits the patron's outstanding fines to /payments.
+  class PayNowFormComponent < ViewComponent::Base
+    attr_reader :fines, :balance, :patron_key, :button_class
+
+    def initialize(fines:, balance:, patron_key:, button_class: 'btn btn-sm btn-secondary')
+      @fines = fines
+      @balance = balance
+      @patron_key = patron_key
+      @button_class = button_class
+    end
+  end
+end

--- a/app/components/home/summary_card_component.html.erb
+++ b/app/components/home/summary_card_component.html.erb
@@ -1,0 +1,34 @@
+<%= render Home::FlatCardComponent.new do |c| %>
+  <% c.with_title do %>
+    <i class="bi <%= icon %> text-60-black fs-4"></i>
+  <% end %>
+
+  <% if next_up_date %>
+    <% c.with_actions do %>
+      <span class="text-digital-red-dark">Next up: <span class="fw-semibold"><%= next_up_date.strftime('%b %-d, %Y') %></span></span>
+    <% end %>
+  <% elsif status.present? %>
+    <% c.with_actions do %>
+      <%= status %>
+    <% end %>
+  <% end %>
+
+  <% c.with_body(classes: %w[pt-1]) do %>
+    <h2 class="mb-1"><%= title %></h2>
+    <% if empty? %>
+      <p class="mb-1"><%= empty_label %></p>
+      <% if empty_path %>
+        <%= render Home::ArrowLinkComponent.new(label: empty_link_label, path: empty_path) %>
+      <% end %>
+    <% else %>
+      <p class="mb-1">
+        <span class="fw-semibold"><%= count %></span> <%= item_label.pluralize(count) %><%= " #{item_label_suffix}" if item_label_suffix %>
+        <% if secondary_count %>
+          <i class="bi bi-dot"></i>
+          <span class="fw-semibold"><%= secondary_count %></span> <%= secondary_label.pluralize(secondary_count) %><%= " #{secondary_label_suffix}" if secondary_label_suffix %>
+        <% end %>
+      </p>
+      <%= render Home::ArrowLinkComponent.new(label: 'View details', path: path) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/home/summary_card_component.rb
+++ b/app/components/home/summary_card_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Home
+  # Generic count-with-link card for the card-view home page.
+  class SummaryCardComponent < ViewComponent::Base
+    attr_reader :title, :icon, :count, :item_label, :item_label_suffix, :empty_label, :path, :status,
+                :empty_path, :empty_link_label, :next_up_date,
+                :secondary_count, :secondary_label, :secondary_label_suffix
+
+    # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+    def initialize(title:, icon:, count:, item_label:, empty_label:, path:,
+                   item_label_suffix: nil, status: nil, empty_path: nil, empty_link_label: nil,
+                   next_up_date: nil, secondary_count: nil, secondary_label: nil, secondary_label_suffix: nil)
+      # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
+      @title = title
+      @icon = icon
+      @count = count
+      @item_label = item_label
+      @item_label_suffix = item_label_suffix
+      @empty_label = empty_label
+      @path = path
+      @status = status
+      @empty_path = empty_path
+      @empty_link_label = empty_link_label
+      @next_up_date = next_up_date
+      @secondary_count = secondary_count
+      @secondary_label = secondary_label
+      @secondary_label_suffix = secondary_label_suffix
+    end
+
+    def empty?
+      count.to_i.zero?
+    end
+  end
+end

--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -6,7 +6,7 @@
 class AeonAppointmentsController < ApplicationController
   include AeonController
 
-  before_action :load_aeon_requests, only: [:index, :items]
+  before_action :load_aeon_requests, only: [:index, :items, :update]
   before_action :load_appointments
   before_action :load_appointment, only: [:edit, :update, :destroy, :items]
   before_action :build_appointment, only: [:new, :create]
@@ -47,7 +47,7 @@ class AeonAppointmentsController < ApplicationController
     render :edit, status: :unprocessable_content and return unless @appointment.save
 
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: turbo_stream.refresh(request_id: nil) }
+      format.turbo_stream
       format.html { redirect_to :index, notice: 'Appointment updated successfully' }
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,7 +9,9 @@ class HomeController < ApplicationController
 
   before_action :authenticate_user!, only: [:show]
 
-  def show; end
+  def show
+    @dashboard = Home::Dashboard.new(current_user)
+  end
 
   def authenticate_user!
     return if current_user.persisted?

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Helpers for the home page redesign views.
+module HomeHelper
+  def count_callout(count:, phrase:)
+    return unless count.to_i.positive?
+
+    tag.span(safe_join([tag.span(count, class: 'fw-semibold'), phrase], ' '),
+             class: 'text-digital-red-dark')
+  end
+end

--- a/app/helpers/mylibrary_helper.rb
+++ b/app/helpers/mylibrary_helper.rb
@@ -30,6 +30,20 @@ module MylibraryHelper
     end
   end
 
+  def format_relative_date_phrase(date)
+    return unless date
+
+    days = (date.to_date - Time.zone.today).to_i
+    case days
+    when 0 then 'today'
+    when 1 then 'tomorrow'
+    when -1 then 'yesterday'
+    when 2..7 then "in #{pluralize(days, 'day')}"
+    when -7..-2 then "#{pluralize(-days, 'day')} ago"
+    else l(date, format: :date_only)
+    end
+  end
+
   # Wrap a link to the SearchWorks record for the given Catkey wrapped in the markup
   # necessary to be aligned with the content in the collapsible list sections
   def detail_link_to_searchworks(catkey)

--- a/app/javascript/controllers/home_view_toggle_controller.js
+++ b/app/javascript/controllers/home_view_toggle_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { storageKey: { type: String, default: "sulRequests:homeView" } }
+
+  connect() {
+    const stored = window.localStorage.getItem(this.storageKeyValue)
+    if (stored === "card" || stored === "list") {
+      this.element.dataset.homeView = stored
+    }
+    this.syncButtons()
+  }
+
+  set(event) {
+    const variant = event.params.variant
+    if (variant !== "card" && variant !== "list") return
+    this.element.dataset.homeView = variant
+    window.localStorage.setItem(this.storageKeyValue, variant)
+    this.syncButtons()
+  }
+
+  syncButtons() {
+    const current = this.element.dataset.homeView
+    this.element.querySelectorAll("[data-home-view-toggle-variant-param]").forEach((btn) => {
+      const isActive = btn.dataset.homeViewToggleVariantParam === current
+      btn.classList.toggle("active", isActive)
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false")
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -90,3 +90,6 @@ application.register("view-container-contents", ViewContainerContentsController)
 
 import AddItemsController from "./add_items_controller"
 application.register("add-items", AddItemsController)
+
+import HomeViewToggleController from "./home_view_toggle_controller"
+application.register("home-view-toggle", HomeViewToggleController)

--- a/app/models/home/dashboard.rb
+++ b/app/models/home/dashboard.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Home
+  # Home page presenter wrapping user data for both view variants.
+  class Dashboard
+    DigitizationStatus = Data.define(:count, :label)
+
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def checkouts
+      @checkouts ||= patron.checkouts.sort_by { |c| c.sort_key(:due_date) }
+    end
+
+    def actionable_borrowed_items
+      @actionable_borrowed_items ||= checkouts.select { |c| c.due_date && c.due_date <= 3.days.from_now }
+    end
+
+    def borrowed_items_preview
+      @borrowed_items_preview ||= preview(actionable_borrowed_items, checkouts)
+    end
+
+    def fines
+      @fines ||= patron.fines
+    end
+
+    def balance
+      @balance ||= fines.sum { |f| f.owed || 0 }
+    end
+
+    def pickup_requests
+      @pickup_requests ||= preview(ready_for_pickup, patron.requests)
+    end
+
+    def ready_for_pickup
+      @ready_for_pickup ||= patron.requests.select(&:ready_for_pickup?)
+    end
+
+    def digital_requests
+      @digital_requests ||= aeon.requests.digitization.submitted.newest_first
+    end
+
+    def recently_delivered_digital_requests
+      @recently_delivered_digital_requests ||= aeon.requests.digitization.recently_delivered.newest_first(&:delivered_date)
+    end
+
+    def digitization_preview_requests
+      preview(recently_delivered_digital_requests, digital_requests)
+    end
+
+    def digitization_status
+      @digitization_status ||= begin
+        count = recently_delivered_digital_requests.count
+        label = count.positive? ? 'delivered recently via email' : 'Recently requested'
+        DigitizationStatus.new(count:, label:)
+      end
+    end
+
+    def appointments
+      @appointments ||= aeon.appointments
+    end
+
+    def appointment_requests_count
+      @appointment_requests_count ||= appointments.sum { |a| a.requests.count }
+    end
+
+    def next_appointment_date
+      @next_appointment_date ||= upcoming_appointments.first&.start_time&.to_date
+    end
+
+    def upcoming_appointments
+      @upcoming_appointments ||= appointments.upcoming(within: 7.days, fallback: 3)
+    end
+
+    def saved_for_later
+      @saved_for_later ||= aeon.requests.saved_for_later.newest_first
+    end
+
+    def next_activity_date
+      first_activity = upcoming_activities&.first
+      @next_activity_date ||= first_activity&.start_time&.to_date
+    end
+
+    def upcoming_activities
+      @upcoming_activities ||= aeon.activities&.active&.upcoming(within: 7.days, fallback: 3)
+    end
+
+    private
+
+    def patron
+      @patron ||= user.patron
+    end
+
+    def aeon
+      @aeon ||= user.aeon
+    end
+
+    def preview(primary, fallback, limit: 3)
+      primary.presence || fallback.first(limit)
+    end
+  end
+end

--- a/app/views/aeon_appointments/destroy.turbo_stream.erb
+++ b/app/views/aeon_appointments/destroy.turbo_stream.erb
@@ -4,6 +4,8 @@
 
 <%= turbo_stream.remove(@appointment) %>
 
+<%= turbo_stream.remove dom_id(@appointment, :home) %>
+
 <%= turbo_stream.remove_all ".dropdown [data-value='#{@appointment.id}']" %>
 
 <%= turbo_stream.replace('saved_for_later_aeon_requests_sidebar') do %>

--- a/app/views/aeon_appointments/update.turbo_stream.erb
+++ b/app/views/aeon_appointments/update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.append(params[:modal]) do %>
+  <div class="d-none" data-modal-target="closeSignal"></div>
+<% end if params[:modal] %>
+
+<%= turbo_stream.replace dom_id(@appointment) do %>
+  <%= render Aeon::AppointmentComponent.new(appointment: @appointment, all_requests: @aeon_requests) %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@appointment, :home) do %>
+  <%= render 'home/appointments/li', appointment: @appointment %>
+<% end %>

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -3,10 +3,10 @@
   <h1 class="mt-2 me-3">Fees and fines</h1>
   <ul class="nav nav-tabs">
     <li class="nav-item">
-      <button class="nav-link active fs-5" data-bs-toggle="tab" data-bs-target="#active-tab">Current</button>
+      <button class="nav-link <%= 'active' unless params[:past] %> fs-5" data-bs-toggle="tab" data-bs-target="#active-tab">Current</button>
     </li>
     <li class="nav-item">
-      <button class="nav-link fs-5" data-bs-toggle="tab" data-bs-target="#past-payments-tab">Past</button>
+      <button class="nav-link <%= 'active' if params[:past] %> fs-5" data-bs-toggle="tab" data-bs-target="#past-payments-tab">Past</button>
     </li>
   </ul>
   <div class="tab-underline-extend flex-grow-1 border-bottom d-none d-sm-block">
@@ -14,7 +14,7 @@
 </div>
 
 <div class="tab-content">
-  <div id="active-tab" class="tab-pane fade show active">
+  <div id="active-tab" class="tab-pane fade <%= 'show active' unless params[:past] %>">
     <% if @fines.any? %>
       <div class="d-flex flex-row align-items-center gap-3 my-3">
         <span class="text-cardinal">Outstanding balance: <strong><%= number_to_currency(@fines.sum(&:owed)) %></strong></span>
@@ -33,7 +33,7 @@
     <% end %>
   </div>
 
-  <div id="past-payments-tab" class="tab-pane fade">
+  <div id="past-payments-tab" class="tab-pane fade <%= 'show active' if params[:past] %>">
     <turbo-frame src="<%= payments_path %>" <% unless params[:past] %>loading="lazy"<% end %> id="past-payments">
       Loading...
     </turbo-frame>

--- a/app/views/home/_card_view.html.erb
+++ b/app/views/home/_card_view.html.erb
@@ -1,0 +1,77 @@
+<div class="home-cards d-grid gap-4" style="grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));">
+  <%= render Home::SummaryCardComponent.new(
+        title: 'Borrowed items',
+        icon: 'bi-book',
+        count: dashboard.checkouts.count,
+        item_label: 'item',
+        item_label_suffix: 'currently loaned',
+        empty_label: 'No items on loan',
+        path: checkouts_path,
+        status: count_callout(count: dashboard.actionable_borrowed_items.count, phrase: 'due soon')) %>
+
+  <%= render Home::FinesCardComponent.new(
+        title: 'Fees and fines',
+        icon: 'bi-cash-coin',
+        fines: dashboard.fines,
+        balance: dashboard.balance,
+        patron_key: current_user.patron.key,
+        path: fines_path,
+        past_path: fines_path(past: 1)) %>
+
+  <%= render Home::SummaryCardComponent.new(
+        title: 'Pickup requests',
+        icon: 'bi-bag',
+        count: dashboard.pickup_requests.count,
+        item_label: 'item',
+        item_label_suffix: 'requested',
+        empty_label: 'No pickup requests',
+        path: folio_requests_path,
+        status: count_callout(count: dashboard.ready_for_pickup.count, phrase: "#{'item'.pluralize(dashboard.ready_for_pickup.count)} ready for pickup")) %>
+
+  <% delivery = dashboard.digitization_status %>
+  <%= render Home::SummaryCardComponent.new(
+        title: 'Digitization requests',
+        icon: 'bi-printer',
+        count: dashboard.digital_requests.count,
+        item_label: 'item',
+        item_label_suffix: 'requested',
+        empty_label: 'No digitization requests',
+        path: aeon_requests_path(kind: 'submitted', filter: 'digitization'),
+        empty_path: aeon_requests_path(kind: 'completed', filter: 'digitization'),
+        empty_link_label: 'View past requests',
+        status: count_callout(count: delivery.count, phrase: delivery.label)) %>
+
+  <%= render Home::SummaryCardComponent.new(
+        title: 'Reading room appointments',
+        icon: 'bi-calendar',
+        count: dashboard.appointments.count,
+        item_label: 'appointment',
+        empty_label: 'No appointments scheduled',
+        path: aeon_appointments_path,
+        empty_path: aeon_requests_path(kind: 'completed', filter: 'reading_room'),
+        empty_link_label: 'View past appointments',
+        secondary_count: dashboard.appointment_requests_count,
+        secondary_label: 'item',
+        secondary_label_suffix: 'scheduled',
+        next_up_date: dashboard.next_appointment_date) %>
+
+  <%= render Home::SummaryCardComponent.new(
+        title: 'Saved for later',
+        icon: 'bi-pin-angle',
+        count: dashboard.saved_for_later.count,
+        item_label: 'item',
+        empty_label: 'No saved items',
+        path: aeon_requests_path(kind: 'saved_for_later'),
+        status: (tag.span('Requests not complete', class: 'text-digital-red-dark') if dashboard.saved_for_later.count.positive?)) %>
+
+  <%= render Home::SummaryCardComponent.new(
+        title: 'Activities',
+        icon: 'bi-person-video3',
+        count: dashboard.upcoming_activities.count,
+        item_label: 'upcoming activity',
+        empty_label: 'No upcoming activities',
+        path: aeon_activities_path,
+        empty_path: past_aeon_activities_path,
+        empty_link_label: 'View past activities',
+        next_up_date: dashboard.next_activity_date) %>
+</div>

--- a/app/views/home/_list_view.html.erb
+++ b/app/views/home/_list_view.html.erb
@@ -16,19 +16,21 @@
     view_all_path: checkouts_path) do |c| %>
     <% c.with_items do %>
       <ul class="borrowed-items list-unstyled mb-2">
-        <% dashboard.borrowed_items_preview&.each do |request| %>
-          <li id="<%= dom_id(request, :home) %>" class="border-bottom d-flex flex-column gap-1 py-1">
-            <% if request.overdue? %>
+        <% dashboard.borrowed_items_preview&.each do |checkout| %>
+          <li id="<%= dom_id(checkout, :home) %>" class="border-bottom d-flex flex-column gap-1 py-1">
+            <% if checkout.overdue? %>
               <span class="fw-semibold small text-cardinal"><i class="bi bi-exclamation-triangle text-cardinal me-1"></i>Overdue</span>
-              <span class="ms-3">Accruing <%= number_to_currency(request.overdue_fines_rate['quantity']) %>/<%= request.overdue_fines_rate['intervalId'] %> until returned
-              </span>
+              <% if checkout.accruing? %>
+                <span class="ms-3">Accruing <%= number_to_currency(checkout.overdue_fines_rate['quantity']) %>/<%= checkout.overdue_fines_rate['intervalId'] %> until returned
+                </span>
+              <% end %>
             <% else %>
               <div class="fw-semibold small text-cardinal">
-                Due <%= format_relative_date_phrase(request.due_date) %>
+                Due <%= format_relative_date_phrase(checkout.due_date) %>
               </div>
             <% end %>
             <div class="small">
-              <%= request.title %>
+              <%= checkout.title %>
             </div>
             <div class="d-flex flex-shrink-0 gap-2">
             </div>

--- a/app/views/home/_list_view.html.erb
+++ b/app/views/home/_list_view.html.erb
@@ -1,0 +1,143 @@
+<div class="row">
+  <div class="home-list d-flex flex-column gap-3 col-lg-10 mx-auto">
+  <%= render Home::ListView::FinesCardComponent.new(
+    title: 'Fees and fines',
+    icon: 'bi-cash-coin',
+    fines: dashboard.fines,
+    balance: dashboard.balance,
+    patron_key: current_user.patron.key,
+    path: fines_path) %>
+
+  <%= render Home::ListView::SummaryCardComponent.new(
+    title: 'Borrowed items',
+    icon: 'bi-book',
+    count: dashboard.checkouts.count,
+    view_all_label: 'View all borrowed items',
+    view_all_path: checkouts_path) do |c| %>
+    <% c.with_items do %>
+      <ul class="borrowed-items list-unstyled mb-2">
+        <% dashboard.borrowed_items_preview&.each do |request| %>
+          <li id="<%= dom_id(request, :home) %>" class="border-bottom d-flex flex-column gap-1 py-1">
+            <% if request.overdue? %>
+              <span class="fw-semibold small text-cardinal"><i class="bi bi-exclamation-triangle text-cardinal me-1"></i>Overdue</span>
+              <span class="ms-3">Accruing <%= number_to_currency(request.overdue_fines_rate['quantity']) %>/<%= request.overdue_fines_rate['intervalId'] %> until returned
+              </span>
+            <% else %>
+              <div class="fw-semibold small text-cardinal">
+                Due <%= format_relative_date_phrase(request.due_date) %>
+              </div>
+            <% end %>
+            <div class="small">
+              <%= request.title %>
+            </div>
+            <div class="d-flex flex-shrink-0 gap-2">
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <%= render Home::ListView::SummaryCardComponent.new(
+    title: 'Pickup requests',
+    icon: 'bi-bag',
+    count: dashboard.pickup_requests.count,
+    view_all_label: 'View all pickup requests',
+    view_all_path: folio_requests_path,
+    status: (dashboard.ready_for_pickup.any? ? "#{dashboard.ready_for_pickup.count} #{'item'.pluralize(dashboard.ready_for_pickup.count)} ready for pickup" : 'Recently requested')) do |c| %>
+    <% c.with_items do %>
+      <ul class="list-unstyled mb-2">
+        <% dashboard.pickup_requests&.each do |request| %>
+          <li id="<%= dom_id(request, :home) %>" class="border-top py-2 d-flex justify-content-between align-items-start gap-3">
+            <% if request.expiration_date %>
+              <div class="fw-semibold small">Available until <%= l(request.expiration_date, format: :date_only) %></div>
+            <% end %>
+            <div class="fw-semibold small">
+              <%= request.title %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <% delivery = dashboard.digitization_status %>
+  <%= render Home::ListView::SummaryCardComponent.new(
+    title: 'Digitization requests',
+    icon: 'bi-printer',
+    count: dashboard.digital_requests.count,
+    view_all_label: 'View all digitization requests',
+    view_all_path: aeon_requests_path(kind: 'submitted', filter: 'digitization'),
+    status: (delivery.count.positive? ? "#{delivery.count} #{delivery.label}" : delivery.label)) do |c| %>
+    <% c.with_items do %>
+      <ul class="list-unstyled mb-2">
+        <% dashboard.digitization_preview_requests&.first(3)&.each do |request| %>
+          <li class="border-top py-2 small">
+            <%= request.title %><i class="bi bi-chevron-right"></i>
+            <%= render Aeon::RequestItemIdentifierComponent.new(request:, classes:[]) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <%= render Home::ListView::SummaryCardComponent.new(
+        title: 'Reading room appointments',
+        icon: 'bi-calendar',
+        count: dashboard.appointments.count,
+        pill_noun: 'appointments',
+        view_all_label: 'View all reading room appointments',
+        view_all_path: aeon_appointments_path,
+        status: 'Coming soon') do |c| %>
+    <% c.with_items do %>
+      <ul class="list-unstyled mb-2">
+        <% dashboard.upcoming_appointments&.each do |appointment| %>
+          <%= render 'home/appointments/li', appointment: appointment %>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <%= render Home::ListView::SummaryCardComponent.new(
+        title: 'Activities',
+        icon: 'bi-person-video3',
+        count: dashboard.upcoming_activities.count,
+        view_all_label: 'View all activities',
+        view_all_path: aeon_activities_path,
+        status: 'Coming soon') do |c| %>
+    <% c.with_items do %>
+      <ul class="list-unstyled mb-2">
+        <% dashboard.upcoming_activities&.each do |activity| %>
+          <li class="border-top py-2">
+            <div class="small"><%= render AppointmentTimeRangeComponent.new(appointment: activity, show_hours: true, location: activity.location, emphasize_date: true) %></div>
+            <div class="small">
+              <%= activity.activity_type %><i class="bi bi-dot"></i><%= activity.name %>
+              <% item_count = activity.requests.count %>
+              <%= render PillComponent.new(classes: %w[bg-stanford-20-black fw-light ms-3 py-0]).with_content("#{item_count} #{'item'.pluralize(item_count)}") %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <%= render Home::ListView::SummaryCardComponent.new(
+    title: 'Saved for later',
+    icon: 'bi-pin-angle',
+    count: dashboard.saved_for_later.count,
+    status: 'Requests not complete',
+    view_all_label: 'View all saved items',
+    view_all_path: aeon_requests_path(kind: 'saved_for_later')) do |c| %>
+    <% c.with_items do %>
+      <ul class="list-unstyled mb-2">
+        <% dashboard.saved_for_later&.first(3)&.each do |request| %>
+          <li class="border-top py-2 small">
+            <%= request.title %><i class="bi bi-chevron-right"></i>
+            <%= render Aeon::RequestItemIdentifierComponent.new(request:, classes:[]) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/home/_questions_aside.html.erb
+++ b/app/views/home/_questions_aside.html.erb
@@ -1,0 +1,57 @@
+<aside class="col-lg-3 mt-4 mt-lg-0">
+  <div class="border-start ps-3 pb-1">
+    <h2 class="mb-4">Questions?</h2>
+
+    <div class="row">
+      <div class="col-md-6 col-lg-12">
+        <h3>Circulating materials</h3>
+        <p class="mb-1">
+          <%= link_to 'https://library.stanford.edu/services/borrow-and-request', class: 'su-underline' do %>
+            Borrow, renew, and <span class="text-nowrap">request<i class="bi bi-arrow-up-right ms-1"></i></span>
+          <% end %>
+        </p>
+        <p class="mb-1">
+          <%= link_to "mailto:#{Settings.libraries.default.contact_info.email}", class: 'su-underline' do %>
+            <i class="align-middle bi bi-envelope me-1"></i><%= Settings.libraries.default.contact_info.email %>
+          <% end %>
+        </p>
+        <p class="mb-3">
+          <i class="align-middle bi bi-phone me-1"></i><%= Settings.libraries.default.contact_info.phone %>
+        </p>
+      </div>
+
+      <div class="col-md-6 col-lg-12">
+        <h3>Special collections</h3>
+        <p class="mb-3">
+          <%= link_to 'https://library.stanford.edu/libraries/special-collections', class: 'su-underline' do %>
+            Access rare and distinctive <span class="text-nowrap">materials<i class="bi bi-arrow-up-right ms-1"></i></span>
+          <% end %>
+        </p>
+
+        <h3>The Libraries doesn't have what you need?</h3>
+        <p class="mb-1">
+          Place a request via <%= link_to 'https://library.stanford.edu/interlibrary-loan', class: 'su-underline' do %>
+          Interlibrary loan.
+          <% end %>
+        </p>
+        <p>
+          Submit a <%= link_to 'purchase recommendation.', 'https://stanforduniversity.qualtrics.com/jfe/form/SV_5iQABR6VSszIQMR', class: 'su-underline' %>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-4 p-3">
+    <p class="small text-muted mb-2">Home page variant</p>
+    <div class="btn-group btn-group-sm" role="group" aria-label="Home view variant">
+      <button type="button"
+              class="btn btn-primary"
+              data-action="home-view-toggle#set"
+              data-home-view-toggle-variant-param="card">Card view</button>
+      <button type="button"
+              class="btn btn-primary"
+              data-action="home-view-toggle#set"
+              data-home-view-toggle-variant-param="list">List view</button>
+    </div>
+  </div>
+</aside>

--- a/app/views/home/_show_redesign.html.erb
+++ b/app/views/home/_show_redesign.html.erb
@@ -1,32 +1,17 @@
 <% if sso_user? %>
-  <div class="d-grid gap-3 w-50 ms-auto me-auto" style="grid-template-columns: 1fr 1fr;">
-    <div class="card bg-light d-flex flex-row">
-      <div class="bg-secondary-subtle w-25"></div>
-      <div class="card-body p-2">
-        <h2 class="card-title fs-5 mb-1"><%= link_to 'Borrowed items', checkouts_path, class: 'fw-semibold' %></h2>
-        <p>Journal articles, eBooks, and more from the Library's digital subscriptions</p>
+  <h1 class="visually-hidden">My Library Account Home</h1>
+  <div class="row"
+       data-controller="home-view-toggle"
+       data-home-view-toggle-storage-key-value="sulRequests:homeView"
+       data-home-view="card">
+    <div class="col-lg-9">
+      <div data-home-view-variant="card">
+        <%= render 'card_view', dashboard: @dashboard %>
+      </div>
+      <div data-home-view-variant="list">
+        <%= render 'list_view', dashboard: @dashboard %>
       </div>
     </div>
-    <div class="card bg-light d-flex flex-row">
-      <div class="bg-secondary-subtle w-25"></div>
-      <div class="card-body p-2">
-        <h2 class="card-title fs-5 mb-1"><%= link_to 'Requests', aeon_requests_path(kind: 'submitted'), class: 'fw-semibold' %></h2>
-        <p>Journal articles, eBooks, and more from the Library's digital subscriptions</p>
-      </div>
-    </div>
-    <div class="card bg-light d-flex flex-row">
-      <div class="bg-secondary-subtle w-25"></div>
-      <div class="card-body p-2">
-        <h2 class="card-title fs-5 mb-1"><%= link_to 'Appointments', aeon_appointments_path, class: 'fw-semibold' %></h2>
-        <p>Journal articles, eBooks, and more from the Library's digital subscriptions</p>
-      </div>
-    </div>
-    <div class="card bg-light d-flex flex-row">
-      <div class="bg-secondary-subtle w-25"></div>
-      <div class="card-body p-2">
-        <h2 class="card-title fs-5 mb-1"><%= link_to 'Fines', fines_path, class: 'fw-semibold' %></h2>
-        <p>Journal articles, eBooks, and more from the Library's digital subscriptions</p>
-      </div>
-    </div>
+    <%= render 'questions_aside' %>
   </div>
 <% end %>

--- a/app/views/home/appointments/_li.html.erb
+++ b/app/views/home/appointments/_li.html.erb
@@ -1,0 +1,11 @@
+<% item_count = appointment.requests.count %>
+<li id="<%= dom_id(appointment, :home) %>" class="border-top py-2 d-flex justify-content-between align-items-start gap-3">
+  <div class="small">
+    <%= render AppointmentTimeRangeComponent.new(appointment: appointment, show_hours: true, location: appointment.reading_room.name, emphasize_date: true) %>
+    <%= render PillComponent.new(classes: %w[bg-stanford-20-black fw-light ms-3 py-0 text-nowrap]).with_content("#{item_count} #{'item'.pluralize(item_count)}") %>
+  </div>
+  <div class="d-flex flex-shrink-0 gap-2">
+    <%= render Aeon::EditAppointmentButtonComponent.new(appointment: appointment) %>
+    <%= render Aeon::DeleteAppointmentButtonComponent.new(appointment: appointment) %>
+  </div>
+</li>

--- a/spec/component_previews/home/card_view/fines_card_component_preview.rb
+++ b/spec/component_previews/home/card_view/fines_card_component_preview.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Home
+  module CardView
+    class FinesCardComponentPreview < ViewComponent::Preview
+      layout 'lookbook'
+
+      def empty
+        render Home::FinesCardComponent.new(
+          title: 'Fees and fines',
+          icon: 'bi-cash-coin',
+          fines: [],
+          balance: 0,
+          patron_key: 'preview',
+          path: '#',
+          past_path: '#'
+        )
+      end
+
+      def with_balance
+        render Home::FinesCardComponent.new(
+          title: 'Fees and fines',
+          icon: 'bi-cash-coin',
+          fines: fake_fines,
+          balance: 25.5,
+          patron_key: 'preview',
+          path: '#',
+          past_path: '#'
+        )
+      end
+
+      private
+
+      def fake_fines
+        [Struct.new(:key).new('fine-1'), Struct.new(:key).new('fine-2')]
+      end
+    end
+  end
+end

--- a/spec/component_previews/home/card_view/summary_card_component_preview.rb
+++ b/spec/component_previews/home/card_view/summary_card_component_preview.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module Home
+  module CardView
+    class SummaryCardComponentPreview < ViewComponent::Preview
+      layout 'lookbook'
+
+      def saved_for_later_empty
+        render Home::SummaryCardComponent.new(
+          title: 'Saved for later',
+          icon: 'bi-pin-angle-fill',
+          count: 0,
+          item_label: 'item',
+          empty_label: 'No saved items',
+          path: '#'
+        )
+      end
+
+      def saved_for_later_with_items
+        render Home::SummaryCardComponent.new(
+          title: 'Saved for later',
+          icon: 'bi-pin-angle-fill',
+          count: 3,
+          item_label: 'item',
+          empty_label: 'No saved items',
+          status: '<span class="text-digital-red-dark">Requests not complete</span>'.html_safe,
+          path: '#'
+        )
+      end
+
+      def borrowed_items_empty
+        render Home::SummaryCardComponent.new(
+          title: 'Borrowed items',
+          icon: 'bi-book',
+          count: 0,
+          item_label: 'item',
+          item_label_suffix: 'currently loaned',
+          empty_label: 'No items on loan',
+          path: '#'
+        )
+      end
+
+      def borrowed_items_with_status
+        render Home::SummaryCardComponent.new(
+          title: 'Borrowed items',
+          icon: 'bi-book',
+          count: 5,
+          item_label: 'item',
+          item_label_suffix: 'currently loaned',
+          empty_label: 'No items on loan',
+          status: '<span class="text-digital-red-dark"><span class="fw-semibold">2</span> due soon</span>'.html_safe,
+          path: '#'
+        )
+      end
+
+      def pickup_requests_empty
+        render Home::SummaryCardComponent.new(
+          title: 'Pickup requests',
+          icon: 'bi-bag',
+          count: 0,
+          item_label: 'item',
+          item_label_suffix: 'requested',
+          empty_label: 'No pickup requests',
+          path: '#'
+        )
+      end
+
+      def pickup_requests_with_status
+        render Home::SummaryCardComponent.new(
+          title: 'Pickup requests',
+          icon: 'bi-bag',
+          count: 4,
+          item_label: 'item',
+          item_label_suffix: 'requested',
+          empty_label: 'No pickup requests',
+          status: '<span class="text-digital-red-dark"><span class="fw-semibold">2</span> items ready for pickup</span>'.html_safe,
+          path: '#'
+        )
+      end
+
+      def digitization_requests_empty
+        render Home::SummaryCardComponent.new(
+          title: 'Digitization requests',
+          icon: 'bi-printer',
+          count: 0,
+          item_label: 'item',
+          item_label_suffix: 'requested',
+          empty_label: 'No digitization requests',
+          path: '#',
+          empty_path: '#',
+          empty_link_label: 'View past requests'
+        )
+      end
+
+      def digitization_requests_with_status # rubocop:disable Metrics/MethodLength
+        render Home::SummaryCardComponent.new(
+          title: 'Digitization requests',
+          icon: 'bi-printer',
+          count: 3,
+          item_label: 'item',
+          item_label_suffix: 'requested',
+          empty_label: 'No digitization requests',
+          path: '#',
+          empty_path: '#',
+          empty_link_label: 'View past requests',
+          status: '<span class="text-digital-red-dark"><span class="fw-semibold">2</span> delivered recently via email</span>'.html_safe
+        )
+      end
+
+      def activities_empty
+        render Home::SummaryCardComponent.new(
+          title: 'Activities',
+          icon: 'bi-person-video3',
+          count: 0,
+          item_label: 'upcoming activity',
+          empty_label: 'No upcoming activities',
+          path: '#',
+          empty_path: '#',
+          empty_link_label: 'View past activities'
+        )
+      end
+
+      def activities_with_next_up
+        render Home::SummaryCardComponent.new(
+          title: 'Activities',
+          icon: 'bi-person-video3',
+          count: 4,
+          item_label: 'upcoming activity',
+          empty_label: 'No upcoming activities',
+          path: '#',
+          empty_path: '#',
+          empty_link_label: 'View past activities',
+          next_up_date: Date.new(2026, 6, 18)
+        )
+      end
+
+      def appointments_empty
+        render Home::SummaryCardComponent.new(
+          title: 'Reading room appointments',
+          icon: 'bi-calendar',
+          count: 0,
+          item_label: 'appointment',
+          empty_label: 'No appointments scheduled',
+          path: '#',
+          empty_path: '#',
+          empty_link_label: 'View past appointments'
+        )
+      end
+
+      def appointments_with_next_up # rubocop:disable Metrics/MethodLength
+        render Home::SummaryCardComponent.new(
+          title: 'Reading room appointments',
+          icon: 'bi-calendar',
+          count: 2,
+          item_label: 'appointment',
+          empty_label: 'No appointments scheduled',
+          path: '#',
+          empty_path: '#',
+          empty_link_label: 'View past appointments',
+          secondary_count: 5,
+          secondary_label: 'item',
+          secondary_label_suffix: 'scheduled',
+          next_up_date: Date.new(2026, 6, 18)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of #2854 
<img width="1418" height="701" alt="Screenshot 2026-06-22 at 1 03 26 PM" src="https://github.com/user-attachments/assets/4d14eda7-e344-4c84-bf38-70021366df19" />
<img width="1090" height="559" alt="Screenshot 2026-06-23 at 9 54 34 AM" src="https://github.com/user-attachments/assets/e2f51e77-4d97-461e-80c6-638711cdb886" />


Trying to leave things hand-tight as we're exploring both layout options and functionality. The dashboard model was a convenience, if we pick a single direction it could likely be consolidated or removed.

There's also the world where we turbo-with-placeholder these cards, some are slow loading. Keeping it simple while we decide between the two.

The variant switcher is only for this testing period, it's not part of the design. 

TODOs:

- [x] Put more thought into the markup/responsiveness of the questions aside
- [x] Break up `AppointmentTimeRangeComponent` into smaller composable components. The list view in the design only has `fw-semibold` for the date, `AppointmentTimeRangeComponent` applies it for all.
- [ ] Revisit all the data sources/sorting. Some things are stubbed, some are Aeon only where they should be mixed.
- [ ] Revisit what Darcy wants to control list view card visibility. For development, in the "List" view I added a "preview" fallback for some cards where Darcy suggested a time window. If there's nothing in the time window, but there are "upcoming" appointments/requests, I favored displaying a minimal set of those. Darcy has some question marks in the issue regarding what's best, this was my initial thought, but we need to have a discussion with her.
- [ ] Add actions for renew (borrowed items) and cancel (pickup)
- [ ] Add "Items" action for reading room appointments
- [ ] Wire up the pay button for real, I copy and pasted some stuff 🤷 
- [x] Populate any remaining stubbed links
- [x] Are all those ordered lists ordered?
- [ ] Tests