### PR TITLE
Remove the request card box-shadow style

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -561,8 +561,6 @@ label.btn-close {
   --bs-border-radius: 0.25rem;
   --bs-card-border-color: var(--stanford-10-black);
 
-  box-shadow: 0px 4px 4px 0px #00000040;
-
   .card-header {
     --bs-card-border-color: var(--stanford-20-black);
   }


### PR DESCRIPTION
- This isn't getting applied because it's missing `!important`.
- It seems to be, to my eye, visually identical to the default box shadow