### PR TITLE
Display submitted Aeon + FOLIO requests on a single page

### DIFF
--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new id: request_group.dom_id, element: element, classes: 'request-group', data: { 'default-sort-value': request_group.sort_key(:default), 'title-sort-value': request_group.sort_key(:title), 'date-sort-value': request_group.sort_key(:date)} do |c| %>
+<%= render CardComponent.new id: request_group.dom_id, element: element, classes: 'request-group', data: { 'filter-value': request_group.digital? ? 'digitization' : 'reading room',  'default-sort-value': request_group.sort_key(:default), 'title-sort-value': request_group.sort_key(:title), 'date-sort-value': request_group.sort_key(:date)} do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/aeon/request_group_component.html.erb
+++ b/app/components/aeon/request_group_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new id: request_group.dom_id, element: element, classes: 'request-group' do |c| %>
+<%= render CardComponent.new id: request_group.dom_id, element: element, classes: 'request-group', data: { 'default-sort-value': request_group.sort_key(:default), 'title-sort-value': request_group.sort_key(:title), 'date-sort-value': request_group.sort_key(:date)} do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">
@@ -23,7 +23,7 @@
   <% end %>
 
   <% c.with_body do %>
-    <ul class="list-group list-group-flush gap-2">
+    <ul class="list-group list-group-flush gap-2" data-sortable-target="subgroup">
       <%= render Aeon::RequestGroupItemComponent.with_collection(requests) %>
     </ul>
   <% end %>

--- a/app/components/aeon/request_group_item_component.html.erb
+++ b/app/components/aeon/request_group_item_component.html.erb
@@ -1,4 +1,4 @@
-<li id="<%= dom_id(request) %>" class="request <%= classes.join(' ') %>">
+<%= tag.li id: dom_id(request), class: classes + ['request'], data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) } do %>
   <div class="rgi-id d-flex align-items-center">
     <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
 
@@ -29,4 +29,4 @@
       <div>Date added/modified: <%= l(transaction_date, format: :full) %></div>
     </div>
   <% end %>
-</li>
+<% end %>

--- a/app/components/folio/ill_request_component.html.erb
+++ b/app/components/folio/ill_request_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) }) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'filter-value': 'pickup', 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) }) do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/folio/ill_request_component.html.erb
+++ b/app/components/folio/ill_request_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'date-sort-value': request.sort_key(:date), 'title-sort-value': request.sort_key(:title), 'date_modified-sort-value': request.sort_key(:date_modified) }) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) }) do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date)}) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'filter-value': 'pickup', 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date)}) do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'date-sort-value': request.sort_key(:date), 'title-sort-value': request.sort_key(:title), 'date_modified-sort-value': request.sort_key(:date_modified)  }) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date)}) do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -8,8 +8,8 @@
       <div>
         <%= tag.h2 request.title || 'Not available', class: @title_classes %>
         <div class="d-flex column-gap-md-3 flex-md-row flex-column flex-wrap">
-          <% if request.call_number.present? %>
-            <span>Call number: <%= request.call_number %></span>
+          <% if request.full_call_number.present? %>
+            <span>Call number: <%= request.full_call_number %></span>
           <% end %>
           <span>
             <%= detail_link_to_searchworks(request.catkey) %>

--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -67,7 +67,7 @@ class AeonAppointmentsController < ApplicationController
     authorize! :read, @appointment
 
     requests = @aeon_requests.for_reading_room(@appointment.reading_room).saved_for_later.sort_by do |x|
-      [x.title, x.sort_key, -1 * x.creation_date.to_i]
+      [x.title, x.default_sort_key, -1 * x.creation_date.to_i]
     end
     @aeon_request_groups = Aeon::RequestGrouping.from_requests(requests)
   end

--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -16,6 +16,8 @@ class AeonRequestsController < ApplicationController
 
   def index
     authorize! :read, Aeon::Request
+
+    render 'async' and return if params[:async]
   end
 
   def resubmit

--- a/app/controllers/concerns/aeon_sortable.rb
+++ b/app/controllers/concerns/aeon_sortable.rb
@@ -7,22 +7,21 @@ module AeonSortable
   SORT_OPTIONS = {
     'title' => {
       label: 'Sort by title',
-      sort: ->(requests) { requests.sort_by { |r| [r.title.to_s, r.sort_key] } }
+      sort: ->(requests) { requests.sort_by { |r| r.sort_key(:title) } }
     },
-    'date_modified' => {
+    'date' => {
       label: 'Sort by date modified',
-      sort: ->(requests) { requests.newest_first(&:transaction_date) }
+      sort: ->(requests) { requests.sort_by { |r| r.sort_key(:date) } }
     },
-    'appointment_time' => {
-      label: 'Sort by appointment time',
+    'default' => {
+      label: 'Sort by default',
       sort: lambda { |requests|
-        requests.sort_by { |r| [r.appointment&.start_time || Time.zone.local(9999), r.title.to_s, r.sort_key] }
-      },
-      only_for_filters: %w[all reading_room]
+        requests.sort_by { |r| r.sort_key(:default) }
+      }
     }
   }.freeze
 
-  DEFAULT_SORT = 'date_modified'
+  DEFAULT_SORT = 'default'
 
   included do
     helper_method :current_aeon_sort, :available_aeon_sort_options
@@ -39,7 +38,6 @@ module AeonSortable
   end
 
   def available_aeon_sort_options
-    filter = respond_to?(:current_aeon_filter, true) ? current_aeon_filter : 'all'
-    SORT_OPTIONS.select { |_, option| option[:only_for_filters].nil? || option[:only_for_filters].include?(filter) }
+    SORT_OPTIONS
   end
 end

--- a/app/controllers/folio_requests_controller.rb
+++ b/app/controllers/folio_requests_controller.rb
@@ -15,7 +15,9 @@ class FolioRequestsController < ApplicationController
   #
   # GET /requests
   # GET /requests.json
-  def index; end
+  def index
+    render 'async' and return if params[:async]
+  end
 
   # Renders a form for editing a request/hold
   #

--- a/app/controllers/ill_requests_controller.rb
+++ b/app/controllers/ill_requests_controller.rb
@@ -12,7 +12,9 @@ class IllRequestsController < ApplicationController
   #
   # GET /ill_requests
   # GET /ill_requests.json
-  def index; end
+  def index
+    render 'async' and return if params[:async]
+  end
 
   private
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -4,6 +4,10 @@
 #  Old requests action that redirects new requests to the PatronRequestsController
 ###
 class RequestsController < ApplicationController
+  include FolioController
+
+  def index; end
+
   def new
     mapped_params = { 'instance_hrid' => new_params[:item_id],
                       'origin_location_code' => new_params[:origin_location],

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,9 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['list', 'menu', 'observe']
+  static targets = ['list', 'menu', 'observe', 'subgroup']
   static values = {
-    sort: String
+    sort: String,
+    filter: String
   }
 
   connect() {
@@ -62,23 +63,28 @@ export default class extends Controller {
   resort() {
     if (!this.sortValue || !this.hasListTarget) return;
 
-    const items = this.listTarget.children;
+    this.resortChildren(this.listTarget, this.sortValue + 'SortValue');
 
+    this.subgroupTargets.forEach(subgroup => {
+      this.resortChildren(subgroup, this.sortValue + 'SortValue');
+    });
+  }
+
+  resortChildren(target, sortValue) {
+    const items = target.children;
     const sortedItems = Array.from(items).sort((a, b) => {
-      const aValue = a.dataset[this.sortValue + 'SortValue'] || '';
-      const bValue = b.dataset[this.sortValue + 'SortValue'] || '';
+      const aValue = a.dataset[sortValue] || '';
+      const bValue = b.dataset[sortValue] || '';
 
       if (aValue < bValue) return -1;
       if (aValue > bValue) return 1;
       return 0;
     });
 
-    // TODO: sort subgroups too.
-
     if (Array.from(items).every((item, index) => item === sortedItems[index])) {
       return;
     }
 
-    sortedItems.forEach(item => this.listTarget.appendChild(item));
+    sortedItems.forEach(item => target.appendChild(item));
   }
 }

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['list', 'menu']
+  static targets = ['list', 'menu', 'observe']
   static values = {
     sort: String
   }
@@ -12,6 +12,30 @@ export default class extends Controller {
     } else {
       this.resort();
     }
+  }
+
+  debouncedDynamicResort() {
+    if (this.debounceTimeout) {
+      clearTimeout(this.debounceTimeout);
+    }
+
+    // this.sorting = true;
+    this.debounceTimeout = setTimeout(() => {
+      this.resort();
+    }, 30);
+  }
+
+  observeTargetConnected(el) {
+    this.observer = new MutationObserver((_mutations => {
+      this.debouncedDynamicResort();
+    }));
+
+    this.observer.observe(el, { childList: true });
+  }
+
+  observeTargetDisconnected() {
+    this.observer.disconnect();
+    if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
   }
 
   sort(event) {
@@ -48,6 +72,12 @@ export default class extends Controller {
       if (aValue > bValue) return 1;
       return 0;
     });
+
+    // TODO: sort subgroups too.
+
+    if (Array.from(items).every((item, index) => item === sortedItems[index])) {
+      return;
+    }
 
     sortedItems.forEach(item => this.listTarget.appendChild(item));
   }

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,17 +1,18 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['list', 'menu', 'observe', 'subgroup']
+  static targets = ['list', 'sortMenu', 'filterMenu', 'observe', 'subgroup']
   static values = {
     sort: String,
-    filter: String
+    filter: { type: String, default: '' }
   }
 
   connect() {
     if (!this.sortValue) {
-      this.sortValue = this.menuTarget.querySelector('[data-sortable-sort-param]').dataset.sortableSortParam;
+      this.sortValue = this.sortMenuTarget.querySelector('[data-sortable-sort-param]').dataset.sortableSortParam;
     } else {
       this.resort();
+      this.refilter();
     }
   }
 
@@ -23,6 +24,7 @@ export default class extends Controller {
     // this.sorting = true;
     this.debounceTimeout = setTimeout(() => {
       this.resort();
+      this.refilter();
     }, 30);
   }
 
@@ -44,22 +46,43 @@ export default class extends Controller {
 
     this.sortValue = event.params['sort']
   }
-  
+
+  filter(event) {
+    event.preventDefault()
+
+    this.filterValue = event.params['filter']
+  }
+
   sortValueChanged() {
     this.resort();
-    this.updateMenu();
+    this.updateSortMenu();
   }
 
-  updateMenu() {
-    if (!this.hasMenuTarget) return;
+  filterValueChanged() {
+    this.refilter();
+    this.updateFilterMenu();
+  }
 
-    this.menuTarget.querySelector('.active')?.classList?.remove('active');
-    const activeSort =  this.menuTarget.querySelector('[data-sortable-sort-param="' + this.sortValue + '"]');
+  updateSortMenu() {
+    if (!this.hasSortMenuTarget) return;
+
+    this.sortMenuTarget.querySelector('.active')?.classList?.remove('active');
+    const activeSort =  this.sortMenuTarget.querySelector('[data-sortable-sort-param="' + this.sortValue + '"]');
 
     activeSort?.classList?.add('active');
-    this.menuTarget.querySelector('.dropdown-toggle').textContent = activeSort?.dataset?.sortableLabelParam || 'Sort';
+    this.sortMenuTarget.querySelector('.dropdown-toggle').textContent = activeSort?.dataset?.sortableLabelParam || 'Sort';
   }
-  
+
+  updateFilterMenu() {
+    if (!this.hasFilterMenuTarget) return;
+
+    this.filterMenuTarget.querySelector('.active')?.classList?.remove('active');
+    const activeFilter =  this.filterMenuTarget.querySelector('[data-sortable-filter-param="' + this.filterValue + '"]');
+
+    activeFilter?.classList?.add('active');
+    this.filterMenuTarget.querySelector('.dropdown-toggle').textContent = activeFilter?.dataset?.sortableLabelParam || 'All requests';
+  }
+
   resort() {
     if (!this.sortValue || !this.hasListTarget) return;
 
@@ -67,6 +90,16 @@ export default class extends Controller {
 
     this.subgroupTargets.forEach(subgroup => {
       this.resortChildren(subgroup, this.sortValue + 'SortValue');
+    });
+  }
+
+  refilter() {
+    if (!this.hasListTarget) return;
+
+    Array.from(this.listTarget.children).forEach(item => {
+      const itemFilterValue = item.dataset.filterValue;
+
+      item.hidden = (this.filterValue == '' || this.filterValue == itemFilterValue) ? false : true;
     });
   }
 

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -186,8 +186,23 @@ module Aeon
       reference_number || transaction_number
     end
 
-    def sort_key
+    def default_sort_key
       [call_number || '', pad_digits_for_sorting(item_volume || ''), id || ''].join('___')
+    end
+
+    def sort_key(key = nil) # rubocop:disable Metrics/AbcSize
+      sort_key = case key
+                 when :title
+                   [title, default_sort_key]
+                 when :date
+                   [(transaction_date || 100.years.from_now).strftime('%FT%T'), title, default_sort_key]
+                 when :default
+                   [(appointment&.start_time || 100.years.from_now).strftime('%FT%T'), title, default_sort_key]
+                 else
+                   [default_sort_key]
+                 end
+
+      sort_key.join('---')
     end
 
     def pad_digits_for_sorting(str)

--- a/app/models/aeon/request_finders.rb
+++ b/app/models/aeon/request_finders.rb
@@ -64,7 +64,7 @@ module Aeon
     # different timestamp accessor (e.g. `&:transaction_date`).
     def newest_first(&date_block)
       date_block ||= :creation_date.to_proc
-      self.class.new(requests.sort_by { |r| [-date_block.call(r).change(sec: 0).to_i, r.title.to_s, r.sort_key] })
+      self.class.new(requests.sort_by { |r| [-date_block.call(r).change(sec: 0).to_i, r.title.to_s, r.default_sort_key] })
     end
 
     def saved_for_later

--- a/app/models/aeon/request_grouping.rb
+++ b/app/models/aeon/request_grouping.rb
@@ -10,7 +10,7 @@ module Aeon
     delegate :each, to: :requests
 
     delegate :submitted?, :base_callnumber, :call_number, :date, :digital?, :activity?,
-             :document_type, :ead_number, :multi_item_selector?, :title, :group_key, :status, to: :first
+             :document_type, :ead_number, :multi_item_selector?, :title, :group_key, :sort_key, :status, to: :first
 
     def self.from_requests(requests)
       requests.group_by(&:group_key).values.map { |group| new(group) }

--- a/app/models/concerns/folio/folio_record.rb
+++ b/app/models/concerns/folio/folio_record.rb
@@ -29,6 +29,18 @@ module Folio
       item.dig('effectiveCallNumberComponents', 'callNumber')
     end
 
+    def full_call_number
+      [call_number, volume, enumeration].compact.join(' ')
+    end
+
+    def volume
+      item['volume']
+    end
+
+    def enumeration
+      item['enumeration']
+    end
+
     def shelf_key
       item['effectiveShelvingOrder']
     end

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -99,11 +99,11 @@ module Folio
     def sort_key(key)
       sort_key = case key
                  when :date
-                   [*date_sort_key, title, author, shelf_key]
+                   [placed_date&.strftime('%FT%T'), title, author, shelf_key]
                  when :title
                    [title, author, shelf_key]
-                 when :date_modified
-                   [-1 * placed_date.to_i, title, author, shelf_key]
+                 when :default
+                   [*date_sort_key, title, author, shelf_key]
                  end
 
       sort_key.join('---')
@@ -111,8 +111,7 @@ module Folio
 
     def date_sort_key
       [
-        (expiration_date || END_OF_DAYS).strftime('%FT%T'),
-        (fill_by_date || END_OF_DAYS).strftime('%FT%T')
+        (expiration_date || fill_by_date || END_OF_DAYS).strftime('%FT%T')
       ]
     end
 

--- a/app/models/illiad_requests.rb
+++ b/app/models/illiad_requests.rb
@@ -64,11 +64,11 @@ class IlliadRequests
     def sort_key(key)
       sort_key = case key
                  when :date
-                   [*date_sort_key, title, author, call_number]
+                   [placed_date.strftime('%FT%T'), title, author, call_number]
                  when :title
                    [title, author, call_number]
-                 when :date_modified
-                   [-1 * placed_date.to_i, title, author, call_number]
+                 when :default
+                   [date_sort_key, title, author, call_number]
                  end
       sort_key.join('---')
     end

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -340,6 +340,8 @@ class FolioGraphqlClient
                                         effectiveCallNumberComponents {
                                           callNumber
                                         }
+                                        enumeration
+                                        volume
                                         permanentLocation {
                                           code
                                         }

--- a/app/views/aeon_requests/async.html.erb
+++ b/app/views/aeon_requests/async.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag :aeon_requests do %>
+  <turbo-stream action="append" target="requests">
+    <template>
+      <%= render Aeon::RequestGroupComponent.with_collection(@aeon_request_groups, element: 'li') %>
+    </template>
+  </turbo-stream>
+<% end %>

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap row-gap-2">
       <h1 class="mb-0">Borrowed (checked out) items</h1>
       <div class="d-flex gap-2 align-items-center">
-        <div class="dropdown" data-sortable-target="menu">
+        <div class="dropdown" data-sortable-target="sortMenu">
           <button class="btn btn-outline-primary btn-sm dropdown-toggle" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Sort (Due date)
           </button>

--- a/app/views/folio_requests/async.html.erb
+++ b/app/views/folio_requests/async.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag :folio_requests do %>
+  <turbo-stream action="append" target="requests">
+    <template>
+      <%= render Folio::RequestComponent.with_collection(@requests, patron: patron_or_group) %>
+    </template>
+  </turbo-stream>
+<% end %>

--- a/app/views/folio_requests/index.html.erb
+++ b/app/views/folio_requests/index.html.erb
@@ -2,7 +2,7 @@
   <div class="d-flex align-items-center justify-content-between mb-4">
     <h1 class="mb-0">Requests</h1>
     <% if @requests.any? %>
-    <div class="dropdown" data-sortable-target="menu">
+    <div class="dropdown" data-sortable-target="sortMenu">
       <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Sort (Not needed after)
       </button>

--- a/app/views/folio_requests/index.html.erb
+++ b/app/views/folio_requests/index.html.erb
@@ -1,4 +1,4 @@
-<div id="requests" class="page-section col-lg-9" data-controller="sortable google-cover-image" data-sortable-sort-value="date">
+<div id="requests" class="page-section col-lg-9" data-controller="sortable google-cover-image" data-sortable-sort-value="default">
   <div class="d-flex align-items-center justify-content-between mb-4">
     <h1 class="mb-0">Requests</h1>
     <% if @requests.any? %>
@@ -8,8 +8,8 @@
       </button>
 
       <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date_modified" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
+        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="default" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
         <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
       </ul>
     </div>

--- a/app/views/ill_requests/async.html.erb
+++ b/app/views/ill_requests/async.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag :ill_requests do %>
+  <turbo-stream action="append" target="requests">
+    <template>
+      <%= render Folio::IllRequestComponent.with_collection(@requests, patron: patron_or_group) %>
+    </template>
+  </turbo-stream>
+<% end %>

--- a/app/views/ill_requests/index.html.erb
+++ b/app/views/ill_requests/index.html.erb
@@ -2,7 +2,7 @@
   <div class="d-flex justify-content-between">
     <h1>Requests</h1>
     <% if @requests.any? %>
-    <div class="dropdown" data-sortable-target="menu">
+    <div class="dropdown" data-sortable-target="sortMenu">
       <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Sort (Not needed after)
       </button>

--- a/app/views/ill_requests/index.html.erb
+++ b/app/views/ill_requests/index.html.erb
@@ -8,8 +8,8 @@
       </button>
 
       <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date_modified" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
+        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="default" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
         <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
       </ul>
     </div>

--- a/app/views/layouts/application_redesign.html.erb
+++ b/app/views/layouts/application_redesign.html.erb
@@ -52,6 +52,7 @@
               Requests
             </button>
             <ul class="dropdown-menu">
+              <li><%= link_to 'Submitted requests (unified)', unified_requests_url, class: 'dropdown-item' %></li>
               <% if current_user.patron.present? %>
               <li><%= link_to 'FOLIO requests', folio_requests_url, class: 'dropdown-item' %></li>
               <li><%= link_to 'ILL requests', ill_requests_url, class: 'dropdown-item' %></li>

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -2,7 +2,7 @@
   <div id="payments" class="page-section" data-controller="sortable" data-sortable-sort-value="date">
     <% if @payments.any? %>
       <div class="d-flex justify-content-end">
-        <div class="dropdown" data-sortable-target="menu">
+        <div class="dropdown" data-sortable-target="sortMenu">
           <button class="btn btn-outline-primary mb-2 dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Sort (Date paid)
           </button>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -2,16 +2,31 @@
   <div class="d-flex justify-content-between">
     <h1>Submitted requests</h1>
 
-    <div class="dropdown" data-sortable-target="menu">
-      <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Default sort
-      </button>
+    <div class="d-flex gap-2">
+      <div class="dropdown" data-sortable-target="sortMenu">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownSortMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Default sort
+        </button>
 
-      <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="default" data-sortable-label-param="Default sort">default</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort by date modified">date modified</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort by title">title</button></li>
-      </ul>
+        <ul class="dropdown-menu" aria-labelledby="dropdownSortMenuLink">
+          <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="default" data-sortable-label-param="Default sort">default</button></li>
+          <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort by date modified">date modified</button></li>
+          <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort by title">title</button></li>
+        </ul>
+      </div>
+
+      <div class="dropdown" data-sortable-target="filterMenu">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownFilterMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        All requests
+        </button>
+
+        <ul class="dropdown-menu" aria-labelledby="dropdownFilterMenuLink">
+          <li><button class="dropdown-item active" data-action="click->sortable#filter" data-sortable-label-param="All requests">All requests</button></li>
+          <li><button class="dropdown-item" data-action="click->sortable#filter" data-sortable-filter-param="digitization" data-sortable-label-param="Digitization">Digitization</button></li>
+          <li><button class="dropdown-item" data-action="click->sortable#filter" data-sortable-filter-param="pickup" data-sortable-label-param="Pickup">Pickup</button></li>
+          <li><button class="dropdown-item" data-action="click->sortable#filter" data-sortable-filter-param="reading room" data-sortable-label-param="Reading room use">Reading room use</button></li>
+        </ul>
+      </div>
     </div>
   </div>
 

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,5 +1,5 @@
 <div class="page-section col-9" data-controller="sortable google-cover-image" data-sortable-sort-value="default">
-  <div class="d-flex justify-content-between">
+  <div class="d-flex justify-content-between mb-4">
     <h1>Submitted requests</h1>
 
     <div class="d-flex gap-2">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,4 +1,4 @@
-<div class="page-section" data-controller="sortable google-cover-image" data-sortable-sort-value="date">
+<div class="page-section col-9" data-controller="sortable google-cover-image" data-sortable-sort-value="date">
   <div class="d-flex justify-content-between">
     <h1>Submitted requests</h1>
 

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -20,9 +20,53 @@
   <ul id="requests" class="requests p-0" data-sortable-target="list observe" aria-live="polite">
   </ul>
 
-  <%= turbo_frame_tag :folio_requests, src: folio_requests_path(async: true) %>
-  <%= turbo_frame_tag :aeon_requests, src: aeon_requests_path(async: true, kind: 'submitted') unless patron_or_group.is_a? Folio::ProxyGroup %>
-  <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) unless patron_or_group.is_a? Folio::ProxyGroup %>
+  <%= turbo_frame_tag :folio_requests, src: folio_requests_path(async: true) do %>
+    <%= render CardComponent.new(element: 'div', classes: 'request placeholder-glow', aria: { hidden: true }) do |c| %>
+      <% c.with_title do %>
+        <div class="col-6">
+          <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">
+            <%= render PillComponent.new(classes: %w[bg-lagunita-dark text-white placeholder]).with_content('Pickup') %>
+          </div>
+
+          <div class="placeholder w-100 h2"></div>
+          <div class="placeholder w-100"></div>
+        </div>
+      <% end %>
+
+      <% c.with_body do %>
+        <div class="bg-white px-3 py-2 d-flex column-gap-4 row-gap-2 justify-content-between align-items-start flex-wrap flex-md-nowrap">
+          <div class="placeholder col-4"></div>
+          <div class="col-5"></div>
+          <div class="placeholder col-1"></div>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= turbo_frame_tag :aeon_requests, src: aeon_requests_path(async: true, kind: 'submitted') do %>
+    <%= render CardComponent.new(element: 'div', classes: 'request placeholder-glow', aria: { hidden: true }) do |c| %>
+      <% c.with_title do %>
+        <div class="col-6">
+          <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">
+            <%= render PillComponent.new(classes: %w[bg-lagunita-dark text-white placeholder]).with_content('Reading room use') %>
+          </div>
+
+          <div class="placeholder w-100 h2"></div>
+          <div class="placeholder w-100"></div>
+        </div>
+      <% end %>
+
+      <% c.with_body do %>
+        <div class="bg-white px-3 py-2 d-flex column-gap-4 row-gap-2 justify-content-between align-items-start flex-wrap flex-md-nowrap">
+          <div class="placeholder col-4"></div>
+          <div class="col-5"></div>
+          <div class="placeholder col-1"></div>
+        </div>
+      <% end %>
+    <% end %>
+  <% end unless patron_or_group.is_a? Folio::ProxyGroup %>
+
+  <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) %>
 </div>
 
 <div class="page-section">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -21,8 +21,8 @@
   </ul>
 
   <%= turbo_frame_tag :folio_requests, src: folio_requests_path(async: true) %>
-  <%= turbo_frame_tag :aeon_requests, src: aeon_requests_path(async: true, kind: 'submitted') %>
-  <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) %>
+  <%= turbo_frame_tag :aeon_requests, src: aeon_requests_path(async: true, kind: 'submitted') unless patron_or_group.is_a? Folio::ProxyGroup %>
+  <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) unless patron_or_group.is_a? Folio::ProxyGroup %>
 </div>
 
 <div class="page-section">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,0 +1,37 @@
+<div class="page-section" data-controller="sortable google-cover-image" data-sortable-sort-value="date">
+  <div class="d-flex justify-content-between">
+    <h1>Submitted requests</h1>
+
+    <div class="dropdown" data-sortable-target="menu">
+      <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Sort (Not needed after)
+      </button>
+
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="library" data-sortable-label-param="Sort (Deliver to)">Deliver to</button></li>
+        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="author" data-sortable-label-param="Sort (Author)">Author name</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="callNumber" data-sortable-label-param="Sort (Call number)">Call number</button></li>
+      </ul>
+    </div>
+  </div>
+
+  <ul id="requests" class="requests p-0" data-sortable-target="list observe" aria-live="polite">
+  </ul>
+
+  <%= turbo_frame_tag :folio_requests, src: folio_requests_path(async: true) %>
+  <%= turbo_frame_tag :aeon_requests, src: aeon_requests_path(async: true, kind: 'submitted') %>
+  <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) %>
+</div>
+
+<div class="page-section">
+  <h2>If your request isn't listed</h2>
+  <ul>
+    <li>Requests for material from Special Collections &amp; University Archives, the David Rumsey Map Center, the Archive of Recorded Sound and East Asia Library Special Collections are listed in <%= link_to 'https://stanford.aeon.atlas-sys.com/logon/', target: '_blank' do %>
+      <%= sul_icon :'sharp-open_in_new-24px' %> Aeon.
+    <% end %>
+    </li>
+    <li>Requests requiring approval are not listed here until they have been approved &mdash; typically 1-3 days before your scheduled visit.</li>
+  </ul>
+</div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,18 +1,16 @@
-<div class="page-section col-9" data-controller="sortable google-cover-image" data-sortable-sort-value="date">
+<div class="page-section col-9" data-controller="sortable google-cover-image" data-sortable-sort-value="default">
   <div class="d-flex justify-content-between">
     <h1>Submitted requests</h1>
 
     <div class="dropdown" data-sortable-target="menu">
       <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Sort (Not needed after)
+        Default sort
       </button>
 
       <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="library" data-sortable-label-param="Sort (Deliver to)">Deliver to</button></li>
-        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="author" data-sortable-label-param="Sort (Author)">Author name</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="callNumber" data-sortable-label-param="Sort (Call number)">Call number</button></li>
+        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="default" data-sortable-label-param="Default sort">default</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort by date modified">date modified</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort by title">title</button></li>
       </ul>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
 
   # requests#new is a legacy route for redirecting old-style requests to the new patron_requests
   get 'requests/new', to: 'requests#new', as: :new_request
+  get 'requests/unified', to: 'requests#index', as: :unified_requests
   resources :folio_requests, except: [:new, :create], path: 'requests'
   resources :ill_requests, only: [:index]
 

--- a/spec/component_previews/sortable_component_preview/default.html.erb
+++ b/spec/component_previews/sortable_component_preview/default.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="sortable">
-  <div class="btn-group" data-sortable-target="menu">
+  <div class="btn-group" data-sortable-target="sortMenu">
     <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
       Sort by ...
     </button>

--- a/spec/controllers/concerns/aeon_sortable_spec.rb
+++ b/spec/controllers/concerns/aeon_sortable_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe AeonSortable do
   let(:request_b_digitial) do
     build(:aeon_request, :digitized,
           item_title: 'Bananas',
-          creation_date: now - 2.days,
-          transaction_date: now - 1.day)
+          creation_date: now - 5.days,
+          transaction_date: now - 4.days)
   end
 
   let(:request_c_with_appointment) do
@@ -44,12 +44,12 @@ RSpec.describe AeonSortable do
   end
 
   describe '#sort_aeon_requests' do
-    context 'with date_modified sort (default)' do
+    context 'with default sort (default)' do
       let(:sort_param) { nil }
 
       it 'sorts by transaction_date descending' do
         result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Bananas Carrots Apples]
+        expect(result.map(&:title)).to eq %w[Apples Carrots Bananas]
       end
     end
 
@@ -62,21 +62,21 @@ RSpec.describe AeonSortable do
       end
     end
 
-    context 'with appointment_time sort' do
-      let(:sort_param) { 'appointment_time' }
+    context 'with date sort' do
+      let(:sort_param) { 'date' }
 
-      it 'sorts by appointment start_time, requests without appointments appearing last' do
+      it 'sorts by request created/modified time' do
         result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Apples Carrots Bananas]
+        expect(result.map(&:title)).to eq %w[Bananas Apples Carrots]
       end
     end
 
     context 'with an invalid sort param' do
       let(:sort_param) { 'invalid' }
 
-      it 'falls back to date_modified sort' do
+      it 'falls back to default sort' do
         result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Bananas Carrots Apples]
+        expect(result.map(&:title)).to eq %w[Apples Carrots Bananas]
       end
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe AeonSortable do
       let(:sort_param) { 'invalid' }
 
       it 'returns the default sort' do
-        expect(controller.send(:current_aeon_sort)).to eq 'date_modified'
+        expect(controller.send(:current_aeon_sort)).to eq 'default'
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe AeonSortable do
       let(:sort_param) { nil }
 
       it 'returns the default sort' do
-        expect(controller.send(:current_aeon_sort)).to eq 'date_modified'
+        expect(controller.send(:current_aeon_sort)).to eq 'default'
       end
     end
   end
@@ -128,7 +128,7 @@ RSpec.describe AeonSortable do
 
       it 'includes all sort options' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
-          .to eq %w[title date_modified appointment_time]
+          .to eq %w[title date default]
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe AeonSortable do
 
       it 'excludes request_type and appointment_time' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
-          .to eq %w[title date_modified]
+          .to eq %w[title date default]
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe AeonSortable do
 
       it 'excludes request_type but includes appointment_time' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
-          .to eq %w[title date_modified appointment_time]
+          .to eq %w[title date default]
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe AeonSortable do
       let(:filter_param) { 'digitization' }
 
       it 'falls back to default sort' do
-        expect(filterable_controller.send(:current_aeon_sort)).to eq 'date_modified'
+        expect(filterable_controller.send(:current_aeon_sort)).to eq 'default'
       end
     end
   end

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Checkout Page' do
       expect(page).to have_css('.dropdown-toggle', text: 'Sort (Due date)')
       click_on 'Sort (Due date)'
 
-      within '[data-sortable-target="menu"] .dropdown-menu' do
+      within '[data-sortable-target="sortMenu"] .dropdown-menu' do
         click_on 'Title'
       end
 

--- a/spec/features/payments_spec.rb
+++ b/spec/features/payments_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Payments History' do
         expect(page).to have_css('.dropdown-toggle', text: 'Sort (Date paid)')
         click_on 'Sort (Date paid)'
 
-        within '[data-sortable-target="menu"] .dropdown-menu' do
+        within '[data-sortable-target="sortMenu"] .dropdown-menu' do
           click_on 'Reason'
         end
         expect(page).to have_css('.dropdown-toggle', text: 'Sort (Reason)')

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Request Page' do
       expect(page).to have_css('.dropdown-toggle', text: 'Sort (Not needed after)')
       click_on 'Sort (Not needed after)'
 
-      within '[data-sortable-target="menu"] .dropdown-menu' do
+      within '[data-sortable-target="sortMenu"] .dropdown-menu' do
         click_on 'Title'
       end
 


### PR DESCRIPTION
TODO:
- [x] resort the list as things load.
- [x] resort subgroups as things load too..
- [x] handle filtering client-side
- [x] progress / spinner indicators
- [x] how do we handle sort options that vary by source?
- [x] decide if this is even a good idea

Future work presumably includes:
- [ ] figure out what to call the default sort (hold shelf expiration + appointment time)
- [ ] expand this to cancelled/completed requests (if we determine we can/want to show that FOLIO data)
- [x] Map ILLiad data better (including differentiating ILL vs scans)
- [ ] ???