### PR TITLE
Extract Aeon activity and delivery logic into finder classes

### DIFF
--- a/app/components/aeon/request_fulfillment_component.rb
+++ b/app/components/aeon/request_fulfillment_component.rb
@@ -6,8 +6,8 @@ module Aeon
   class RequestFulfillmentComponent < ViewComponent::Base
     attr_reader :request
 
-    delegate :appointment?, :cancelled_by_staff?, :digital?, :saved_for_later?, :scan_delivered?, :submitted?,
-             :photoduplication_date, :transaction_date, to: :request
+    delegate :appointment?, :cancelled_by_staff?, :delivered_date, :digital?, :saved_for_later?,
+             :scan_delivered?, :submitted?, to: :request
 
     def initialize(request:)
       @request = request
@@ -17,10 +17,6 @@ module Aeon
       return false if saved_for_later?
 
       mode.present?
-    end
-
-    def delivered_date
-      photoduplication_date.presence || transaction_date
     end
 
     def mode

--- a/app/controllers/aeon_activities_controller.rb
+++ b/app/controllers/aeon_activities_controller.rb
@@ -12,14 +12,14 @@ class AeonActivitiesController < ApplicationController
   def index; end
 
   def active
-    @activities = all_activities.select(&:active?)
+    @activities = all_activities.active
     @activity_types = @activities.map(&:activity_type)
     filter
     sort_results
   end
 
   def past
-    @activities = all_activities.reject(&:active?)
+    @activities = all_activities.past
     @activity_types = @activities.map(&:activity_type)
     filter
     sort_results

--- a/app/controllers/concerns/aeon_sortable.rb
+++ b/app/controllers/concerns/aeon_sortable.rb
@@ -16,11 +16,11 @@ module AeonSortable
     },
     'date_added' => {
       label: 'Sort by date added',
-      sort: ->(requests) { requests.sort_by { |r| [-r.creation_date.change(sec: 0).to_i, r.title.to_s, r.sort_key] } }
+      sort: ->(requests) { requests.newest_first }
     },
     'date_modified' => {
       label: 'Sort by date modified',
-      sort: ->(requests) { requests.sort_by { |r| [-r.transaction_date.change(sec: 0).to_i, r.title.to_s, r.sort_key] } }
+      sort: ->(requests) { requests.newest_first(&:transaction_date) }
     },
     'appointment_time' => {
       label: 'Sort by appointment time',

--- a/app/models/aeon/activity_finders.rb
+++ b/app/models/aeon/activity_finders.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Wraps a group of Aeon activities with finder methods
+  class ActivityFinders
+    include Enumerable
+    include ScheduledFinders
+
+    attr_reader :activities
+
+    delegate :each, :-, :+, :present?, :blank?, :length, :count, :to_ary, to: :activities
+
+    def initialize(activities)
+      @activities = activities
+    end
+
+    def find(id_or_ids = nil, &)
+      return super(&) if block_given?
+
+      if id_or_ids.is_a?(Array)
+        ids = id_or_ids.map(&:to_i)
+        self.class.new(activities.select { |activity| ids.include?(activity.id) })
+      else
+        id = id_or_ids.to_i
+        activities.find { |activity| activity.id == id }
+      end
+    end
+
+    def select(&)
+      self.class.new(activities.select(&))
+    end
+
+    def reject(&)
+      self.class.new(activities.reject(&))
+    end
+
+    def active
+      self.class.new(activities.select(&:active?))
+    end
+
+    def past
+      self.class.new(activities.reject(&:active?))
+    end
+  end
+end

--- a/app/models/aeon/appointment_finders.rb
+++ b/app/models/aeon/appointment_finders.rb
@@ -4,6 +4,7 @@ module Aeon
   # Wraps a group of Aeon appointments with finder methods
   class AppointmentFinders
     include Enumerable
+    include ScheduledFinders
 
     attr_reader :appointments
 

--- a/app/models/aeon/null_user.rb
+++ b/app/models/aeon/null_user.rb
@@ -23,6 +23,10 @@ module Aeon
       @appointments ||= Aeon::AppointmentFinders.new([])
     end
 
+    def activities
+      @activities ||= Aeon::ActivityFinders.new([])
+    end
+
     def present? = false
 
     def persisted? = false

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -112,6 +112,16 @@ module Aeon
       digital? && in_completed_queue?
     end
 
+    def delivered_date
+      return unless scan_delivered?
+
+      photoduplication_date.presence || transaction_date
+    end
+
+    def delivered_recently?(within: 3.days)
+      delivered_date.present? && delivered_date >= within.ago
+    end
+
     def cancelled?
       (digital? && photoduplication_queue&.cancelled?) || transaction_queue&.cancelled?
     end

--- a/app/models/aeon/request_finders.rb
+++ b/app/models/aeon/request_finders.rb
@@ -59,6 +59,14 @@ module Aeon
       self.class.new(requests.sort_by(&))
     end
 
+    # Sorts requests newest-first by `creation_date`, rounded to the minute,
+    # with title and sort_key as tiebreakers. Pass a block to sort by a
+    # different timestamp accessor (e.g. `&:transaction_date`).
+    def newest_first(&date_block)
+      date_block ||= :creation_date.to_proc
+      self.class.new(requests.sort_by { |r| [-date_block.call(r).change(sec: 0).to_i, r.title.to_s, r.sort_key] })
+    end
+
     def saved_for_later
       self.class.new requests.select(&:saved_for_later?)
     end
@@ -77,6 +85,10 @@ module Aeon
 
     def digitization
       self.class.new requests.select(&:digital?)
+    end
+
+    def recently_delivered(within: 3.days)
+      self.class.new(requests.select { |r| r.delivered_recently?(within: within) })
     end
 
     def reading_room

--- a/app/models/aeon/scheduled_finders.rb
+++ b/app/models/aeon/scheduled_finders.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Shared finders for collections of time-scheduled items (each item must
+  # respond to `start_time`). Includers must be Enumerable and accept an
+  # array of items in their initializer.
+  module ScheduledFinders
+    # Upcoming items that start within `within`, sorted by start time; if none
+    # fall in that range, falls back to the next `fallback` upcoming items.
+    def upcoming(within:, fallback:)
+      now = Time.zone.now
+      future = select { |item| item.start_time && item.start_time >= now }.sort_by(&:start_time)
+      cutoff = within.from_now
+      in_window = future.take_while { |item| item.start_time <= cutoff }
+      in_window.any? ? in_window : future.first(fallback)
+    end
+  end
+end

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -42,7 +42,8 @@ module Aeon
     end
 
     def activities # rubocop:disable Metrics/AbcSize
-      @activities ||= self.class.aeon_client.activities_for(username:).sort_by(&:sort_key).tap do |activities|
+      @activities ||= begin
+        activities = self.class.aeon_client.activities_for(username:).sort_by(&:sort_key)
         # use the same user instances across activities to preserve e.g. memoized requests
         users_cache = activities.flat_map(&:users).index_by(&:username).merge(username => self)
 
@@ -50,6 +51,8 @@ module Aeon
           users = users_cache.values_at(*activity.users.map(&:username)).compact
           activity.users = users
         end
+
+        Aeon::ActivityFinders.new(activities)
       end
     end
 

--- a/spec/controllers/concerns/aeon_sortable_spec.rb
+++ b/spec/controllers/concerns/aeon_sortable_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe AeonSortable do
           appointment: build(:aeon_appointment, start_time: now + 3.days))
   end
 
-  let(:requests) { [request_c_with_appointment, request_a_with_appointment, request_b_digitial] }
+  let(:requests) do
+    Aeon::RequestFinders.new([request_c_with_appointment, request_a_with_appointment, request_b_digitial])
+  end
 
   before do
     allow(controller).to receive(:params).and_return(ActionController::Parameters.new(sort: sort_param))

--- a/spec/models/aeon/activity_finders_spec.rb
+++ b/spec/models/aeon/activity_finders_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::ActivityFinders do
+  let(:now) { Time.zone.now }
+
+  let(:active_class_visit) { build(:aeon_activity, id: 1, active: true, status: 'Pending') }
+  let(:completed_activity) { build(:aeon_activity, id: 2, active: true, status: 'Completed') }
+  let(:inactive_activity) { build(:aeon_activity, id: 3, active: false, status: 'Pending') }
+
+  describe '#active' do
+    it 'returns only activities where active? is true' do
+      finders = described_class.new([active_class_visit, completed_activity, inactive_activity])
+
+      expect(finders.active.map(&:id)).to eq [1]
+    end
+
+    it 'returns an ActivityFinders instance' do
+      finders = described_class.new([active_class_visit])
+
+      expect(finders.active).to be_a(described_class)
+    end
+  end
+
+  describe '#past' do
+    it 'returns activities where active? is false' do
+      finders = described_class.new([active_class_visit, completed_activity, inactive_activity])
+
+      expect(finders.past.map(&:id)).to contain_exactly(2, 3)
+    end
+
+    it 'returns an ActivityFinders instance' do
+      finders = described_class.new([inactive_activity])
+
+      expect(finders.past).to be_a(described_class)
+    end
+  end
+
+  describe '#find' do
+    let(:finders) { described_class.new([active_class_visit, completed_activity, inactive_activity]) }
+
+    it 'returns a single activity when given an id' do
+      expect(finders.find(2)).to eq completed_activity
+    end
+
+    it 'coerces string ids' do
+      expect(finders.find('2')).to eq completed_activity
+    end
+
+    it 'returns a new ActivityFinders when given an array of ids' do
+      result = finders.find([1, 3])
+
+      expect(result).to be_a(described_class)
+      expect(result.map(&:id)).to contain_exactly(1, 3)
+    end
+
+    it 'falls back to Enumerable#find when a block is given' do
+      result = finders.find { |a| a.status == 'Completed' }
+
+      expect(result).to eq completed_activity
+    end
+  end
+
+  describe '#upcoming (via ScheduledFinders)' do
+    let(:past) { build(:aeon_activity, id: 10, start_time: now - 1.day) }
+    let(:soon) { build(:aeon_activity, id: 11, start_time: now + 2.hours) }
+    let(:tomorrow) { build(:aeon_activity, id: 12, start_time: now + 1.day) }
+    let(:far_future) { build(:aeon_activity, id: 13, start_time: now + 30.days) }
+    let(:no_start) { build(:aeon_activity, id: 14, start_time: nil) }
+
+    it 'returns future activities within the window sorted by start_time' do
+      finders = described_class.new([tomorrow, past, soon, far_future, no_start])
+
+      expect(finders.upcoming(within: 7.days, fallback: 1).map(&:id)).to eq [11, 12]
+    end
+
+    it 'excludes activities without a start_time' do
+      finders = described_class.new([no_start, soon])
+
+      expect(finders.upcoming(within: 7.days, fallback: 1).map(&:id)).to eq [11]
+    end
+
+    it 'falls back to the next N upcoming activities when nothing is in the window' do
+      finders = described_class.new([past, far_future, no_start])
+
+      expect(finders.upcoming(within: 7.days, fallback: 1).map(&:id)).to eq [13]
+    end
+
+    it 'returns an empty result when there are no future activities' do
+      finders = described_class.new([past, no_start])
+
+      expect(finders.upcoming(within: 7.days, fallback: 1)).to be_empty
+    end
+  end
+end

--- a/spec/models/aeon/request_finders_spec.rb
+++ b/spec/models/aeon/request_finders_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::RequestFinders do
+  before do
+    allow(Aeon::Queue).to receive(:find_by) do |id: nil, **_kwargs|
+      Aeon::Queue.from_dynamic(StubAeonClient::Queue.find_by(id: id).as_json) if id
+    end
+  end
+
+  let(:now) { Time.zone.now }
+
+  describe '#newest_first' do
+    let(:older) do
+      build(:aeon_request, item_title: 'Older',
+                           creation_date: now - 2.days,
+                           transaction_date: now - 1.day)
+    end
+    let(:newer) do
+      build(:aeon_request, item_title: 'Newer',
+                           creation_date: now - 1.day,
+                           transaction_date: now - 2.days)
+    end
+
+    it 'sorts by creation_date descending by default' do
+      finders = described_class.new([older, newer])
+
+      expect(finders.newest_first.map(&:title)).to eq %w[Newer Older]
+    end
+
+    it 'sorts by the given timestamp accessor when a block is provided' do
+      finders = described_class.new([older, newer])
+
+      expect(finders.newest_first(&:transaction_date).map(&:title)).to eq %w[Older Newer]
+    end
+
+    it 'breaks ties on creation_date using title, then sort_key' do
+      tied_time = now - 1.day
+      first_alpha = build(:aeon_request,
+                          transaction_number: 1, item_title: 'Apples',
+                          call_number: 'AAA', creation_date: tied_time)
+      second_alpha = build(:aeon_request,
+                           transaction_number: 2, item_title: 'Bananas',
+                           call_number: 'AAA', creation_date: tied_time)
+      same_title_higher_sort_key = build(:aeon_request,
+                                         transaction_number: 3, item_title: 'Apples',
+                                         call_number: 'ZZZ', creation_date: tied_time)
+
+      finders = described_class.new([second_alpha, same_title_higher_sort_key, first_alpha])
+
+      expect(finders.newest_first.map(&:transaction_number)).to eq [1, 3, 2]
+    end
+
+    it 'ignores sub-minute differences in the timestamp' do
+      a = build(:aeon_request, item_title: 'Apples',
+                               creation_date: now.change(sec: 5))
+      b = build(:aeon_request, item_title: 'Bananas',
+                               creation_date: now.change(sec: 55))
+
+      finders = described_class.new([b, a])
+
+      expect(finders.newest_first.map(&:title)).to eq %w[Apples Bananas]
+    end
+
+    it 'returns a RequestFinders instance' do
+      finders = described_class.new([older, newer])
+
+      expect(finders.newest_first).to be_a(described_class)
+    end
+  end
+
+  describe '#recently_delivered' do
+    let(:recently_delivered) do
+      build(:aeon_request, :digitized,
+            item_title: 'Recent',
+            transaction_status: 17, photoduplication_status: 23,
+            photoduplication_date: 1.day.ago)
+    end
+    let(:long_ago_delivered) do
+      build(:aeon_request, :digitized,
+            item_title: 'Stale',
+            transaction_status: 17, photoduplication_status: 23,
+            photoduplication_date: 10.days.ago)
+    end
+    let(:not_delivered) do
+      build(:aeon_request, item_title: 'Pending',
+                           shipping_option: nil,
+                           transaction_status: 8, photoduplication_status: nil)
+    end
+
+    it 'returns only requests delivered within the default 3-day window' do
+      finders = described_class.new([recently_delivered, long_ago_delivered, not_delivered])
+
+      expect(finders.recently_delivered.map(&:title)).to eq %w[Recent]
+    end
+
+    it 'respects a custom window' do
+      finders = described_class.new([recently_delivered, long_ago_delivered, not_delivered])
+
+      expect(finders.recently_delivered(within: 30.days).map(&:title))
+        .to contain_exactly('Recent', 'Stale')
+    end
+
+    it 'returns a RequestFinders instance' do
+      finders = described_class.new([recently_delivered])
+
+      expect(finders.recently_delivered).to be_a(described_class)
+    end
+  end
+end

--- a/spec/models/aeon/request_spec.rb
+++ b/spec/models/aeon/request_spec.rb
@@ -157,4 +157,56 @@ RSpec.describe Aeon::Request do
       expect(request).not_to be_scan_delivered
     end
   end
+
+  describe '#delivered_date' do
+    it 'returns nil when the request is not scan delivered' do
+      request = build(:aeon_request, shipping_option: nil, transaction_status: 8, photoduplication_status: nil)
+      expect(request.delivered_date).to be_nil
+    end
+
+    it 'returns the photoduplication date when present' do
+      photoduplication_date = Time.zone.parse('2024-03-12T12:44:01.23Z')
+      request = build(:aeon_request, :digitized,
+                      transaction_status: 17, photoduplication_status: 23,
+                      photoduplication_date: photoduplication_date)
+      expect(request.delivered_date).to eq photoduplication_date
+    end
+
+    it 'falls back to the transaction date when photoduplication date is blank' do
+      transaction_date = Time.zone.parse('2024-03-11T23:35:01.23Z')
+      request = build(:aeon_request, :digitized,
+                      transaction_status: 17, photoduplication_status: 23,
+                      photoduplication_date: nil, transaction_date: transaction_date)
+      expect(request.delivered_date).to eq transaction_date
+    end
+  end
+
+  describe '#delivered_recently?' do
+    it 'returns false when the request has no delivered date' do
+      request = build(:aeon_request, shipping_option: nil, transaction_status: 8, photoduplication_status: nil)
+      expect(request).not_to be_delivered_recently
+    end
+
+    it 'returns true when delivered inside the default window' do
+      request = build(:aeon_request, :digitized,
+                      transaction_status: 17, photoduplication_status: 23,
+                      photoduplication_date: 1.day.ago)
+      expect(request).to be_delivered_recently
+    end
+
+    it 'returns false when delivered outside the default window' do
+      request = build(:aeon_request, :digitized,
+                      transaction_status: 17, photoduplication_status: 23,
+                      photoduplication_date: 10.days.ago)
+      expect(request).not_to be_delivered_recently
+    end
+
+    it 'respects a custom window' do
+      request = build(:aeon_request, :digitized,
+                      transaction_status: 17, photoduplication_status: 23,
+                      photoduplication_date: 5.days.ago)
+      expect(request.delivered_recently?(within: 7.days)).to be true
+      expect(request.delivered_recently?(within: 3.days)).to be false
+    end
+  end
 end


### PR DESCRIPTION
In support of the home page designs in https://github.com/sul-dlss/sul-requests/issues/2854, split off from https://github.com/sul-dlss/sul-requests/pull/3871.

We have some logic that could be pulled into the models and some where it seems we could centralize in the Finders, which makes it accessible to the new home page without requiring duplication.
