### PR TITLE
Pull up patron + aeon user arguments so the dashboard works for proxy group too

### DIFF
--- a/app/controllers/concerns/folio_controller.rb
+++ b/app/controllers/concerns/folio_controller.rb
@@ -17,12 +17,14 @@ module FolioController
   end
 
   def current_proxy_group
+    return @current_proxy_group if defined?(@current_proxy_group)
+
     return unless session[:proxyFor]
 
     sponsor = current_user.patron.sponsors.find { |s| s.id == session[:proxyFor] }
 
     return unless sponsor
 
-    sponsor.proxy_group.with_proxy(current_user.patron)
+    @current_proxy_group = sponsor.proxy_group.with_proxy(current_user.patron)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,7 +10,11 @@ class HomeController < ApplicationController
   before_action :authenticate_user!, only: [:show]
 
   def show
-    @dashboard = Home::Dashboard.new(current_user)
+    @dashboard = if patron_or_group.is_a? Folio::ProxyGroup
+                   Home::Dashboard.new(aeon: Aeon::NullUser.new, patron: patron_or_group)
+                 else
+                   Home::Dashboard.new(aeon: current_user.aeon, patron: patron_or_group)
+                 end
   end
 
   def authenticate_user!

--- a/app/models/home/dashboard.rb
+++ b/app/models/home/dashboard.rb
@@ -5,10 +5,11 @@ module Home
   class Dashboard
     DigitizationStatus = Data.define(:count, :label)
 
-    attr_reader :user
+    attr_reader :aeon, :patron
 
-    def initialize(user)
-      @user = user
+    def initialize(aeon:, patron:)
+      @aeon = aeon
+      @patron = patron
     end
 
     def checkouts
@@ -89,14 +90,6 @@ module Home
     end
 
     private
-
-    def patron
-      @patron ||= user.patron
-    end
-
-    def aeon
-      @aeon ||= user.aeon
-    end
 
     def preview(primary, fallback, limit: 3)
       primary.presence || fallback.first(limit)

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe 'Home Page' do
       expect(page).to have_link('Earth Sciences Library (Branner)', href: '/admin/SAL3-PAGE-MP')
     end
   end
+
+  context 'with the new layout' do
+    before do
+      allow(Settings.features).to receive(:requests_redesign).and_return(true)
+      login_as(current_user)
+    end
+
+    let(:user) { create(:sso_user) }
+    let(:current_user) { CurrentUser.new(username: user.sunetid, patron_key: user.patron_key, shibboleth: true, ldap_attributes: {}) }
+
+    it 'renders the cards' do
+      visit root_path
+
+      expect(page).to have_css('.card', count: 7)
+      expect(page).to have_css('.card', text: 'No pickup requests')
+      expect(page).to have_css('.card', text: 'No items on loan')
+    end
+  end
 end

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -77,4 +77,17 @@ RSpec.describe 'Proxy User' do
       expect(page).to have_no_text('A history of Persia')
     end
   end
+
+  context 'when on the home page' do
+    it 'displays the sponsor information' do
+      visit root_path
+
+      expect(page).to have_css('.card', text: '1 item currently loaned')
+
+      click_on 'Switch to proxy'
+      click_on 'Proxy for: Shea Sponsor'
+
+      expect(page).to have_css('.card', text: '2 due soon')
+    end
+  end
 end


### PR DESCRIPTION
`User` doesn't know we want the proxy group view, so we should pass in the aeon + folio contexts to the dashboard