### PR TITLE
add save for later functionality to cancelled items

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -723,6 +723,31 @@ summary .disclosure-icon::before {
   }
 }
 
+.cancelled.request.list-group-item {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "id"
+    "detail"
+    "actions"
+    "footer";
+
+  @media (min-width: 576px) {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "id          id"
+      "detail      actions"
+      "footer      footer";
+  }
+
+  @media (min-width: 992px) {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "id      actions"
+      "detail       detail"
+      "footer       footer";
+  }
+}
+
 .list-group:has(.request.list-group-item .request-fulfillment) .request.list-group-item {
   grid-template-columns: 1fr;
   grid-template-areas:
@@ -741,18 +766,24 @@ summary .disclosure-icon::before {
       "footer      footer";
   }
 
-  @media (min-width: 992px) {
-    grid-template-columns: 1fr 19.5rem 3rem;
-    grid-template-areas:
-      "id     fulfillment actions"
-      "detail detail      detail"
-      "footer footer      footer";
+  &:not(.cancelled) {
+    @media (min-width: 992px) {
+      grid-template-columns: 1fr 19.5rem 3rem;
+      grid-template-areas:
+        "id     fulfillment actions"
+        "detail detail      detail"
+        "footer footer      footer";
+    }
   }
-}
 
-.list-group:has(.request.list-group-item .request-fulfillment):has(.btn.resubmit) .request.list-group-item {
-  @media (min-width: 992px) {
-    grid-template-columns: 1fr 19.5rem 5.5rem;
+  &.cancelled {
+    @media (min-width: 992px) {
+      grid-template-columns: 1fr 19.5rem 8rem;
+      grid-template-areas:
+        "id     fulfillment actions"
+        "detail detail      detail"
+        "footer footer      footer";
+    }
   }
 }
 

--- a/app/components/aeon/request_actions_component.html.erb
+++ b/app/components/aeon/request_actions_component.html.erb
@@ -1,59 +1,57 @@
-    <div class="d-flex text-nowrap align-items-baseline align-self-start justify-content-xl-end">
-      <% if request.cancelled? %>
-        <form action="<%= resubmit_aeon_request_path(transaction_number) %>" method="PATCH">
-          <button type="submit" class="btn btn-link btn-sm su-underline resubmit" aria-label="Resubmit request"><i class="bi bi-arrow-clockwise"></i> Resubmit</button>
-        </form>
+<div class="d-flex text-nowrap align-items-baseline align-self-start justify-content-xl-end">
+  <% if include_bulk_actions? %>
+    <span>
+      <input type="checkbox" class="form-check-input" id="delete-bulk-<%= request.id %>"
+        data-action="change->request-bulk-delete#updateDeleteButton request-bulk-delete#updateSelectAll"
+        data-request-bulk-delete-target="select" data-id="<%= request.id %>">
+      <%= label_tag "delete-bulk-#{request.id}", 'Select', class: 'ms-1 me-3 small form-check-label fw-normal' %>
+    </span>
+  <% end %>
+
+  <% if helpers.can? :edit, request %>
+    <%= link_to edit_aeon_request_path(request), class: 'btn btn-link btn-sm su-underline p-0 me-sm-2', data: { action: 'modal#open' } do %>
+      <% if request.saved_for_later? || request.cancelled? %>
+        <% if request.digital? %>
+          <i class="bi bi-file-earmark-plus me-1 align-middle"></i> Add instructions
+        <% else %>
+          <i class="bi bi-calendar-plus me-1 align-middle"></i> Add appointment
+        <% end %>
+
       <% else %>
-        <% if include_bulk_actions? %>
-          <span>
-            <input type="checkbox" class="form-check-input" id="delete-bulk-<%= request.id %>"
-              data-action="change->request-bulk-delete#updateDeleteButton request-bulk-delete#updateSelectAll"
-              data-request-bulk-delete-target="select" data-id="<%= request.id %>">
-            <%= label_tag "delete-bulk-#{request.id}", 'Select', class: 'ms-1 me-3 small form-check-label fw-normal' %>
-          </span>
-        <% end %>
-
-        <% if helpers.can? :edit, request %>
-          <%= link_to edit_aeon_request_path(request), class: 'btn btn-link btn-sm su-underline p-0 me-sm-2', data: { action: 'modal#open' } do %>
-            <% if request.saved_for_later? && request.digital? %>
-              <i class="bi bi-file-earmark-plus me-1 align-middle"></i> Add instructions
-            <% elsif request.saved_for_later? && !request.digital? %>
-              <i class="bi bi-calendar-plus me-1 align-middle"></i> Add appointment
-            <% else %>
-              <i class="bi bi-pencil-fill me-1 align-middle"></i><span class="visually-hidden">Edit request</span>
-            <% end %>
-          <% end %>
-        <% end %>
-
-        <% if helpers.can? :destroy, request %>
-          <button class="btn btn-link su-underline p-0" data-bs-toggle="modal" data-bs-target="#delete-<%= transaction_number %>">
-            <i class="bi bi-trash align-middle"></i><span class="visually-hidden">Delete <%= title %> request</span>
-          </button>
-        <% end %>
+        <i class="bi bi-pencil-fill me-1 align-middle"></i><span class="visually-hidden">Edit request</span>
       <% end %>
-      <!-- Delete modal -->
-      <%= render ModalComponent.new(id: "delete-#{transaction_number}") do |component| %>
-        <% component.with_title.with_content('Delete request?') %>
-        <% component.with_body do %>
-          <div class="d-flex flex-column gap-3">
-            <div class="text-lagunita-dark"><%= request_type %></div>
-            <div class="d-flex flex-column gap-1">
-              <div class="text-wrap fw-semibold"><%= title %></div>
-              <% if request.base_callnumber.present? %>
-                <div>Call number: <%= request.base_callnumber %></div>
-              <% end %>
-              <%= render Aeon::RequestItemIdentifierComponent.new(request:, classes: ['fw-semibold', 'selected-item-title', 'px-1'], wrapper_tag: :div, wrapper_classes: ['text-wrap']) %>
-            </div>
-            <%= render AlertComponent.new(type: :info, classes: ['border-0', 'shadow-none', 'mb-0'], with_icon: false) do %>
-              <span class="fw-semibold text-wrap">This action cannot be undone.</span>
-            <% end %>
-          </div>
-        <% end %>
-        <% component.with_footer do %>
-          <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">No</button>
-          <%= form_with url: aeon_request_path(transaction_number), method: 'delete' do %>
-            <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Yes - Delete</button>
+    <% end %>
+  <% end %>
+
+  <% if helpers.can? :destroy, request %>
+    <button class="btn btn-link su-underline p-0" data-bs-toggle="modal" data-bs-target="#delete-<%= transaction_number %>">
+      <i class="bi bi-trash align-middle"></i><span class="visually-hidden">Delete <%= title %> request</span>
+    </button>
+  <% end %>
+
+  <!-- Delete modal -->
+  <%= render ModalComponent.new(id: "delete-#{transaction_number}") do |component| %>
+    <% component.with_title.with_content('Delete request?') %>
+    <% component.with_body do %>
+      <div class="d-flex flex-column gap-3">
+        <div class="text-lagunita-dark"><%= request_type %></div>
+        <div class="d-flex flex-column gap-1">
+          <div class="text-wrap fw-semibold"><%= title %></div>
+          <% if request.base_callnumber.present? %>
+            <div>Call number: <%= request.base_callnumber %></div>
           <% end %>
+          <%= render Aeon::RequestItemIdentifierComponent.new(request:, classes: ['fw-semibold', 'selected-item-title', 'px-1'], wrapper_tag: :div, wrapper_classes: ['text-wrap']) %>
+        </div>
+        <%= render AlertComponent.new(type: :info, classes: ['border-0', 'shadow-none', 'mb-0'], with_icon: false) do %>
+          <span class="fw-semibold text-wrap">This action cannot be undone.</span>
         <% end %>
+      </div>
+    <% end %>
+    <% component.with_footer do %>
+      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">No</button>
+      <%= form_with url: aeon_request_path(transaction_number), method: 'delete' do %>
+        <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Yes - Delete</button>
       <% end %>
-    </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/aeon/request_group_item_component.html.erb
+++ b/app/components/aeon/request_group_item_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.li id: dom_id(request), class: classes + ['request'], data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) } do %>
+<%= tag.li id: dom_id(request), class: classes + ['request', request.status], data: { 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) } do %>
     <div class="rgi-id d-flex align-items-center">
       <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
 

--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -20,16 +20,6 @@ class AeonRequestsController < ApplicationController
     render 'async' and return if params[:async]
   end
 
-  def resubmit
-    authorize! :update, @aeon_request
-
-    @updated_aeon_request = Aeon::UpdateRequestService.new(@aeon_request, { status: 'Submitted by User' }).call
-
-    respond_to do |format|
-      format.turbo_stream { update_turbo_stream }
-    end
-  end
-
   def save_for_later
     authorize! :update, @aeon_request
 

--- a/app/models/abilities/aeon_ability.rb
+++ b/app/models/abilities/aeon_ability.rb
@@ -21,6 +21,8 @@ class AeonAbility
     can :destroy, Aeon::Request do |request|
       owner?(aeon_user:, record: request) || member_of_request_activity?(aeon_user:, request:)
     end
+    cannot :destroy, Aeon::Request, &:cancelled?
+
     can :update, Aeon::Request do |request|
       (owner?(aeon_user:, record: request) || member_of_request_activity?(aeon_user:, request:)) &&
         (request.saved_for_later? || request.appointment&.editable? || request.cancelled?)

--- a/app/services/aeon/update_request_service.rb
+++ b/app/services/aeon/update_request_service.rb
@@ -39,7 +39,7 @@ module Aeon
     end
 
     def needs_set_to_submitted?
-      aeon_request.saved_for_later? && aeon_request.valid?
+      (aeon_request.saved_for_later? || aeon_request.cancelled?) && aeon_request.valid?
     end
 
     def needs_set_to_saved_for_later?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,6 @@ Rails.application.routes.draw do
     end
 
     member do
-      patch :resubmit
       post :save_for_later
     end
   end


### PR DESCRIPTION
closes #3900 

Different thing noticed here. Some things don't have volumes (see Stanford microform screenshots) but we still have background and space for it. Obviously separate ticket

<img width="761" height="950" alt="Screenshot 2026-06-25 at 4 33 03 PM" src="https://github.com/user-attachments/assets/7a958ab1-cc4a-4749-b157-467c9175d384" />
<img width="709" height="284" alt="Screenshot 2026-06-25 at 4 32 54 PM" src="https://github.com/user-attachments/assets/dbb065da-3100-41ef-a56f-ed898616f0f3" />
<img width="764" height="916" alt="Screenshot 2026-06-25 at 4 32 45 PM" src="https://github.com/user-attachments/assets/d04f01b3-146a-4775-83a7-a4eb1d7d9cc2" />
<img width="742" height="713" alt="Screenshot 2026-06-25 at 4 32 35 PM" src="https://github.com/user-attachments/assets/06171310-c92d-4958-a74a-3e689cceab9c" />
