### PR TITLE
Load home page cards asynchronously.

### DIFF
--- a/app/components/home/fines_card_component.html.erb
+++ b/app/components/home/fines_card_component.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% c.with_actions do %>
-    <%= render Home::PayNowFormComponent.new(fines: fines, balance: balance, patron_key: patron_key) %>
+    <%= render Home::PayNowFormComponent.new(fines: fines, balance: balance, patron_key: patron_key) if balance %>
   <% end %>
 
   <% c.with_body(classes: %w[pt-1]) do %>
@@ -13,7 +13,7 @@
       <p class="mb-1">No fees or fines</p>
       <%= render Home::ArrowLinkComponent.new(label: 'View past fees/fines', path: past_path, classes: ['stretched-link']) %>
     <% else %>
-      <p class="mb-1"><span class="fw-semibold"><%= number_to_currency(balance) %></span> balance</p>
+      <p class="mb-1"><span class="fw-semibold"><%= number_to_currency(balance) if balance %></span> balance</p>
       <%= render Home::ArrowLinkComponent.new(label: 'View details', path: path, classes: ['stretched-link']) %>
     <% end %>
   <% end %>

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,8 +8,15 @@ class HomeController < ApplicationController
   bot_challenge
 
   before_action :authenticate_user!, only: [:show]
+  before_action :load_dashboard
 
-  def show
+  def show; end
+
+  def show_folio; end
+
+  def show_aeon; end
+
+  def load_dashboard
     @dashboard = if patron_or_group.is_a? Folio::ProxyGroup
                    Home::Dashboard.new(aeon: Aeon::NullUser.new, patron: patron_or_group)
                  else

--- a/app/views/home/_card_view.html.erb
+++ b/app/views/home/_card_view.html.erb
@@ -3,67 +3,64 @@
         id: 'folio-borrowed-items',
         title: 'Borrowed items',
         icon_class: 'bi-book',
-        label: t('dashboard.borrowed_items.label_html', count: dashboard.checkouts.count),
-        path: dashboard.checkouts.count.positive? ? checkouts_path : nil ) do |c| %>
-            <% c.with_status_count(label: t('dashboard.borrowed_items_due_soon.label_html', count: dashboard.actionable_borrowed_items.count)) %>
+        label: t('dashboard.borrowed_items.label_placeholder_html'),
+        path: checkouts_path ) do |c| %>
+            <% c.with_status_count(label: t('dashboard.borrowed_items_due_soon.label_placeholder_html')) %>
         <% end if dashboard.folio? %>
 
-  <%= render Home::FinesCardComponent.new(
+  <%= render Home::SummaryCardComponent.new(
         id: 'folio-fines-and-fees',
         title: 'Fees and fines',
-        icon: 'bi-cash-coin',
-        fines: dashboard.fines,
-        balance: dashboard.balance,
-        patron_key: current_user.patron.key,
-        path: fines_path,
-        past_path: fines_path(past: 1)) if dashboard.folio? %>
+        icon_class: 'bi-cash-coin',
+        label: t('dashboard.fines_and_fees.label_placeholder_html'),
+        path: fines_path) if dashboard.folio? %>
 
   <%= render Home::SummaryCardComponent.new(
         id: 'folio-pickup-requests',
         title: 'Pickup requests',
         icon_class: 'bi-bag',
-        label: t('dashboard.pickup_requests.label_html', count: dashboard.pickup_requests.count),
-        path: dashboard.pickup_requests.count.positive? ? folio_requests_path : nil) do |c| %>
-            <% c.with_status_count(label: t('dashboard.pickup_requests_ready.label_html', count: dashboard.ready_for_pickup.count)) %>
+        label: t('dashboard.pickup_requests.label_placeholder_html'),
+        path: folio_requests_path) do |c| %>
+            <% c.with_status_count(label: t('dashboard.pickup_requests_ready.label_placeholder_html')) %>
         <% end if dashboard.folio? %>
 
   <%= render Home::SummaryCardComponent.new(
         id: 'aeon-digitization-requests',
         title: 'Digitization requests',
         icon_class: 'bi-printer',
-        label: t('dashboard.digitization_requests.label_html', count: dashboard.digital_requests.count),
-        path: dashboard.digital_requests.count.positive? ? aeon_requests_path(kind: 'submitted', filter: 'digitization') : aeon_requests_path(kind: 'completed', filter: 'digitization'),
-        link_label: dashboard.digital_requests.count.zero? ? 'View past requests' : nil) do |c| %>
-            <% c.with_status_count(label: t('dashboard.digitization_requests_delivered.label_html', count: dashboard.recently_delivered_digital_requests.count)) %>
+        label: t('dashboard.digitization_requests.label_placeholder_html'),
+        path: aeon_requests_path(kind: 'submitted', filter: 'digitization'),
+        link_label: nil) do |c| %>
+            <% c.with_status_count(label: t('dashboard.digitization_requests_delivered.label_placeholder_html')) %>
         <% end if dashboard.aeon? %>
 
   <%= render Home::SummaryCardComponent.new(
         id: 'aeon-reading-room-appointments',
         title: 'Reading room appointments',
         icon_class: 'bi-calendar',
-        label: t('dashboard.appointments.label_html', count: dashboard.appointments.count),
-        path: dashboard.appointments.count.positive? ? aeon_appointments_path : aeon_requests_path(kind: 'completed', filter: 'reading_room'),
-        link_label: dashboard.appointments.count.zero? ? 'View past appointments' : nil,
-        secondary_label: t('dashboard.appointment_items.label_html', count: dashboard.appointment_requests_count)) do |c| %>
-        <% c.with_status_next_up(date: dashboard.next_appointment_date) %>
+        label: t('dashboard.appointments.label_placeholder_html'),
+        path: aeon_appointments_path,
+        link_label: nil,
+        secondary_label: t('dashboard.appointment_items.label_placeholder_html')) do |c| %>
+        <% c.with_status_text(text: '') %>
       <% end if dashboard.aeon? %>
 
   <%= render Home::SummaryCardComponent.new(
         id: 'aeon-saved-for-later',
         title: 'Saved for later',
         icon_class: 'bi-pin-angle',
-        label: t('dashboard.saved_for_later.label_html', count: dashboard.saved_for_later.count),
-        path: dashboard.saved_for_later.count.positive? ? aeon_requests_path(kind: 'saved_for_later') : nil) do |c| %>
-            <% c.with_status_count(label: 'Requests not complete') if dashboard.saved_for_later.count.positive? %>
+        label: t('dashboard.saved_for_later.label_placeholder_html'),
+        path: aeon_requests_path(kind: 'saved_for_later')) do |c| %>
+            <% c.with_status_count(label: '') %>
         <% end if dashboard.aeon? %>
 
   <%= render Home::SummaryCardComponent.new(
         id: 'aeon-activities',
         title: 'Activities',
         icon_class: 'bi-person-video3',
-        label: t('dashboard.activities.label_html', count: dashboard.upcoming_activities.count),
-        path: dashboard.upcoming_activities.count.positive? ? aeon_activities_path : past_aeon_activities_path,
-        link_label: dashboard.upcoming_activities.count.zero? ? 'View past activities' : nil) do |c| %>
-        <% c.with_status_next_up(date: dashboard.next_activity_date) %>
+        label: t('dashboard.activities.label_placeholder_html'),
+        path: aeon_activities_path,
+        link_label: nil) do |c| %>
+        <% c.with_status_text(text: '') %>
       <% end if dashboard.aeon? %>
 </div>

--- a/app/views/home/_show_redesign.html.erb
+++ b/app/views/home/_show_redesign.html.erb
@@ -5,3 +5,6 @@
   </div>
   <%= render 'questions_aside' %>
 </div>
+
+<%= turbo_frame_tag 'folio-dashboard', src: folio_dashboard_path if @dashboard.folio? %>
+<%= turbo_frame_tag 'aeon-dashboard', src: aeon_dashboard_path if @dashboard.aeon? %>

--- a/app/views/home/show_aeon.html.erb
+++ b/app/views/home/show_aeon.html.erb
@@ -1,0 +1,49 @@
+<%= turbo_frame_tag 'aeon-dashboard' do %>
+  <%= turbo_stream.replace 'aeon-digitization-requests' do %>
+      <%= render Home::SummaryCardComponent.new(
+            id: 'aeon-digitization-requests',
+            title: 'Digitization requests',
+            icon_class: 'bi-printer',
+            label: t('dashboard.digitization_requests.label_html', count: @dashboard.digital_requests.count),
+            path: @dashboard.digital_requests.count.positive? ? aeon_requests_path(kind: 'submitted', filter: 'digitization') : aeon_requests_path(kind: 'completed', filter: 'digitization'),
+            link_label: @dashboard.digital_requests.count.zero? ? 'View past requests' : nil) do |c| %>
+                  <% c.with_status_count(label: t('dashboard.digitization_requests_delivered.label_html', count: @dashboard.recently_delivered_digital_requests.count)) %>
+            <% end %>
+      <% end %>
+
+  <%= turbo_stream.replace 'aeon-reading-room-appointments' do %>
+    <%= render Home::SummaryCardComponent.new(
+          id: 'aeon-reading-room-appointments',
+          title: 'Reading room appointments',
+          icon_class: 'bi-calendar',
+          label: t('dashboard.appointments.label_html', count: @dashboard.appointments.count),
+          path: @dashboard.appointments.count.positive? ? aeon_appointments_path : aeon_requests_path(kind: 'completed', filter: 'reading_room'),
+          link_label: @dashboard.appointments.count.zero? ? 'View past appointments' : nil,
+          secondary_label: t('dashboard.appointment_items.label_html', count: @dashboard.appointment_requests_count)) do |c| %>
+          <% c.with_status_next_up(date: @dashboard.next_appointment_date) %>
+        <% end %>
+  <% end %>
+
+  <%= turbo_stream.replace 'aeon-saved-for-later' do %>
+    <%= render Home::SummaryCardComponent.new(
+          id: 'aeon-saved-for-later',
+          title: 'Saved for later',
+          icon_class: 'bi-pin-angle',
+          label: t('dashboard.saved_for_later.label_html', count: @dashboard.saved_for_later.count),
+          path: @dashboard.saved_for_later.count.positive? ? aeon_requests_path(kind: 'saved_for_later') : nil) do |c| %>
+              <% c.with_status_count(label: 'Requests not complete') if @dashboard.saved_for_later.count.positive? %>
+          <% end %>
+    <% end %>
+
+  <%= turbo_stream.replace 'aeon-activities' do %>
+    <%= render Home::SummaryCardComponent.new(
+          id: 'aeon-activities',
+          title: 'Activities',
+          icon_class: 'bi-person-video3',
+          label: t('dashboard.activities.label_html', count: @dashboard.upcoming_activities.count),
+          path: @dashboard.upcoming_activities.count.positive? ? aeon_activities_path : past_aeon_activities_path,
+          link_label: @dashboard.upcoming_activities.count.zero? ? 'View past activities' : nil) do |c| %>
+          <% c.with_status_next_up(date: @dashboard.next_activity_date) %>
+        <% end %>
+  <% end %>
+<% end if @dashboard.aeon? %>

--- a/app/views/home/show_folio.html.erb
+++ b/app/views/home/show_folio.html.erb
@@ -1,0 +1,35 @@
+<%= turbo_frame_tag 'folio-dashboard' do %>
+  <%= turbo_stream.replace 'folio-borrowed-items' do %>
+    <%= render Home::SummaryCardComponent.new(
+          id: 'folio-borrowed-items',
+          title: 'Borrowed items',
+          icon_class: 'bi-book',
+          label: t('dashboard.borrowed_items.label_html', count: @dashboard.checkouts.count),
+          path: @dashboard.checkouts.count.positive? ? checkouts_path : nil ) do |c| %>
+              <% c.with_status_count(label: t('dashboard.borrowed_items_due_soon.label_html', count: @dashboard.actionable_borrowed_items.count)) %>
+          <% end %>
+  <% end %>
+
+  <%= turbo_stream.replace 'folio-fines-and-fees' do %>
+    <%= render Home::FinesCardComponent.new(
+          id: 'folio-fines-and-fees',
+          title: 'Fees and fines',
+          icon: 'bi-cash-coin',
+          fines: @dashboard.fines,
+          balance: @dashboard.balance,
+          patron_key: current_user.patron.key,
+          path: fines_path,
+          past_path: fines_path(past: 1)) %>
+  <% end %>
+
+  <%= turbo_stream.replace 'folio-pickup-requests' do %>
+    <%= render Home::SummaryCardComponent.new(
+          id: 'folio-pickup-requests',
+          title: 'Pickup requests',
+          icon_class: 'bi-bag',
+          label: t('dashboard.pickup_requests.label_html', count: @dashboard.pickup_requests.count),
+          path: @dashboard.pickup_requests.count.positive? ? folio_requests_path : nil) do |c| %>
+              <% c.with_status_count(label: t('dashboard.pickup_requests_ready.label_html', count: @dashboard.ready_for_pickup.count)) %>
+          <% end %>
+  <% end %>
+<% end if @dashboard.folio? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,51 +278,63 @@ en:
       payment_failed_html: <span class="font-weight-bold">Sorry!</span> Payment failed. Please <a href="mailto:sul-privileges@stanford.edu">contact us</a> for help resolving your fines.
   dashboard:
     borrowed_items:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
       label_html:
         zero: 'No items on loan'
         one: '<span class="fw-semibold">1</span> item currently loaned'
         other: '<span class="fw-semibold">%{count}</span> items currently loaned'
     borrowed_items_due_soon:
+      label_placeholder_html: ''
       label_html:
         zero: ''
         one: '<span class="fw-semibold">1</span> due soon'
         other: '<span class="fw-semibold">%{count}</span> due soon'
+    fines_and_fees:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
     pickup_requests:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
       label_html:
         zero: 'No pickup requests'
         one: '<span class="fw-semibold">1</span> item requested'
         other: '<span class="fw-semibold">%{count}</span> items requested'
     pickup_requests_ready:
+      label_placeholder_html: ''
       label_html:
         zero: ''
         one: '<span class="fw-semibold">1</span> item ready for pickup'
         other: '<span class="fw-semibold">%{count}</span> items ready for pickup'
     digitization_requests:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
       label_html:
         zero: 'No digitization requests'
         one: '<span class="fw-semibold">1</span> item requested'
         other: '<span class="fw-semibold">%{count}</span> items requested'
     digitization_requests_delivered:
+      label_placeholder_html: ''
       label_html:
         zero: ''
         one: '<span class="fw-semibold">1</span> delivered recently via email'
         other: '<span class="fw-semibold">%{count}</span> delivered recently via email'
     appointments:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
       label_html:
         zero: 'No appointments scheduled'
         one: '<span class="fw-semibold">1</span> appointment'
         other: '<span class="fw-semibold">%{count}</span> appointments'
     appointment_items:
+      label_placeholder_html: ''
       label_html:
         zero: 'No items scheduled'
         one: '<span class="fw-semibold">1</span> item scheduled'
         other: '<span class="fw-semibold">%{count}</span> items scheduled'
     saved_for_later:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
       label_html:
         zero: 'No saved items'
         one: '<span class="fw-semibold">1</span> item saved for later'
         other: '<span class="fw-semibold">%{count}</span> items saved for later'
     activities:
+      label_placeholder_html: '<div class="placeholder-glow"><span class="placeholder col-8"></span></div>'
       label_html:
         zero: 'No upcoming activities'
         one: '<span class="fw-semibold">1</span> upcoming activity'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   root 'home#show'
+  get 'home/folio', to: 'home#show_folio', as: :folio_dashboard
+  get 'home/aeon', to: 'home#show_aeon', as: :aeon_dashboard
+
   get "/feature_flags", to: "feature_flags#index", as: :feature_flags
   post "/feature_flags", to: "feature_flags#update"
   match "/404", to: 'errors#not_found', via: :all

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Home Page' do
     end
   end
 
-  context 'with the new layout' do
+  context 'with the new layout', :js do
     before do
       allow(Settings.features).to receive(:requests_redesign).and_return(true)
       allow(Folio::Patron).to receive(:find_by).with(patron_key: user.patron_key).and_return(patron)

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Proxy User' do
     end
   end
 
-  context 'when on the home page' do
+  context 'when on the home page', :js do
     it 'displays the sponsor information' do
       visit root_path
 


### PR DESCRIPTION
This cuts down on some of the initial queries to FOLIO + Aeon (although we contact both services to get the user account information.. presumably, it'd be even better if we could defer some of that too) 🤷‍♂️ 