### PR TITLE
Send Aeon API errors to HoneyBadger and record errors in the response log

### DIFF
--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -3,6 +3,19 @@
 ##
 # Rails Job to submit a request to ILLiad for handling (and possible rerouting)
 class SubmitAeonPatronRequestJob < ApplicationJob
+  # Raised when one or more items in a patron request fail to submit to Aeon.
+  class SubmissionFailure < StandardError
+    def initialize(patron_request, count)
+      @patron_request_id = patron_request.id
+      @count = count
+      super("Failed to create #{count} Aeon request(s) for patron_request #{patron_request.id}")
+    end
+
+    def to_honeybadger_context
+      { patron_request_id: @patron_request_id, aeon_api_error_count: @count }
+    end
+  end
+
   # Per-item fields that are meaningful to Aeon for each request_type. Hidden accordion sections
   # in the form still submit their inputs, so we drop anything that doesn't belong before building
   # the Aeon payload.
@@ -47,7 +60,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
     rescue AeonClient::ApiError => e
       failures << e
     end
-    raise failures.first if failures.any?
+    report_failures(patron_request, failures)
   end
 
   def perform_ead_request(patron_request, activity_id: nil)
@@ -59,7 +72,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
     rescue AeonClient::ApiError => e
       failures << e
     end
-    raise failures.first if failures.any?
+    report_failures(patron_request, failures)
   end
 
   def common_aeon_data_from_patron_request(patron_request, volume_params, activity_id) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -129,9 +142,6 @@ class SubmitAeonPatronRequestJob < ApplicationJob
     (volume_params || {}).slice(*fields)
   end
 
-  # Runs the block and logs the outcome (success or AeonClient::ApiError) to
-  # aeon_api_responses so failures show up on the patron-request page, then
-  # re-raises any error for the caller to collect.
   def record_aeon_response(patron_request, item_id, request)
     response_data = yield.as_json
     write_aeon_response(patron_request, item_id, request, response_data)
@@ -143,5 +153,12 @@ class SubmitAeonPatronRequestJob < ApplicationJob
   def write_aeon_response(patron_request, item_id, request, response_data)
     patron_request.aeon_api_responses.where(item_id: item_id).delete_all
     patron_request.aeon_api_responses.create(item_id: item_id, request_data: request.as_json, response_data: response_data)
+  end
+
+  def report_failures(patron_request, failures)
+    return if failures.empty?
+
+    failures.each { |failure| Honeybadger.notify(failure) }
+    raise SubmissionFailure.new(patron_request, failures.size)
   end
 end

--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -40,25 +40,26 @@ class SubmitAeonPatronRequestJob < ApplicationJob
   end
 
   def perform_folio_request(patron_request, activity_id: nil)
+    failures = []
     patron_request.selected_items.each do |folio_item|
       request = as_aeon_create_request_data(patron_request, folio_item, aeon_item_for(patron_request, folio_item.id), activity_id)
-      response = submit_aeon_request(request)
-
-      patron_request.aeon_api_responses.where(item_id: folio_item.id).delete_all
-      patron_request.aeon_api_responses.create(item_id: folio_item.id, request_data: request.as_json, response_data: response.as_json)
+      record_aeon_response(patron_request, folio_item.id, request) { submit_aeon_request(request) }
+    rescue AeonClient::ApiError => e
+      failures << e
     end
+    raise failures.first if failures.any?
   end
 
   def perform_ead_request(patron_request, activity_id: nil)
+    failures = []
     patron_request.aeon_item.each_value do |volume_params|
       request = as_aeon_create_ead_request_data(patron_request, relevant_aeon_fields(patron_request, volume_params), activity_id)
-      response = submit_aeon_request(request)
-
       item_id = "#{request.call_number} #{request.item_volume}"
-
-      patron_request.aeon_api_responses.where(item_id: item_id).delete_all
-      patron_request.aeon_api_responses.create(item_id: item_id, request_data: request.as_json, response_data: response.as_json)
+      record_aeon_response(patron_request, item_id, request) { submit_aeon_request(request) }
+    rescue AeonClient::ApiError => e
+      failures << e
     end
+    raise failures.first if failures.any?
   end
 
   def common_aeon_data_from_patron_request(patron_request, volume_params, activity_id) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -126,5 +127,21 @@ class SubmitAeonPatronRequestJob < ApplicationJob
   def relevant_aeon_fields(patron_request, volume_params)
     fields = AEON_ITEM_FIELDS_BY_REQUEST_TYPE[patron_request.request_type] || []
     (volume_params || {}).slice(*fields)
+  end
+
+  # Runs the block and logs the outcome (success or AeonClient::ApiError) to
+  # aeon_api_responses so failures show up on the patron-request page, then
+  # re-raises any error for the caller to collect.
+  def record_aeon_response(patron_request, item_id, request)
+    response_data = yield.as_json
+    write_aeon_response(patron_request, item_id, request, response_data)
+  rescue AeonClient::ApiError => e
+    write_aeon_response(patron_request, item_id, request, e.to_honeybadger_context)
+    raise
+  end
+
+  def write_aeon_response(patron_request, item_id, request, response_data)
+    patron_request.aeon_api_responses.where(item_id: item_id).delete_all
+    patron_request.aeon_api_responses.create(item_id: item_id, request_data: request.as_json, response_data: response_data)
   end
 end

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -2,7 +2,33 @@
 
 # Client for the Aeon API
 class AeonClient
-  class ApiError < StandardError; end
+  # Accepts a Faraday::Response or plain message to report on Aeon API errors
+  class ApiError < StandardError
+    attr_reader :response
+
+    def initialize(response_or_message)
+      if response_or_message.is_a?(Faraday::Response)
+        @response = response_or_message
+        super("Aeon API #{response.env.method.to_s.upcase} #{response.env.url.path} failed: #{response.status}")
+      else
+        super
+      end
+    end
+
+    def to_honeybadger_context
+      return {} unless response
+
+      env = response.env
+      {
+        status: response.status,
+        method: env.method.to_s.upcase,
+        url: env.url.to_s,
+        request_body: env.request_body,
+        response_body: response.body
+      }
+    end
+  end
+
   class NotFoundError < ApiError; end
 
   DEFAULT_HEADERS = {
@@ -99,7 +125,7 @@ class AeonClient
     when 204, 404
       true
     else
-      raise ApiError, "Aeon API error: #{response.status}"
+      raise ApiError, response
     end
   end
 
@@ -297,7 +323,7 @@ class AeonClient
     elsif faraday_response.status == 404
       not_found
     else
-      raise ApiError, "Aeon API error: #{faraday_response.status}"
+      raise ApiError, faraday_response
     end
   end
 end

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -6,7 +6,7 @@ class AeonClient
   class ApiError < StandardError
     attr_reader :response
 
-    def initialize(response_or_message)
+    def initialize(response_or_message = nil)
       if response_or_message.is_a?(Faraday::Response)
         @response = response_or_message
         super("Aeon API #{response.env.method.to_s.upcase} #{response.env.url.path} failed: #{response.status}")

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# If an exception defines #to_honeybadger_context (e.g. AeonClient::ApiError),
+# fold its return value into the Honeybadger notice so unrescued errors still
+# surface their request/response details.
+Honeybadger.configure do |config|
+  config.before_notify do |notice|
+    notice.context.merge!(notice.exception.to_honeybadger_context) if notice.exception.respond_to?(:to_honeybadger_context)
+  end
+end

--- a/spec/jobs/submit_aeon_patron_request_job_spec.rb
+++ b/spec/jobs/submit_aeon_patron_request_job_spec.rb
@@ -172,6 +172,40 @@ RSpec.describe SubmitAeonPatronRequestJob do
       end
     end
 
+    context 'when create_request raises an ApiError' do
+      let(:folio_instance) { build(:special_collections_single_holding) }
+      let(:request_type) { 'scan' }
+      let(:data) do
+        {
+          barcodes: ['12345678'], aeon_item: {
+            folio_instance.items.first.id => { requested_pages: '23', for_publication: 'false', additional_information: 'info' }
+          }
+        }
+      end
+      let(:response) do
+        Faraday.new do |b|
+          b.adapter(:test) { |s| s.post('/Requests/create') { [500, {}, '{"err":"error message"}'] } }
+        end.post('/Requests/create', '{"username":"aeon_user"}')
+      end
+
+      before do
+        allow(stub_aeon_client).to receive(:create_request).and_raise(AeonClient::ApiError.new(response))
+      end
+
+      it 'logs the error to aeon_api_responses and re-raises' do
+        expect { described_class.perform_now(request) }.to raise_error(AeonClient::ApiError)
+
+        log = request.aeon_api_responses.find_by(item_id: folio_instance.items.first.id)
+        expect(log.response_data).to include(
+          'status' => 500,
+          'method' => 'POST',
+          'request_body' => '{"username":"aeon_user"}',
+          'response_body' => '{"err":"error message"}'
+        )
+        expect(log.request_data).to include('username' => 'aeon_user')
+      end
+    end
+
     context 'with multi item digitization request' do
       let(:folio_instance) { build(:special_collections_holdings) }
       let(:request_type) { 'scan' }

--- a/spec/jobs/submit_aeon_patron_request_job_spec.rb
+++ b/spec/jobs/submit_aeon_patron_request_job_spec.rb
@@ -172,13 +172,21 @@ RSpec.describe SubmitAeonPatronRequestJob do
       end
     end
 
-    context 'when create_request raises an ApiError' do
-      let(:folio_instance) { build(:special_collections_single_holding) }
+    context 'when some items in a multi-item request fail' do
       let(:request_type) { 'scan' }
+      let(:folio_instance) do
+        items = %w[111 222 333].map do |barcode|
+          build(:item, barcode: barcode, base_callnumber: "CALL #{barcode}",
+                       status: 'Available', effective_location: build(:spec_coll_location))
+        end
+        build(:special_collections_holdings, items: items)
+      end
       let(:data) do
         {
-          barcodes: ['12345678'], aeon_item: {
-            folio_instance.items.first.id => { requested_pages: '23', for_publication: 'false', additional_information: 'info' }
+          barcodes: %w[111 222 333], aeon_item: {
+            folio_instance.items[0].id => { requested_pages: '1', for_publication: 'false', additional_information: 'first' },
+            folio_instance.items[1].id => { requested_pages: '2', for_publication: 'false', additional_information: 'second' },
+            folio_instance.items[2].id => { requested_pages: '3', for_publication: 'false', additional_information: 'third' }
           }
         }
       end
@@ -189,20 +197,32 @@ RSpec.describe SubmitAeonPatronRequestJob do
       end
 
       before do
-        allow(stub_aeon_client).to receive(:create_request).and_raise(AeonClient::ApiError.new(response))
+        allow(stub_aeon_client).to receive(:create_request).and_invoke(
+          ->(_) { raise AeonClient::ApiError, response },
+          ->(_) { Aeon::Request.new },
+          ->(_) { raise AeonClient::ApiError, response }
+        )
+        allow(Honeybadger).to receive(:notify)
       end
 
-      it 'logs the error to aeon_api_responses and re-raises' do
-        expect { described_class.perform_now(request) }.to raise_error(AeonClient::ApiError)
+      it 'logs every item, notifies Honeybadger per failure, and raises SubmissionFailure' do
+        expect { described_class.perform_now(request) }
+          .to raise_error(SubmitAeonPatronRequestJob::SubmissionFailure, /Failed to create 2 Aeon request/)
 
-        log = request.aeon_api_responses.find_by(item_id: folio_instance.items.first.id)
-        expect(log.response_data).to include(
+        expect(Honeybadger).to have_received(:notify).twice.with(an_instance_of(AeonClient::ApiError))
+
+        rows = request.aeon_api_responses
+        expect(rows.count).to eq(3)
+        error_rows = rows.select { |r| r.response_data['status'] == 500 }
+        expect(error_rows.size).to eq(2)
+
+        expect(error_rows.first.response_data).to include(
           'status' => 500,
           'method' => 'POST',
           'request_body' => '{"username":"aeon_user"}',
           'response_body' => '{"err":"error message"}'
         )
-        expect(log.request_data).to include('username' => 'aeon_user')
+        expect(error_rows.first.request_data).to include('username' => 'aeon_user')
       end
     end
 

--- a/spec/services/aeon_client_spec.rb
+++ b/spec/services/aeon_client_spec.rb
@@ -112,6 +112,29 @@ RSpec.describe AeonClient do
       expect(request).to be_a(Aeon::Request)
       expect(request.transaction_number).to eq('123')
     end
+
+    it 'raises an ApiError carrying request/response context on a server error' do
+      payload = AeonClient::RequestData.with_defaults.with(
+        username: 'jdoe',
+        item_title: 'Test Request'
+      )
+
+      stub_request(:post, 'https://aeon.example.com/api/Requests/create')
+        .with(body: payload.as_json.to_json)
+        .to_return(status: 500, body: { message: 'oh no an Aeon error' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.create_request(payload) }.to raise_error(AeonClient::ApiError) do |error|
+        expect(error.message).to eq('Aeon API POST /api/Requests/create failed: 500')
+        expect(error.to_honeybadger_context).to include(
+          status: 500,
+          method: 'POST',
+          url: 'https://aeon.example.com/api/Requests/create',
+          response_body: { 'message' => 'oh no an Aeon error' }
+        )
+        expect(error.to_honeybadger_context[:request_body]).to include('"username":"jdoe"')
+      end
+    end
   end
 
   describe '#update_request_route' do


### PR DESCRIPTION
I think there are further improvements we could/should make in the case of `Faraday::ConnectionFailed`, but I think this maintains current behavior while giving us more HoneyBadger notifications.