### PR TITLE
Use the same request sort options across data sources

### DIFF
--- a/app/components/folio/ill_request_component.html.erb
+++ b/app/components/folio/ill_request_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'library-sort-value': request.sort_key(:library), 'date-sort-value': request.sort_key(:date), 'title-sort-value': request.sort_key(:title), 'author-sort-value': request.sort_key(:author), 'call-number-sort-value': request.sort_key(:call_number)  }) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'date-sort-value': request.sort_key(:date), 'title-sort-value': request.sort_key(:title), 'date_modified-sort-value': request.sort_key(:date_modified) }) do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'library-sort-value': request.sort_key(:library), 'date-sort-value': request.sort_key(:date), 'title-sort-value': request.sort_key(:title), 'author-sort-value': request.sort_key(:author), 'call-number-sort-value': request.sort_key(:call_number)  }) do |c| %>
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'date-sort-value': request.sort_key(:date), 'title-sort-value': request.sort_key(:title), 'date_modified-sort-value': request.sort_key(:date_modified)  }) do |c| %>
   <% c.with_title do %>
     <div class="flex-grow-1">
       <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">

--- a/app/controllers/concerns/aeon_sortable.rb
+++ b/app/controllers/concerns/aeon_sortable.rb
@@ -5,18 +5,9 @@ module AeonSortable
   extend ActiveSupport::Concern
 
   SORT_OPTIONS = {
-    'request_type' => {
-      label: 'Sort by request type',
-      sort: ->(requests) { requests.sort_by { |r| [r.digital? ? 0 : 1, r.title.to_s, -r.creation_date.to_i, r.sort_key] } },
-      only_for_filters: %w[all]
-    },
     'title' => {
       label: 'Sort by title',
       sort: ->(requests) { requests.sort_by { |r| [r.title.to_s, r.sort_key] } }
-    },
-    'date_added' => {
-      label: 'Sort by date added',
-      sort: ->(requests) { requests.newest_first }
     },
     'date_modified' => {
       label: 'Sort by date modified',
@@ -31,7 +22,7 @@ module AeonSortable
     }
   }.freeze
 
-  DEFAULT_SORT = 'date_added'
+  DEFAULT_SORT = 'date_modified'
 
   included do
     helper_method :current_aeon_sort, :available_aeon_sort_options

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -96,24 +96,18 @@ module Folio
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def sort_key(key)
       sort_key = case key
-                 when :library
-                   [service_point_code, title, author, shelf_key]
                  when :date
                    [*date_sort_key, title, author, shelf_key]
                  when :title
                    [title, author, shelf_key]
-                 when :author
-                   [author, title, shelf_key]
-                 when :call_number
-                   [shelf_key]
+                 when :date_modified
+                   [-1 * placed_date.to_i, title, author, shelf_key]
                  end
 
       sort_key.join('---')
     end
-    # rubocop:enable Metrics/MethodLength
 
     def date_sort_key
       [

--- a/app/models/illiad_requests.rb
+++ b/app/models/illiad_requests.rb
@@ -61,23 +61,17 @@ class IlliadRequests
     end
     alias id key
 
-    # rubocop:disable Metrics/MethodLength
     def sort_key(key)
       sort_key = case key
-                 when :library
-                   [library_code, title, author, call_number]
                  when :date
                    [*date_sort_key, title, author, call_number]
                  when :title
                    [title, author, call_number]
-                 when :author
-                   [author, title, call_number]
-                 when :call_number
-                   [call_number]
+                 when :date_modified
+                   [-1 * placed_date.to_i, title, author, call_number]
                  end
       sort_key.join('---')
     end
-    # rubocop:enable Metrics/MethodLength
 
     def date_sort_key
       (expiration_date || Folio::Request::END_OF_DAYS).strftime('%FT%T')

--- a/app/views/folio_requests/index.html.erb
+++ b/app/views/folio_requests/index.html.erb
@@ -8,11 +8,9 @@
       </button>
 
       <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="library" data-sortable-label-param="Sort (Deliver to)">Deliver to</button></li>
         <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date_modified" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
         <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="author" data-sortable-label-param="Sort (Author)">Author name</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="callNumber" data-sortable-label-param="Sort (Call number)">Call number</button></li>
       </ul>
     </div>
     <% end %>

--- a/app/views/ill_requests/index.html.erb
+++ b/app/views/ill_requests/index.html.erb
@@ -8,11 +8,9 @@
       </button>
 
       <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="library" data-sortable-label-param="Sort (Deliver to)">Deliver to</button></li>
         <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date_modified" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
         <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="author" data-sortable-label-param="Sort (Author)">Author name</button></li>
-        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="callNumber" data-sortable-label-param="Sort (Call number)">Call number</button></li>
       </ul>
     </div>
     <% end %>

--- a/spec/controllers/concerns/aeon_sortable_spec.rb
+++ b/spec/controllers/concerns/aeon_sortable_spec.rb
@@ -44,17 +44,8 @@ RSpec.describe AeonSortable do
   end
 
   describe '#sort_aeon_requests' do
-    context 'with date_added sort (default)' do
+    context 'with date_modified sort (default)' do
       let(:sort_param) { nil }
-
-      it 'sorts by creation_date descending' do
-        result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Carrots Apples Bananas]
-      end
-    end
-
-    context 'with date_modified sort' do
-      let(:sort_param) { 'date_modified' }
 
       it 'sorts by transaction_date descending' do
         result = controller.send(:sort_aeon_requests, requests)
@@ -71,15 +62,6 @@ RSpec.describe AeonSortable do
       end
     end
 
-    context 'with request_type sort' do
-      let(:sort_param) { 'request_type' }
-
-      it 'sorts digital requests first, then by title' do
-        result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Bananas Apples Carrots]
-      end
-    end
-
     context 'with appointment_time sort' do
       let(:sort_param) { 'appointment_time' }
 
@@ -92,9 +74,9 @@ RSpec.describe AeonSortable do
     context 'with an invalid sort param' do
       let(:sort_param) { 'invalid' }
 
-      it 'falls back to date_added sort' do
+      it 'falls back to date_modified sort' do
         result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Carrots Apples Bananas]
+        expect(result.map(&:title)).to eq %w[Bananas Carrots Apples]
       end
     end
   end
@@ -112,7 +94,7 @@ RSpec.describe AeonSortable do
       let(:sort_param) { 'invalid' }
 
       it 'returns the default sort' do
-        expect(controller.send(:current_aeon_sort)).to eq 'date_added'
+        expect(controller.send(:current_aeon_sort)).to eq 'date_modified'
       end
     end
 
@@ -120,7 +102,7 @@ RSpec.describe AeonSortable do
       let(:sort_param) { nil }
 
       it 'returns the default sort' do
-        expect(controller.send(:current_aeon_sort)).to eq 'date_added'
+        expect(controller.send(:current_aeon_sort)).to eq 'date_modified'
       end
     end
   end
@@ -146,7 +128,7 @@ RSpec.describe AeonSortable do
 
       it 'includes all sort options' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
-          .to eq %w[request_type title date_added date_modified appointment_time]
+          .to eq %w[title date_modified appointment_time]
       end
     end
 
@@ -155,7 +137,7 @@ RSpec.describe AeonSortable do
 
       it 'excludes request_type and appointment_time' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
-          .to eq %w[title date_added date_modified]
+          .to eq %w[title date_modified]
       end
     end
 
@@ -164,7 +146,7 @@ RSpec.describe AeonSortable do
 
       it 'excludes request_type but includes appointment_time' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
-          .to eq %w[title date_added date_modified appointment_time]
+          .to eq %w[title date_modified appointment_time]
       end
     end
 
@@ -173,7 +155,7 @@ RSpec.describe AeonSortable do
       let(:filter_param) { 'digitization' }
 
       it 'falls back to default sort' do
-        expect(filterable_controller.send(:current_aeon_sort)).to eq 'date_added'
+        expect(filterable_controller.send(:current_aeon_sort)).to eq 'date_modified'
       end
     end
   end


### PR DESCRIPTION
Darcy + I talked about what options to provide. 

## Aeon
Request type is better served by filtering
Date added is confusing (because we're not showing it anywhere), 

## Folio
We're dropping library (why would you sort by it?),  author + call number are probably little used (maybe for topic grouping?) but don't interfile as nice.

Future work will rename date modified to something like "date added/modified", and come up with a better/consistent label for appointment date / expiration date / etc across types.