### PR TITLE
Guard against missing appointment start time's in editable check

### DIFF
--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -78,6 +78,8 @@ module Aeon
     end
 
     def editable?
+      return true unless start_time
+
       start_time.after?(edit_policy.days.from_now)
     end
 


### PR DESCRIPTION
We're cagy about it being nil in other methods; presumably we need something here too?