### PR TITLE
Display mediated requests on the requests page

### DIFF
--- a/app/components/mediated_request_component.html.erb
+++ b/app/components/mediated_request_component.html.erb
@@ -1,0 +1,30 @@
+<%= render CardComponent.new(element: 'li', id: dom_id(request), classes: 'request', data: { 'filter-value': 'reading room', 'default-sort-value': request.sort_key(:default), 'title-sort-value': request.sort_key(:title), 'date-sort-value': request.sort_key(:date) }) do |c| %>
+  <% c.with_title do %>
+    <div class="flex-grow-1">
+      <div class="d-flex flex-wrap gap-1 justify-content-between align-items-center mt-2 mb-3">
+        <%= render PillComponent.new(classes: %w[bg-lagunita-dark text-white]).with_content('Reading room use') %>
+      </div>
+
+      <div>
+        <%= tag.h2 request.item_title || 'Not available', class: @title_classes %>
+      </div>
+    </div>
+  <% end %>
+
+  <% c.with_body do %>
+    <div class="bg-white px-3 py-2 d-flex column-gap-4 row-gap-2 justify-content-between align-items-center flex-wrap flex-md-nowrap">
+      <div class="d-flex justify-content-start gap-2">
+        <span class="text-body-secondary small">Date added/modified: <span class="text-nowrap"><%= l(request.updated_at, format: :full) %></span></span>
+      </div>
+
+      <div class="d-flex flex-grow-1 column-gap-4 row-gap-2 justify-content-between align-items-center flex-wrap flex-md-nowrap">
+        <div>
+          <span class="text-spirited-dark"><i class="bi bi-clock me-1" aria-hidden></i>Staff processing</span>
+        </div>
+
+        <div class="d-flex text-nowrap align-items-baseline align-self-start justify-content-xl-end">
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/mediated_request_component.rb
+++ b/app/components/mediated_request_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Component for rendering unapproved mediated requests
+class MediatedRequestComponent < ViewComponent::Base
+  with_collection_parameter :request
+
+  attr_reader :request
+
+  def initialize(request:)
+    @request = request
+    super()
+  end
+end

--- a/app/controllers/mediated_requests_controller.rb
+++ b/app/controllers/mediated_requests_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+###
+#  A user's mediated requests (that haven't been placed in FOLIO yet)
+###
+class MediatedRequestsController < ApplicationController
+  before_action :load_requests
+
+  def index
+    render 'async' and return if params[:async]
+  end
+
+  def load_requests
+    @requests = PatronRequest.unapproved.where(user: current_user)
+  end
+end

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -195,9 +195,9 @@ module Aeon
                  when :title
                    [title, default_sort_key]
                  when :date
-                   [(transaction_date || 100.years.from_now).strftime('%FT%T'), title, default_sort_key]
+                   [(transaction_date || 100.years.from_now.end_of_day).strftime('%FT%T'), title, default_sort_key]
                  when :default
-                   [(appointment&.start_time || 100.years.from_now).strftime('%FT%T'), title, default_sort_key]
+                   [(appointment&.start_time || 100.years.from_now.end_of_day).strftime('%FT%T'), title, default_sort_key]
                  else
                    [default_sort_key]
                  end

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -9,7 +9,7 @@ module Folio
     attr_reader :record
 
     # A sufficiently large time used to sort nil values last
-    END_OF_DAYS = 100.years.from_now # rubocop:disable Rails/RelativeDateConstant
+    END_OF_DAYS = 100.years.from_now.end_of_day # rubocop:disable Rails/RelativeDateConstant
 
     def initialize(record)
       @record = record

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -613,6 +613,19 @@ class PatronRequest < ApplicationRecord
   end
   # @!endgroup
 
+  def sort_key(key)
+    case key
+    when :default
+      [(needed_date || 100.years.from_now.end_of_day).strftime('%FT%T'), item_title].join('---')
+    when :title
+      [item_title].join('---')
+    when :date
+      [updated_at.strftime('%FT%T'), item_title].join('---')
+    else
+      raise ArgumentError, "Invalid sort key: #{key}"
+    end
+  end
+
   private
 
   # @return [Folio::ServicePoint] the selected service point for pickup

--- a/app/views/mediated_requests/async.html.erb
+++ b/app/views/mediated_requests/async.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag :mediated_requests do %>
+  <turbo-stream action="append" target="requests">
+    <template>
+      <%= render MediatedRequestComponent.with_collection(@requests) %>
+    </template>
+  </turbo-stream>
+<% end %>

--- a/app/views/mediated_requests/index.html.erb
+++ b/app/views/mediated_requests/index.html.erb
@@ -1,0 +1,34 @@
+<div id="requests" class="page-section col-lg-9" data-controller="sortable google-cover-image" data-sortable-sort-value="default">
+  <div class="d-flex align-items-center justify-content-between mb-4">
+    <h1 class="mb-0">Mediated Requests</h1>
+    <% if @requests.any? %>
+    <div class="dropdown" data-sortable-target="sortMenu">
+      <button class="btn btn-outline-primary btn-sm dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Sort (Not needed after)
+      </button>
+
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+        <li><button class="dropdown-item active" data-action="click->sortable#sort" data-sortable-sort-param="default" data-sortable-label-param="Sort (Not needed after)">Not needed after</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="date" data-sortable-label-param="Sort (Date modified)">Date modified</button></li>
+        <li><button class="dropdown-item" data-action="click->sortable#sort" data-sortable-sort-param="title" data-sortable-label-param="Sort (Title)">Title</button></li>
+      </ul>
+    </div>
+    <% end %>
+  </div>
+  <% if @requests.any? %>
+    <ul class="requests p-0" data-sortable-target="list" aria-live="polite">
+      <%= render MediatedRequestComponent.with_collection(@requests) %>
+    </ul>
+  <% end %>
+</div>
+
+<div class="page-section">
+  <h2>If your request isn't listed</h2>
+  <ul>
+    <li>Requests for material from Special Collections &amp; University Archives, the David Rumsey Map Center, the Archive of Recorded Sound and East Asia Library Special Collections are listed in <%= link_to 'https://stanford.aeon.atlas-sys.com/logon/', target: '_blank' do %>
+      <%= sul_icon :'sharp-open_in_new-24px' %> Aeon.
+    <% end %>
+    </li>
+    <li>Requests requiring approval are not listed here until they have been approved &mdash; typically 1-3 days before your scheduled visit.</li>
+  </ul>
+</div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -80,6 +80,7 @@
   <% end unless patron_or_group.is_a? Folio::ProxyGroup %>
 
   <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) %>
+  <%= turbo_frame_tag :mediated_requests, src: mediated_requests_path(async: true) %>
 <% end %>
 
 <div class="page-section">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
   # requests#new is a legacy route for redirecting old-style requests to the new patron_requests
   get 'requests/new', to: 'requests#new', as: :new_request
   get 'requests/unified', to: 'requests#index', as: :unified_requests
+  get 'requests/mediated', to: 'mediated_requests#index', as: :mediated_requests
   resources :folio_requests, except: [:new, :create], path: 'requests'
   resources :ill_requests, only: [:index]
 


### PR DESCRIPTION
Future TODO:

- [ ] (how) are these displayed on the home page? (they aren't a pickup, they aren't really an appointment, etc)
- [ ] think about whether we want to include author, call number, format, etc in data we persist to the database
- [ ] ???