### PR TITLE
Count both Aeon digitization + ILLiad scan requests on the home page.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,7 +18,7 @@ class HomeController < ApplicationController
 
   def load_dashboard
     @dashboard = if patron_or_group.is_a? Folio::ProxyGroup
-                   Home::Dashboard.new(aeon: Aeon::NullUser.new, patron: patron_or_group)
+                   Home::Dashboard.new(aeon: Aeon::NullUser.new, patron: patron_or_group, include_illiad: false)
                  else
                    Home::Dashboard.new(aeon: current_user.aeon, patron: patron_or_group)
                  end

--- a/app/models/home/dashboard.rb
+++ b/app/models/home/dashboard.rb
@@ -3,11 +3,12 @@
 module Home
   # Home page presenter wrapping user data for both view variants.
   class Dashboard
-    attr_reader :aeon, :patron
+    attr_reader :aeon, :patron, :include_illiad
 
-    def initialize(aeon:, patron:)
+    def initialize(aeon:, patron:, include_illiad: false)
       @aeon = aeon
       @patron = patron
+      @include_illiad = include_illiad
     end
 
     def folio? = patron.present?
@@ -38,7 +39,19 @@ module Home
     end
 
     def digital_requests
-      @digital_requests ||= aeon.requests.digitization.submitted.newest_first
+      aeon_digital_requests + illiad_digital_requests
+    end
+
+    def aeon_digital_requests
+      return [] unless aeon?
+
+      @aeon_digital_requests ||= aeon.requests.digitization.submitted.newest_first
+    end
+
+    def illiad_digital_requests
+      return [] unless folio? && include_illiad
+
+      @illiad_digital_requests ||= patron.illiad_requests.select(&:scan_type?)
     end
 
     def recently_delivered_digital_requests

--- a/app/views/home/_card_view.html.erb
+++ b/app/views/home/_card_view.html.erb
@@ -25,14 +25,14 @@
         <% end if dashboard.folio? %>
 
   <%= render Home::SummaryCardComponent.new(
-        id: 'aeon-digitization-requests',
+        id: 'aeon-illiad-digitization-requests',
         title: 'Digitization requests',
         icon_class: 'bi-printer',
         label: t('dashboard.digitization_requests.label_placeholder_html'),
         path: aeon_requests_path(kind: 'submitted', filter: 'digitization'),
         link_label: nil) do |c| %>
             <% c.with_status_count(label: t('dashboard.digitization_requests_delivered.label_placeholder_html')) %>
-        <% end if dashboard.aeon? %>
+        <% end if dashboard.aeon? || dashboard.folio? %>
 
   <%= render Home::SummaryCardComponent.new(
         id: 'aeon-reading-room-appointments',

--- a/app/views/home/_show_redesign.html.erb
+++ b/app/views/home/_show_redesign.html.erb
@@ -6,5 +6,5 @@
   <%= render 'questions_aside' %>
 </div>
 
-<%= turbo_frame_tag 'folio-dashboard', src: folio_dashboard_path if @dashboard.folio? %>
+<%= turbo_frame_tag 'folio-dashboard', src: folio_dashboard_path(include_illiad: !@dashboard.aeon?) if @dashboard.folio? %>
 <%= turbo_frame_tag 'aeon-dashboard', src: aeon_dashboard_path if @dashboard.aeon? %>

--- a/app/views/home/show_aeon.html.erb
+++ b/app/views/home/show_aeon.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag 'aeon-dashboard' do %>
-  <%= turbo_stream.replace 'aeon-digitization-requests' do %>
+  <%= turbo_stream.replace 'aeon-illiad-digitization-requests' do %>
       <%= render Home::SummaryCardComponent.new(
-            id: 'aeon-digitization-requests',
+            id: 'aeon-illiad-digitization-requests',
             title: 'Digitization requests',
             icon_class: 'bi-printer',
             label: t('dashboard.digitization_requests.label_html', count: @dashboard.digital_requests.count),
-            path: @dashboard.digital_requests.count.positive? ? aeon_requests_path(kind: 'submitted', filter: 'digitization') : aeon_requests_path(kind: 'completed', filter: 'digitization'),
+            path: @dashboard.digital_requests.count.positive? ? unified_requests_path(filter: 'digitization') : aeon_requests_path(kind: 'completed', filter: 'digitization'),
             link_label: @dashboard.digital_requests.count.zero? ? 'View past requests' : nil) do |c| %>
                   <% c.with_status_count(label: t('dashboard.digitization_requests_delivered.label_html', count: @dashboard.recently_delivered_digital_requests.count)) %>
             <% end %>

--- a/app/views/home/show_folio.html.erb
+++ b/app/views/home/show_folio.html.erb
@@ -32,4 +32,16 @@
               <% c.with_status_count(label: t('dashboard.pickup_requests_ready.label_html', count: @dashboard.ready_for_pickup.count)) %>
           <% end %>
   <% end %>
+
+  <% if params[:include_illiad] %>
+    <%= turbo_stream.replace 'aeon-illiad-digitization-requests' do %>
+      <%= render Home::SummaryCardComponent.new(
+          id: 'aeon-illiad-digitization-requests',
+          title: 'Digitization requests',
+          icon_class: 'bi-printer',
+          label: t('dashboard.digitization_requests.label_html', count: @dashboard.digital_requests.count),
+          path: unified_requests_path(filter: 'digitization'),
+          link_label: nil) %>
+    <% end %>
+  <% end %>
 <% end if @dashboard.folio? %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,4 +1,4 @@
-<div class="page-section col-9" data-controller="sortable google-cover-image" data-sortable-sort-value="default">
+<%= tag.div class: 'page-section col-9', data: { controller: 'sortable google-cover-image', 'sortable-sort-value': 'default', 'sortable-filter-value': params[:filter] } do %>
   <div class="d-flex justify-content-between mb-4">
     <h1>Submitted requests</h1>
 
@@ -80,7 +80,7 @@
   <% end unless patron_or_group.is_a? Folio::ProxyGroup %>
 
   <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) %>
-</div>
+<% end %>
 
 <div class="page-section">
   <h2>If your request isn't listed</h2>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Home Page' do
+  before do
+    allow(IlliadRequests).to receive(:new).and_return(instance_double(IlliadRequests, requests: []))
+  end
+
   describe 'layout' do
     before do
       visit root_path
@@ -70,9 +74,10 @@ RSpec.describe 'Home Page' do
       it 'renders just the FOLIO cards' do
         visit root_path
 
-        expect(page).to have_css('.card', count: 3)
+        expect(page).to have_css('.card', count: 4)
         expect(page).to have_css('.card', text: 'Pickup requests')
-        expect(page).to have_no_css('.card', text: 'Digitization requests')
+        expect(page).to have_css('.card', text: 'Digitization requests')
+        expect(page).to have_no_css('.card', text: 'Reading room appointments')
       end
     end
 
@@ -83,6 +88,7 @@ RSpec.describe 'Home Page' do
         visit root_path
 
         expect(page).to have_css('.card', count: 4)
+        expect(page).to have_css('.card', text: 'Reading room appointments')
         expect(page).to have_css('.card', text: 'Digitization requests')
         expect(page).to have_no_css('.card', text: 'Pickup requests')
       end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/sul-requests/issues/3951

Maybe it's a little funny that the Aeon view queries ILLiad, but that seemed nicer than merging result counts client-side (at least until we have a stronger reason to do so)