### PR TITLE
Include status in single-item group_key to avoid empty group cards

### DIFF
--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -77,7 +77,7 @@ module Aeon
       if multi_item_selector?
         [status, title, digital?]
       else
-        [id]
+        [id, status]
       end
     end
 

--- a/spec/features/aeon_requests_spec.rb
+++ b/spec/features/aeon_requests_spec.rb
@@ -116,4 +116,28 @@ RSpec.describe 'Requests', :js do
       expect(page).to have_no_text('Slow poetry in America : a poetry quarterly')
     end
   end
+
+  describe 'submitted' do
+    let(:single_submitted_request) do
+      StubAeonClient::Request.create(
+        itemTitle: 'A Book',
+        username: aeon_user.username,
+        webRequestForm: 'single',
+        transactionStatus: 3
+      )
+    end
+
+    before { single_submitted_request }
+
+    it 'removes the empty group card when the last single-item request is deleted' do
+      visit aeon_requests_path(kind: 'submitted')
+
+      expect(page).to have_css('.request-group', text: 'A Book')
+
+      click_on 'Delete A Book'
+      click_on 'Yes - Delete'
+
+      expect(page).to have_no_css('.request-group', text: 'A Book')
+    end
+  end
 end


### PR DESCRIPTION
I think the group for a reading room request with an appointments gets removed after the request is destroyed (presumably due to some appointment handling?), but digitization for non-multi-item selector requests are not currently.

<img width="844" height="286" alt="Screenshot 2026-07-02 at 4 52 33 PM" src="https://github.com/user-attachments/assets/be56213f-d745-4c5a-9625-fd137b7e2613" />
<img width="850" height="182" alt="Screenshot 2026-07-02 at 4 52 47 PM" src="https://github.com/user-attachments/assets/a35af8ad-2b27-4bbe-9c93-15c469646ae8" />
