### PR TITLE
Tweak the rounded pill padding to get the text to sit better.

### DIFF
--- a/app/assets/stylesheets/utility.css
+++ b/app/assets/stylesheets/utility.css
@@ -137,7 +137,10 @@ label.btn-close {
 }
 
 .rounded-pill {
-  padding: 4px 12px;
+  padding-top: 4px;
+  padding-bottom: 2px;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .hidden-if-peers {


### PR DESCRIPTION
I think the text in the pills is sitting too high. 

Current:
<img width="293" height="112" alt="Screenshot 2026-07-06 at 09 23 28" src="https://github.com/user-attachments/assets/d772f616-cae9-4be3-a75b-157f68ca23c4" />

After:
<img width="803" height="192" alt="Screenshot 2026-07-06 at 09 24 47" src="https://github.com/user-attachments/assets/71fe3473-842e-42c0-8082-84336144011b" />
