### PR TITLE
Restore width of duration selector buttons

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -393,6 +393,7 @@ summary .disclosure-icon::before {
 }
 
 /* Available time slots get fixed widths to line up in uniform rows/columns */
+.duration-selector .btn,
 #available_appointments .btn {
   width: 6rem;
   text-align: center;


### PR DESCRIPTION
<img width="707" height="316" alt="Screenshot 2026-07-06 at 1 12 23 PM" src="https://github.com/user-attachments/assets/5f56af2f-73a7-40c7-a5b6-f08798388e16" />
