### PR TITLE
Start updating selected item form styles

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -435,13 +435,6 @@ summary .disclosure-icon::before {
     "actions";
 
   @media (min-width: 768px) {
-    grid-template-columns: 1fr auto;
-    grid-template-areas:
-      "title  title"
-      "actions select";
-  }
-
-  @media (min-width: 1200px) {
     grid-template-columns: auto 1fr;
     grid-template-areas:
       "title   title"

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -471,6 +471,16 @@ summary .disclosure-icon::before {
 .appt-actions { grid-area: actions; }
 .appt-select  { grid-area: select; }
 
+.digitization-title {
+  display: flex;
+  flex-direction: column;
+}
+
+.accordion-item:only-child .digitization-title {
+  flex-direction: row;
+  align-items: center;
+}
+
 #reading:has(.appointments-item:only-child),
 #pickup:has(.appointments-item:only-child) {
   .hide-when-1-item {
@@ -530,7 +540,7 @@ summary .disclosure-icon::before {
     border-width: 0;
   }
 
-  .selected-item-status, .selected-item-remove, .disclosure-icon {
+  .selected-item-status, .selected-item-remove, .disclosure-icon, .accordion-header-icon {
     display: none;
   }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -425,11 +425,6 @@ summary .disclosure-icon::before {
   display: none;
 }
 
-/* Hint to avoid wrapping only the view contents button */
-.text-wrap:has(.selected-item-title) {
-  text-wrap: pretty;
-}
-
 .appointments-item {
   padding: 0.5rem 1rem 0.5rem 1rem;
   grid-template-columns: 1fr;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -427,6 +427,7 @@ summary .disclosure-icon::before {
 
 .appointments-item {
   padding: 0.5rem 1rem 0.5rem 1rem;
+  row-gap: 0.25rem;
   grid-template-columns: 1fr;
   grid-template-areas:
     "title"
@@ -436,14 +437,14 @@ summary .disclosure-icon::before {
   @media (min-width: 768px) {
     grid-template-columns: 1fr auto;
     grid-template-areas:
-      "title  actions"
-      "select select";
+      "title  title"
+      "actions select";
   }
 
   @media (min-width: 1200px) {
     grid-template-columns: auto 1fr;
     grid-template-areas:
-      "title   select"
+      "title   title"
       "actions select";
     align-items: center;
 
@@ -455,11 +456,11 @@ summary .disclosure-icon::before {
 
 .appointments-item:only-child {
   padding-left: 0;
-  grid-template-columns: 1fr;
+  row-gap: 1.5rem;
+  grid-template-columns: auto 1fr;
   grid-template-areas:
-    "title"
-    "actions"
-    "select";
+    "title actions"
+    "select select";
 
   .appt-select {
     justify-content: flex-start;

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -3,7 +3,7 @@
   <div class="appt-title text-wrap">
     <span class="text-black fw-semibold selected-item-title"><%= title %></span>
   </div>
-  <div class="appt-actions d-flex gap-2">
+  <div class="appt-actions d-flex flex-wrap gap-2">
     <button class="btn btn-link p-0 ps-1 d-none su-underline fs-14" data-action="view-container-contents#openViewModal"
             data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
       <i class="bi bi-list-ul me-1"></i>View contents

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -3,13 +3,13 @@
   <div class="appt-title">
     <span class="text-wrap">
       <span class="text-black fw-semibold selected-item-title"><%= title %></span>
-      <button class="btn btn-link d-none" data-action="view-container-contents#openViewModal"
-              data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
-        <i class="bi bi-list-ul me-1"></i>View contents
-      </button>
     </span>
   </div>
   <div class="appt-actions">
+    <button class="btn btn-link d-none" data-action="view-container-contents#openViewModal"
+            data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
+      <i class="bi bi-list-ul me-1"></i>View contents
+    </button>
     <% if save_for_later? %>
     <button class="btn btn-link p-0 ps-1 su-underline fs-14" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>">
       <i class="bi bi-pin-angle-fill me-1"></i>Save for later

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -16,7 +16,7 @@
     </button>
     <% end %>
     <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-      <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+      <i class="bi bi-trash"></i>Delete <span class="visually-hidden"><%= title %></span>
     </button>
   </div>
   <%= fields_for base_name, object do |f| %>

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -1,9 +1,7 @@
-<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 d-grid row-gap-2 column-gap-3 text-nowrap" data-content-id="<%= dom_id %>">
+<li data-controller="selected-item-form" data-action="input->selected-item-form#updateStatus" class="appointments-item rounded mb-2 d-grid column-gap-3 text-nowrap" data-content-id="<%= dom_id %>">
   <i class="bi bi-check2 selected-item-status"></i>
-  <div class="appt-title">
-    <span class="text-wrap">
-      <span class="text-black fw-semibold selected-item-title"><%= title %></span>
-    </span>
+  <div class="appt-title text-wrap">
+    <span class="text-black fw-semibold selected-item-title"><%= title %></span>
   </div>
   <div class="appt-actions d-flex gap-2">
     <button class="btn btn-link p-0 ps-1 d-none su-underline fs-14" data-action="view-container-contents#openViewModal"

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -5,7 +5,7 @@
       <span class="text-black fw-semibold selected-item-title"><%= title %></span>
       <button class="btn btn-link d-none" data-action="view-container-contents#openViewModal"
               data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
-        <i class="bi bi-list-ul"></i><span class="visually-hidden">View contents</span>
+        <i class="bi bi-list-ul me-1"></i>View contents
       </button>
     </span>
   </div>

--- a/app/components/aeon/appointment_form_item_component.html.erb
+++ b/app/components/aeon/appointment_form_item_component.html.erb
@@ -5,8 +5,8 @@
       <span class="text-black fw-semibold selected-item-title"><%= title %></span>
     </span>
   </div>
-  <div class="appt-actions">
-    <button class="btn btn-link d-none" data-action="view-container-contents#openViewModal"
+  <div class="appt-actions d-flex gap-2">
+    <button class="btn btn-link p-0 ps-1 d-none su-underline fs-14" data-action="view-container-contents#openViewModal"
             data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
       <i class="bi bi-list-ul me-1"></i>View contents
     </button>
@@ -15,7 +15,7 @@
       <i class="bi bi-pin-angle-fill me-1"></i>Save for later
     </button>
     <% end %>
-    <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+    <button class="btn btn-link p-0 ps-1 su-underline fs-14 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
       <i class="bi bi-trash"></i>Delete <span class="visually-hidden"><%= title %></span>
     </button>
   </div>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -13,20 +13,20 @@
         <i class="bi bi-check2 selected-item-status"></i>
         <span id="title_<%= dom_id %>" class="text-wrap">
           <span class="text-black fw-semibold selected-item-title"><%= title %></span>
-          <button class="btn btn-link position-relative z-3 d-none" data-action="view-container-contents#openViewModal"
-                  data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
-            <i class="bi bi-list-ul"></i><span class="visually-hidden">View contents</span>
-          </button>
         </span>
       </div>
-      <div class="d-flex position-relative z-3">
+      <div class="d-flex position-relative d-flex gap-2 z-3">
+        <button class="btn btn-link p-0 ps-1 d-none su-underline fs-14" data-action="view-container-contents#openViewModal"
+                data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
+          <i class="bi bi-list-ul me-1"></i>View contents
+        </button>
         <% if save_for_later? %>
           <button class="btn btn-link p-0 ps-1 z-3 su-underline fs-14 text-nowrap" data-action="save-for-later#save" data-save-for-later-id-param="<%= dom_id %>">
           <i class="bi bi-pin-angle-fill me-1"></i>Save for later
         </button>
         <% end %>
-        <button class="btn btn-link p-0 ps-1 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
-          <i class="bi bi-trash"></i><span class="visually-hidden"> Delete <%= title %></span>
+        <button class="btn btn-link p-0 ps-1 su-underline fs-14 selected-item-remove" data-action="item-selector#remove" data-item-selector-id-param="<%= dom_id %>">
+          <i class="bi bi-trash"></i>Delete <span class="visually-hidden"><%= title %></span>
         </button>
       </div>
     </div>

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -8,14 +8,12 @@
         aria: { expanded: !accordion?, controls: "content_#{dom_id}", labelledby: "title_#{dom_id}" },
         disabled: !accordion?
     ) %>
-    <div class="d-flex flex-column flex-lg-row align-items-lg-center flex-grow-1 justify-content-lg-between">
-      <div class="d-flex align-items-center">
-        <i class="bi bi-check2 selected-item-status"></i>
-        <span id="title_<%= dom_id %>" class="text-wrap">
-          <span class="text-black fw-semibold selected-item-title"><%= title %></span>
-        </span>
-      </div>
-      <div class="d-flex position-relative d-flex gap-2 z-3">
+    <i class="bi bi-check2 selected-item-status"></i>
+    <div class="digitization-title gap-2 flex-grow-1">
+      <span id="title_<%= dom_id %>" class="text-wrap">
+        <span class="text-black fw-semibold selected-item-title"><%= title %></span>
+      </span>
+      <div class="digitization-actions position-relative d-flex gap-2 z-3">
         <button class="btn btn-link p-0 ps-1 d-none su-underline fs-14" data-action="view-container-contents#openViewModal"
                 data-view-container-contents-target="displayButton" data-item-id="<%= dom_id %>">
           <i class="bi bi-list-ul me-1"></i>View contents

--- a/app/components/aeon/digitization_form_item_component.html.erb
+++ b/app/components/aeon/digitization_form_item_component.html.erb
@@ -33,12 +33,12 @@
   <div id="content_<%= dom_id %>" class="accordion-collapse <%= 'collapse' if accordion? %>">
     <%= fields_for base_name, object do |f| %>
       <div class="accordion-body">
-        <div class="mb-3">
+        <div class="mb-4">
           <%= f.label :requested_pages, 'Requested pages or instructions', class: 'form-label fw-semibold redesign-required-label' %>
           <%= f.text_field :requested_pages, placeholder: 'e.g. 100-150, 167, 170-180 or Chapter 5', class: 'form-control', data: { 'required-for-submit': true } %>
         </div>
 
-        <div class="mb-3">
+        <div class="mb-4">
           <fieldset>
             <legend class="form-label fs-6 mb-1 fw-semibold">Is this for publication or distribution?</legend>
             <span class="me-3">
@@ -51,7 +51,7 @@
           </fieldset>
         </div>
 
-        <div class="mb-3" data-controller="char-counter" data-char-counter-default-class="text-body-tertiary" data-char-counter-warning-class="text-cardinal">
+        <div class="mb-4" data-controller="char-counter" data-char-counter-default-class="text-body-tertiary" data-char-counter-warning-class="text-cardinal">
           <%= f.label :additional_information, class: 'form-label fw-semibold' %>
           <%= f.text_area :additional_information, class: 'form-control', maxlength: 255, data: { action: "input->char-counter#updateCharCounter"} %>
           <p class="form-text text-secondary d-flex justify-content-between">

--- a/app/views/patron_requests/_contact_aside.html.erb
+++ b/app/views/patron_requests/_contact_aside.html.erb
@@ -1,5 +1,5 @@
 
-<aside class="col-4 d-none d-lg-block">
+<aside class="col-3 d-none d-lg-block">
   <% if @patron_request.ead_doc %>
     <h2>Contact information</h2>
     <div>

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -1,4 +1,4 @@
-<div class="row p-3 pt-0 gap-3 flex-column flex-md-row">
+<div class="row p-3 pt-0 gap-4 flex-column flex-md-row">
   <% appointments = current_user.aeon.appointments.for_site(f.object.aeon_site) %>
   <div id="new-appt-alert">
     <% if appointments.blank? %>
@@ -14,9 +14,9 @@
 
   <%= render Aeon::ReadingRoomBriefComponent.new(reading_room: f.object.aeon_reading_room) %>
 
-  <div class="mt-3">
+  <div>
     <%= render 'save_for_later' %>
-    <ul class="appointments-container list-unstyled selected-items-container" data-item-selector-target="selectedItems" data-template="#appointmentTemplate">
+    <ul class="appointments-container list-unstyled selected-items-container mb-0" data-item-selector-target="selectedItems" data-template="#appointmentTemplate">
       <% if f.object.selectable_items.one? %>
         <%= render Aeon::AppointmentFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", reading_room_id: f.object.aeon_reading_room.id, appointments: appointments) %>
       <% end %>
@@ -27,7 +27,7 @@
     </template>
   </div>
 
-  <div class="mt-3 mb-2" data-controller="char-counter" data-char-counter-default-class="text-body-tertiary" data-char-counter-warning-class="text-cardinal">
+  <div class="mb-2" data-controller="char-counter" data-char-counter-default-class="text-body-tertiary" data-char-counter-warning-class="text-cardinal">
     <%= f.label :aeon_reading_special, 'Additional information', :class => 'fw-bold py-2' %>
     <%= f.text_area :aeon_reading_special, :class => 'form-control', rows: 3, maxlength: 255, data: { action: "input->char-counter#updateCharCounter"} %>
     <p class="form-text text-secondary d-flex justify-content-between">

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -11,7 +11,7 @@
 
 
 <div class="row">
-  <div class="col-12 col-lg-8">
+  <div class="col-12 col-lg-9">
 
     <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record) %>
     <%= render 'contact_brief' %>

--- a/spec/component_previews/appointment_form_item_component_preview/default.html.erb
+++ b/spec/component_previews/appointment_form_item_component_preview/default.html.erb
@@ -7,7 +7,7 @@
 
 %>
 <form id="reading-accordion">
-  <ul id="reading" class="appointments-container list-unstyled">
+  <ul id="reading" class="appointments-container list-unstyled selected-items-container">
     <%= 
       render Aeon::AppointmentFormItemComponent.new(
         title: 'Item 1',
@@ -20,6 +20,18 @@
       render Aeon::AppointmentFormItemComponent.new(
         title: 'Item 2',
         dom_id: 'item_2',
+        appointments: appointments
+      ) %>
+  </ul>
+</form>
+
+
+<form id="reading-accordion2">
+  <ul id="reading2" class="appointments-container list-unstyled selected-items-container">
+    <%=
+      render Aeon::AppointmentFormItemComponent.new(
+        title: 'Item 1',
+        dom_id: 'item_1',
         appointments: appointments
       ) %>
   </ul>


### PR DESCRIPTION
This PR is an alternate take on #3908 + #3913

- [x] updates the vertical rhythm to use 24px (1.5rem / gap-4) spacing
- [x] bumps the actions below the title (generally) 
- [x] updates the new request column layout to use  9 / 3 (instead of 8 / 4) to make more room for the form element at -lg and -xl 
- [x] adds action labels and make the buttons consistent

Changes from the design:
- [x] Darcy is reluctantly ok with keeping the actions outside the volume box area

Future TODOs:
- [ ] need a decision about action wrapping at -md / -lg
- [ ] handle hiding the additional notes field if all requests are save-for-later'ed (extracted to #3981)