### PR TITLE
Hide + show the additional information section when there's no submitted items.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -462,6 +462,10 @@ summary .disclosure-icon::before {
   }
 }
 
+#reading:not(:has(.appointments-item)) #additional-information {
+  display: none;
+}
+
 .selected-items-container {
   .accordion-item:last-child .next-item {
     display: none;

--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -90,7 +90,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
       site: patron_request.aeon_site,
       special_request: if patron_request.request_type == 'scan'
                          volume_params['additional_information']
-                       else
+                       elsif volume_params['appointment_id'].present?
                          patron_request.aeon_reading_special
                        end,
       username: patron_request.user.aeon.username,

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -27,7 +27,7 @@
     </template>
   </div>
 
-  <div class="mb-2" data-controller="char-counter" data-char-counter-default-class="text-body-tertiary" data-char-counter-warning-class="text-cardinal">
+  <div id="additional-information" class="mb-2" data-controller="char-counter" data-char-counter-default-class="text-body-tertiary" data-char-counter-warning-class="text-cardinal">
     <%= f.label :aeon_reading_special, 'Additional information', :class => 'fw-bold py-2' %>
     <%= f.text_area :aeon_reading_special, :class => 'form-control', rows: 3, maxlength: 255, data: { action: "input->char-counter#updateCharCounter"} %>
     <p class="form-text text-secondary d-flex justify-content-between">

--- a/spec/jobs/submit_aeon_patron_request_job_spec.rb
+++ b/spec/jobs/submit_aeon_patron_request_job_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe SubmitAeonPatronRequestJob do
       let(:request_type) { 'pickup' }
       let(:data) do
         {
-          barcodes: ['12345678'], aeon_reading_special: 'Some info'
+          barcodes: ['12345678'], aeon_reading_special: 'Some info', aeon_item: {
+            folio_instance.items.first.id => { appointment_id: '99' }
+          }
         }
       end
 


### PR DESCRIPTION
Part of #3913, done with CSS instead of javascript toggling.