### PR TITLE
Consolidate FOLIO patron reads into a single GraphQL query

### DIFF
--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -3,9 +3,11 @@
 module Folio
   # Model for working with FOLIO Patron information
   class Patron
-    def self.find_by(sunetid: nil, library_id: nil, patron_key: nil, **_kwargs) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-      user_info = folio_client.find_user_by_id(patron_key) if patron_key.present?
-      user_info ||= folio_client.find_user_by_barcode(library_id) if library_id.present?
+    def self.find_by(sunetid: nil, library_id: nil, patron_key: nil, **_kwargs) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength
+      response = folio_client.patron_graphql_response(patron_key) if patron_key.present?
+      return Folio::Patron.new(patron_graphql_response: response) if response
+
+      user_info = folio_client.find_user_by_barcode(library_id) if library_id.present?
       user_info ||= folio_client.find_user_by_university_id(library_id) if library_id.present?
       user_info ||= folio_client.find_user_by_legacy_barcode(library_id) if library_id.present?
       user_info ||= folio_client.find_user_by_sunetid(sunetid) if sunetid.present?
@@ -278,11 +280,11 @@ module Folio
     private
 
     def extended_user_info
-      @extended_user_info ||= folio_client.extended_user_info(id)
+      @extended_user_info ||= patron_graphql_response&.dig('user')
     end
 
     def patron_graphql_response
-      @patron_graphql_response ||= folio_client.extended_patron_info(id)
+      @patron_graphql_response ||= folio_client.patron_graphql_response(id)
     end
 
     def valid_proxy_relation?(info)
@@ -294,8 +296,11 @@ module Folio
     end
 
     def patron_group_id
-      # FOLIO APIs return a UUID here
-      user_info['patronGroup'] || extended_user_info&.dig('patronGroup', 'id')
+      # REST /users returns patronGroup as a UUID string; GraphQL returns it as an
+      # object and exposes the UUID separately as patronGroupId.
+      user_info['patronGroupId'] ||
+        (user_info['patronGroup'] if user_info['patronGroup'].is_a?(String)) ||
+        extended_user_info&.dig('patronGroup', 'id')
     end
 
     # Get all the sponsors for this patron

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -19,7 +19,7 @@ class FolioClient
 
   attr_reader :base_url
 
-  delegate :loan_policies, :service_points, :patron_info, to: :folio_graphql_client
+  delegate :loan_policies, :service_points, :patron_graphql_response, :patron_info, to: :folio_graphql_client
 
   def initialize(url: Settings.folio.okapi_url, tenant: Settings.folio.tenant)
     uri = URI.parse(url)
@@ -98,8 +98,6 @@ class FolioClient
     response = post('/patron-pin', json: { id: user_id, pin: new_pin })
     check_response(response, title: 'Assign pin', context: { user_id: })
   end
-
-  delegate :extended_user_info, :extended_patron_info, to: :folio_graphql_client
 
   def patron_account(patron_key)
     get_json("/patron/account/#{CGI.escape(patron_key)}", params: {
@@ -409,14 +407,6 @@ class FolioClient
   def find_user_by_sunetid(sunetid)
     user = get_json('/users', params: { query: CqlQuery.new(username: sunetid).to_query })&.dig('users', 0)
     raise ActiveRecord::RecordNotFound, "User with username '#{sunetid}' not found" unless user
-
-    user
-  end
-
-  # Find a user by ID in FOLIO; raise an error if not found
-  def find_user_by_id(user_id)
-    user = get_json("/users/#{user_id}")
-    raise ActiveRecord::RecordNotFound, "User with id '#{user_id}' not found" unless user
 
     user
   end

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -219,298 +219,320 @@ class FolioGraphqlClient
     data.dig('data', 'loanPolicies')
   end
 
-  def extended_user_info(patron_uuid)
+  # Fetch user + patron data in a single GraphQL round-trip.
+  # Returns a hash shaped like the patron node, with the user node merged in under 'user',
+  # so it is directly consumable by Folio::Patron.new(patron_graphql_response:).
+  def patron_graphql_response(patron_uuid)
     data = post_json('/', json: {
-                       query: "query Query($patronId: UUID!) {
-                                 user(id: $patronId) {
-                                    id
-                                    username
-                                    barcode
-                                    active
-                                    personal {
-                                      email
-                                      lastName
-                                      firstName
-                                      preferredFirstName
-                                    }
-                                    proxiesFor {
-                                      userId
-                                      requestForSponsor
-                                      status
-                                      expirationDate
-                                      user {
-                                        id
-                                        barcode
-                                        personal {
-                                          firstName
-                                          preferredFirstName
-                                          lastName
-                                        }
-                                      }
-                                    }
-                                    proxiesOf {
-                                      proxyUserId
-                                      requestForSponsor
-                                      status
-                                      expirationDate
-                                      proxyUser {
-                                        id
-                                        barcode
-                                        personal {
-                                          firstName
-                                          preferredFirstName
-                                          lastName
-                                        }
-                                      }
-                                    }
-                                    expirationDate
-                                    externalSystemId
-                                    patronGroup {
-                                      id
-                                      desc
-                                      group
-                                      limits {
-                                        conditionId
-                                        id
-                                        patronGroupId
-                                        value
-                                        condition {
-                                          blockBorrowing
-                                          blockRenewals
-                                          blockRequests
-                                          message
-                                          name
-                                          valueType
-                                        }
-                                      }
-                                    }
-                                    blocks {
-                                      message
-                                    }
-                                    manualBlocks {
-                                      desc
-                                    }
-                                    patronGroupId
-                                  }
-                              }",
+                       query: patron_graphql_query,
                        variables: { patronId: patron_uuid }
                      })
+    return nil if data.nil?
 
     Honeybadger.notify(data['errors'].pluck('message').join("\n"), context: { patron_uuid: }) if data.key?('errors')
 
-    data.dig('data', 'user')
-  end
+    user_node = data.dig('data', 'user')
+    return nil if user_node.nil?
 
-  def extended_patron_info(patron_uuid)
-    data = post_json('/', json: {
-                       query: "query Query($patronId: UUID!) {
-                                patron(id: $patronId) {
-                                  id
-                                  holds {
-                                    requestDate
-                                    item {
-                                      instanceId
-                                      title
-                                      itemId
-
-                                      item {
-                                        circulationNotes {
-                                          id
-                                          noteType
-                                          note
-                                          source {
-                                            personal {
-                                              lastName
-                                            }
-                                            id
-                                          }
-                                          date
-                                          staffOnly
-                                        }
-                                        effectiveShelvingOrder
-                                        effectiveCallNumberComponents {
-                                          callNumber
-                                        }
-                                        enumeration
-                                        volume
-                                        permanentLocation {
-                                          code
-                                        }
-                                        effectiveLocation {
-                                          id
-                                          code
-                                          details {
-                                            pageServicePoints {
-                                              code
-                                              id
-                                              discoveryDisplayName
-                                              pickupLocation
-                                            }
-                                          }
-                                        }
-                                        holdingsRecord {
-                                          effectiveLocation {
-                                            id
-                                            code
-                                          }
-                                        }
-                                      }
-                                      author
-                                      instance {
-                                        #{instance_fields}
-                                      }
-                                      isbn
-                                    }
-                                    requestId
-                                    status
-                                    expirationDate
-                                    details {
-                                      holdShelfExpirationDate
-                                      proxyUserId
-                                      proxy {
-                                        firstName
-                                        lastName
-                                        barcode
-                                      }
-                                    }
-                                    pickupLocationId
-                                    pickupLocation {
-                                      code
-                                    }
-                                    queueTotalLength
-                                    queuePosition
-                                    cancellationReasonId
-                                    canceledByUserId
-                                    cancellationAdditionalInformation
-                                    canceledDate
-                                    patronComments
-                                  }
-                                  accounts {
-                                    id
-                                    userId
-                                    remaining
-                                    dateCreated
-                                    amount
-                                    loanId
-                                    loan {
-                                      proxyUserId
-                                    }
-                                    status {
-                                      name
-                                    }
-                                    feeFine {
-                                      feeFineType
-                                    }
-                                    actions {
-                                      dateAction
-                                      typeAction
-                                    }
-                                    metadata {
-                                      createdDate
-                                    }
-                                    paymentStatus {
-                                      name
-                                    }
-                                    item {
-                                      id
-                                      barcode
-                                      effectiveShelvingOrder
-                                      effectiveLocation {
-                                        id
-                                        code
-                                      }
-                                      permanentLocation {
-                                        code
-                                      }
-                                      instance {
-                                        #{instance_fields}
-                                      }
-                                      holdingsRecord {
-                                        callNumber
-                                        effectiveLocation {
-                                          id
-                                          code
-                                        }
-                                      }
-                                    }
-                                  }
-                                  loans {
-                                    id
-                                    item {
-                                      title
-                                      author
-                                      instanceId
-                                      itemId
-                                      isbn
-                                      instance {
-                                        #{instance_fields}
-                                      }
-                                      item {
-                                        barcode
-                                        id
-                                        status {
-                                          date
-                                          name
-                                        }
-                                        effectiveShelvingOrder
-                                        effectiveCallNumberComponents {
-                                          callNumber
-                                        }
-                                        permanentLoanTypeId
-                                        temporaryLoanTypeId
-                                        materialTypeId
-                                        effectiveLocationId
-                                        effectiveLocation {
-                                          id
-                                          code
-                                        }
-                                        permanentLocation {
-                                          code
-                                        }
-                                        holdingsRecord {
-                                          effectiveLocation {
-                                            id
-                                            code
-                                          }
-                                        }
-                                        queueTotalLength
-                                      }
-                                    }
-                                    loanDate
-                                    dueDate
-                                    overdue
-                                    details {
-                                      renewalCount
-                                      dueDateChangedByRecall
-                                      dueDateChangedByHold
-                                      proxyUserId
-                                      userId
-                                      status {
-                                        name
-                                      }
-                                      feesAndFines {
-                                        amountRemainingToPay
-                                      }
-                                    }
-                                  }
-                                  totalCharges {
-                                    isoCurrencyCode
-                                    amount
-                                  }
-                                  totalChargesCount
-                                  totalLoans
-                                  totalHolds
-                                }
-                              }",
-                       variables: { patronId: patron_uuid }
-                     })
-
-    Honeybadger.notify(data['errors'].pluck('message').join("\n"), context: { patron_uuid: }) if data.key?('errors')
-
-    data.dig('data', 'patron')
+    patron_node = data.dig('data', 'patron') || {}
+    patron_node.merge('user' => user_node)
   end
 
   # rubocop:enable Metrics/MethodLength
+
+  # A convenience method so it is easy to copy the giant query for testing
+  def patron_graphql_query
+    <<~GQL
+      query PatronGraphqlResponse($patronId: UUID!) {
+        user(id: $patronId) { #{user_fields} }
+        patron(id: $patronId) { #{patron_fields} }
+      }
+    GQL
+  end
+
+  def user_fields
+    <<-GQL
+      id
+      username
+      barcode
+      active
+      personal {
+        email
+        lastName
+        firstName
+        preferredFirstName
+        phone
+        addresses {
+          addressLine1
+          addressLine2
+          city
+          region
+          countryId
+          postalCode
+          primaryAddress
+          addressTypeId
+        }
+      }
+      proxiesFor {
+        userId
+        requestForSponsor
+        status
+        expirationDate
+        user {
+          id
+          barcode
+          personal {
+            firstName
+            preferredFirstName
+            lastName
+          }
+        }
+      }
+      proxiesOf {
+        proxyUserId
+        requestForSponsor
+        status
+        expirationDate
+        proxyUser {
+          id
+          barcode
+          personal {
+            firstName
+            preferredFirstName
+            lastName
+          }
+        }
+      }
+      expirationDate
+      externalSystemId
+      patronGroup {
+        id
+        desc
+        group
+        limits {
+          conditionId
+          id
+          patronGroupId
+          value
+          condition {
+            blockBorrowing
+            blockRenewals
+            blockRequests
+            message
+            name
+            valueType
+          }
+        }
+      }
+      blocks {
+        message
+      }
+      manualBlocks {
+        desc
+      }
+      patronGroupId
+    GQL
+  end
+
+  def patron_fields
+    <<-GQL
+      id
+      holds {
+        requestDate
+        item {
+          instanceId
+          title
+          itemId
+          item {
+            circulationNotes {
+              id
+              noteType
+              note
+              source {
+                personal {
+                  lastName
+                }
+                id
+              }
+              date
+              staffOnly
+            }
+            effectiveShelvingOrder
+            effectiveCallNumberComponents {
+              callNumber
+            }
+            enumeration
+            volume
+            permanentLocation {
+              code
+            }
+            effectiveLocation {
+              id
+              code
+              details {
+                pageServicePoints {
+                  code
+                  id
+                  discoveryDisplayName
+                  pickupLocation
+                }
+              }
+            }
+            holdingsRecord {
+              effectiveLocation {
+                id
+                code
+              }
+            }
+          }
+          author
+          instance {
+            #{instance_fields}
+          }
+          isbn
+        }
+        requestId
+        status
+        expirationDate
+        details {
+          holdShelfExpirationDate
+          proxyUserId
+          proxy {
+            firstName
+            lastName
+            barcode
+          }
+        }
+        pickupLocationId
+        pickupLocation {
+          code
+        }
+        queueTotalLength
+        queuePosition
+        cancellationReasonId
+        canceledByUserId
+        cancellationAdditionalInformation
+        canceledDate
+        patronComments
+      }
+      accounts {
+        id
+        userId
+        remaining
+        dateCreated
+        amount
+        loanId
+        loan {
+          proxyUserId
+        }
+        status {
+          name
+        }
+        feeFine {
+          feeFineType
+        }
+        actions {
+          dateAction
+          typeAction
+        }
+        metadata {
+          createdDate
+        }
+        paymentStatus {
+          name
+        }
+        item {
+          id
+          barcode
+          effectiveShelvingOrder
+          effectiveLocation {
+            id
+            code
+          }
+          permanentLocation {
+            code
+          }
+          instance {
+            #{instance_fields}
+          }
+          holdingsRecord {
+            callNumber
+            effectiveLocation {
+              id
+              code
+            }
+          }
+        }
+      }
+      loans {
+        id
+        item {
+          title
+          author
+          instanceId
+          itemId
+          isbn
+          instance {
+            #{instance_fields}
+          }
+          item {
+            barcode
+            id
+            status {
+              date
+              name
+            }
+            effectiveShelvingOrder
+            effectiveCallNumberComponents {
+              callNumber
+            }
+            permanentLoanTypeId
+            temporaryLoanTypeId
+            materialTypeId
+            effectiveLocationId
+            effectiveLocation {
+              id
+              code
+            }
+            permanentLocation {
+              code
+            }
+            holdingsRecord {
+              effectiveLocation {
+                id
+                code
+              }
+            }
+            queueTotalLength
+          }
+        }
+        loanDate
+        dueDate
+        overdue
+        details {
+          renewalCount
+          dueDateChangedByRecall
+          dueDateChangedByHold
+          proxyUserId
+          userId
+          status {
+            name
+          }
+          feesAndFines {
+            amountRemainingToPay
+          }
+        }
+      }
+      totalCharges {
+        isoCurrencyCode
+        amount
+      }
+      totalChargesCount
+      totalLoans
+      totalHolds
+    GQL
+  end
+
   def item_fields
     <<-GQL
       id

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe 'Proxy User' do
     allow(Folio::LoanPolicy).to receive(:new).and_return(build(:grad_mono_loans))
 
     allow(Folio::Patron).to receive(:find_by).with(patron_key: patron.key).and_return(patron)
-    allow(mock_client).to receive(:extended_user_info).with(sponsor.key).and_return(sponsor.send(:extended_user_info))
-    allow(mock_client).to receive(:extended_patron_info).with(sponsor.key).and_return(sponsor.send(:patron_graphql_response))
+    allow(mock_client).to receive(:patron_graphql_response).with(sponsor.key).and_return(sponsor.send(:patron_graphql_response))
 
     login_as(CurrentUser.new(username: 'stub_user', patron_key: patron.key, shibboleth: true))
   end

--- a/spec/models/folio/patron_spec.rb
+++ b/spec/models/folio/patron_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Folio::Patron do
     end
 
     describe '#make_request_as_patron?' do
-      let(:folio_client) { instance_double(FolioClient, extended_user_info:) }
+      let(:folio_client) { instance_double(FolioClient) }
       let(:extended_user_info) do
         { 'blocks' => [
           {

--- a/spec/services/folio_graphql_client_spec.rb
+++ b/spec/services/folio_graphql_client_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FolioGraphqlClient do
+  subject(:client) { described_class.new(url:) }
+
+  let(:url) { 'https://graphql.example.edu' }
+  let(:patron_uuid) { '562a5cb0-e998-4ea2-80aa-34ac2b536238' }
+
+  describe '#patron_graphql_response' do
+    subject(:response) { client.patron_graphql_response(patron_uuid) }
+
+    context 'when both user and patron nodes are returned' do
+      before do
+        stub_request(:post, 'https://graphql.example.edu/')
+          .to_return(
+            body: {
+              data: {
+                user: { 'id' => patron_uuid, 'username' => 'jdoe', 'patronGroupId' => 'pg-uuid' },
+                patron: { 'id' => patron_uuid, 'holds' => [], 'accounts' => [], 'loans' => [{ 'id' => 'loan-1' }] }
+              }
+            }.to_json,
+            status: 200
+          )
+      end
+
+      it 'merges the user node under the "user" key in the patron node' do
+        expect(response).to include(
+          'id' => patron_uuid,
+          'holds' => [],
+          'accounts' => [],
+          'loans' => [{ 'id' => 'loan-1' }],
+          'user' => { 'id' => patron_uuid, 'username' => 'jdoe', 'patronGroupId' => 'pg-uuid' }
+        )
+      end
+    end
+
+    context 'when the response body is empty' do
+      before do
+        stub_request(:post, 'https://graphql.example.edu/').to_return(body: '', status: 200)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the user node is nil (patron not found)' do
+      before do
+        stub_request(:post, 'https://graphql.example.edu/')
+          .to_return(body: { data: { user: nil, patron: nil } }.to_json, status: 200)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the patron node is nil but the user node is present' do
+      before do
+        stub_request(:post, 'https://graphql.example.edu/')
+          .to_return(
+            body: { data: { user: { 'id' => patron_uuid }, patron: nil } }.to_json,
+            status: 200
+          )
+      end
+
+      it 'returns a response with just the user node' do
+        expect(response).to eq('user' => { 'id' => patron_uuid })
+      end
+    end
+
+    context 'when the response includes GraphQL errors' do
+      before do
+        stub_request(:post, 'https://graphql.example.edu/')
+          .to_return(
+            body: {
+              errors: [{ 'message' => 'something went wrong' }],
+              data: { user: { 'id' => patron_uuid }, patron: { 'id' => patron_uuid, 'holds' => [] } }
+            }.to_json,
+            status: 200
+          )
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'notifies Honeybadger with the error messages' do
+        response
+        expect(Honeybadger).to have_received(:notify).with('something went wrong', context: { patron_uuid: })
+      end
+
+      it 'still returns the merged response' do
+        expect(response).to include('id' => patron_uuid, 'user' => { 'id' => patron_uuid })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small increase in performance. Example for my user:

### Borrowed items
main:
```
[folio benchmark] request.folio 664.2ms
[folio benchmark] request.folio 284.2ms
```

single:
```
[folio benchmark] request.folio 708.2ms
```


### Fees and fines
main:
```
[folio benchmark] request.folio 674.0ms
[folio benchmark] request.folio 325.4ms
```

single:
```
[folio benchmark] request.folio 652.6ms
```

### A [request](http://localhost:3000/patron_requests/new?instance_hrid=L222&origin_location_code=LANE-SAL3)
main:
```
[folio benchmark] REST  231.8ms POST /authn/login
[folio benchmark] REST  203.5ms GET /users
[folio benchmark] GQL   1127.9ms InstanceByHrid
[folio benchmark] GQL   328.2ms PatronGraphqlResponse
```

single:
```
[folio benchmark] REST 185.1ms POST /authn/login
[folio benchmark] REST 200.6ms GET /users
[folio benchmark] GQL  1075.6ms InstanceByHrid
[folio benchmark] GQL  1212.0ms PatronGraphqlResponse
```

- [ ] Find and squash the request query issue