### PR TITLE
Add create_appointment attribute to ReadingRoomBriefComponent so we render the correct thing

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -688,10 +688,6 @@ summary .disclosure-icon::before {
   --bs-btn-disabled-border-color: rgba(var(--stanford-cardinal-rgb), 0.3);
 }
 
-.modal-location .hide-when-1-item {
-  display: none;
-}
-
 #aeon-appointments-frame .card {
   --bs-card-border-color: var(--stanford-20-black);
 }

--- a/app/components/aeon/reading_room_brief_component.html.erb
+++ b/app/components/aeon/reading_room_brief_component.html.erb
@@ -9,7 +9,9 @@
       Hours: <%= reading_room.human_readable_hours %>
     </span>
   </div>
-  <%= link_to new_aeon_appointment_path(aeon_appointment: { reading_room_id: reading_room.id }), class: 'btn btn-primary hide-when-1-item text-nowrap', data: { action: 'modal#open' } do %>
-    <i class="bi bi-calendar-plus me-1"></i>Create new appointment
+  <% if create_appointment? %>
+    <%= link_to new_aeon_appointment_path(aeon_appointment: { reading_room_id: reading_room.id }), class: 'btn btn-primary hide-when-1-item text-nowrap', data: { action: 'modal#open' } do %>
+      <i class="bi bi-calendar-plus me-1"></i>Create new appointment
+    <% end %>
   <% end %>
 </div>

--- a/app/components/aeon/reading_room_brief_component.rb
+++ b/app/components/aeon/reading_room_brief_component.rb
@@ -3,8 +3,13 @@
 module Aeon
   # Render an accordion item for a digitization form step.
   class ReadingRoomBriefComponent < ViewComponent::Base
-    def initialize(reading_room:)
+    def initialize(reading_room:, create_appointment: false)
       @reading_room = reading_room
+      @create_appointment = create_appointment
+    end
+
+    def create_appointment?
+      @create_appointment
     end
 
     attr_reader :reading_room

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   </div>
 
-  <%= render Aeon::ReadingRoomBriefComponent.new(reading_room: f.object.aeon_reading_room) %>
+  <%= render Aeon::ReadingRoomBriefComponent.new(reading_room: f.object.aeon_reading_room, create_appointment: true) %>
 
   <div>
     <%= render 'save_for_later' %>

--- a/spec/component_previews/aeon/reading_room_brief_component_preview.rb
+++ b/spec/component_previews/aeon/reading_room_brief_component_preview.rb
@@ -8,25 +8,25 @@ module Aeon
     def spec
       @reading_room = Aeon::ReadingRoom.find_by(site: 'SPECUA')
 
-      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room)
+      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room, create_appointment: true)
     end
 
     def rumsey
       @reading_room = Aeon::ReadingRoom.find_by(site: 'RUMSEY')
 
-      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room)
+      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room, create_appointment: true)
     end
 
     def eal
       @reading_room = Aeon::ReadingRoom.find_by(site: 'EASTASIA')
 
-      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room)
+      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room, create_appointment: true)
     end
 
     def ars
       @reading_room = Aeon::ReadingRoom.find_by(site: 'ARS')
 
-      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room)
+      render Aeon::ReadingRoomBriefComponent.new(reading_room: @reading_room, create_appointment: true)
     end
     # @!endgroup
   end


### PR DESCRIPTION
We're re-using `ReadingRoomBriefComponent` in the patron request form (where we sometimes need the contrl) and the edit aeon request form (where we never do). Let's just not render it if we're not going to use it.