### PR TITLE
Updated save-for-later to stash the data into a template

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -443,7 +443,7 @@ summary .disclosure-icon::before {
   }
 }
 
-.appointments-item:only-child {
+.selected-items-container:not(:has(.saved-item)) .appointments-item:only-child {
   padding-left: 0;
   row-gap: 1.5rem;
   grid-template-columns: auto 1fr;
@@ -470,8 +470,9 @@ summary .disclosure-icon::before {
   align-items: center;
 }
 
-#reading:has(.appointments-item:only-child),
-#pickup:has(.appointments-item:only-child) {
+#reading:has(.appointments-item:only-child):not(:has(.saved-item)),
+#reading:not(:has(.appointments-item)),
+#pickup:has(.appointments-item:only-child):not(:has(.saved-item)) {
   .hide-when-1-item {
     display: none;
   }
@@ -482,7 +483,7 @@ summary .disclosure-icon::before {
     display: none;
   }
 
-  .appointments-item:not(:only-child) {
+  .appointments-item {
     /* .border */
     border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
     /* explicitly setting position:relative on its parent
@@ -510,76 +511,75 @@ summary .disclosure-icon::before {
     }
   }
 
-  .appointments-item:only-child,
-  .accordion-item:only-child,
-  .activity-item
-  {
-    --bs-accordion-border-width: 0;
-    --bs-accordion-active-bg: transparent;
-    --bs-accordion-btn-bg: transparent;
+  &:not(:has(.saved-item)) {
+    .appointments-item:only-child,
+    .accordion-item:only-child,
+    .activity-item
+    {
+      --bs-accordion-border-width: 0;
+      --bs-accordion-active-bg: transparent;
+      --bs-accordion-btn-bg: transparent;
+      border: none !important;
+      background: transparent !important;
 
-    .accordion-button {
-      background-color: transparent;
-      border-width: 0;
-    }
+      .accordion-button {
+        background-color: transparent;
+        border-width: 0;
+      }
 
-    .selected-item-status, .selected-item-remove, .disclosure-icon, .accordion-header-icon {
-      display: none;
+      .accordion-body {
+        padding-inline-start: 0 !important;
+      }
+
+      &:is(.appointments-item), .accordion-header {
+        padding-inline-start: 0 !important;
+      }
+
+      .selected-item-status, .selected-item-remove, .disclosure-icon, .accordion-header-icon {
+        display: none !important;
+      }
+
+      .create-appointment-section {
+        display: block !important;
+      }
     }
   }
-  .accordion-item .accordion-header > div {
-    margin-inline-start: 1rem;
+
+  .accordion-item .accordion-header {
+    padding-inline-start: 0.5rem;
   }
 
-  .appointments-item[data-selected-item-form-status-value="complete"]:not(:only-child) {
+  .appointments-item[data-selected-item-form-status-value="complete"],
+  .accordion-item[data-selected-item-form-status-value="complete"] .accordion-header {
     padding-inline-start: 2rem;
+
     @media (min-width: 576px) {
       padding-inline-start: 2.5rem;
     }
-  }
-
-  .accordion-item[data-selected-item-form-status-value="complete"]:not(:only-child) .accordion-header > div {
-    margin-inline-start: 2rem;
-    @media (min-width: 576px) {
-      margin-inline-start: 2.5rem;
-    }
-  }
-
-  .appointments-item[data-selected-item-form-status-value="complete"]:not(:only-child),
-  .accordion-item[data-selected-item-form-status-value="complete"]:not(:only-child) .accordion-header {
-    &::before {
-      content: '';
-      position: absolute;
-      left: calc(-1 * var(--bs-border-width));
-      top: calc(-1 * var(--bs-border-width));
-      bottom: calc(-1 * var(--bs-border-width));
-      width: 1.75rem;
+    .selected-item-status {
       background-color: var(--stanford-digital-green);
       border-radius: inherit;
       border-start-end-radius: 0;
       border-end-end-radius: 0;
-    }
-
-    .selected-item-status {
       align-items: center;
       justify-content: center;
       color: #fff;
       display: flex;
       font-size: 1.25rem;
       position: absolute;
-      left: 0;
-      top: 0;
-      bottom: 0;
+      left: calc(-1 * var(--bs-border-width));
+      top: calc(-1 * var(--bs-border-width));
+      bottom: calc(-1 * var(--bs-border-width));
       width: 1.75rem;
     }
   }
 
-  .accordion-item[data-selected-item-form-status-value="complete"]:not(:only-child) .accordion-header::before {
+  .accordion-item[data-selected-item-form-status-value="complete"] .accordion-header::before {
     border-end-start-radius: 0;
     bottom: 0;
   }
 
-  .accordion-item[data-selected-item-form-status-value="complete"]:not(:only-child) .accordion-header:has(.accordion-button[aria-expanded="false"])::before {
+  .accordion-item[data-selected-item-form-status-value="complete"] .accordion-header:has(.accordion-button[aria-expanded="false"])::before {
     border-end-start-radius: inherit;
     bottom: calc(-1 * var(--bs-border-width));
   }

--- a/app/javascript/controllers/save_for_later_controller.js
+++ b/app/javascript/controllers/save_for_later_controller.js
@@ -12,9 +12,18 @@ export default class extends Controller {
 
     const id = formItem.dataset.contentId
 
-    // Auto-expand the next visible sibling if this section uses expand/collapse
-    let nextItem = formItem.nextElementSibling
-    while (nextItem && !nextItem.offsetParent) nextItem = nextItem.nextElementSibling
+    if (formItem.classList.contains('accordion-item') && formItem.querySelector('.accordion-collapse.show')) {
+      // Auto-expand the next sibling that is not completed, or wrap around to the first incomplete sibling
+      const siblings = Array.from(formItem.parentElement.children)
+      const currentIndex = siblings.indexOf(formItem)
+      let nextItem = siblings.slice(currentIndex + 1).find(item => item.matches('[data-selected-item-form-status-value="incomplete"]'))
+      if (!nextItem) {
+        nextItem = siblings.slice(0, currentIndex).find(item => item.matches('[data-selected-item-form-status-value="incomplete"]'))
+      }
+
+      const nextCollapse = nextItem?.querySelector('.accordion-collapse')
+      if (nextCollapse) Collapse.getOrCreateInstance(nextCollapse).show()
+    }
 
     // move all the form items (acorss all the different sections) into the saved-for-later state
     this.formItemsFor(id).forEach(item => {
@@ -31,10 +40,6 @@ export default class extends Controller {
       savedItem.appendChild(template);
       savedForLaterList.appendChild(savedItem)
     })
-
-
-    const nextCollapse = nextItem?.querySelector('.accordion-collapse')
-    if (nextCollapse) Collapse.getOrCreateInstance(nextCollapse).show()
 
     this.dispatch('changed')
   }

--- a/app/javascript/controllers/save_for_later_controller.js
+++ b/app/javascript/controllers/save_for_later_controller.js
@@ -11,19 +11,28 @@ export default class extends Controller {
     if (!formItem) return
 
     const id = formItem.dataset.contentId
-    const originSection = this.sectionTargets.find(section => section.contains(formItem))
-    if (originSection) this.clearRequiredInputs(originSection, id)
-
-    this.formItemsFor(id).forEach(item => {
-      item.classList.add('d-none')
-      item.setAttribute('data-saved-for-later', '')
-    })
-
-    this.listTargets.forEach(list => list.appendChild(this.makeSavedItem(formItem)))
 
     // Auto-expand the next visible sibling if this section uses expand/collapse
     let nextItem = formItem.nextElementSibling
     while (nextItem && !nextItem.offsetParent) nextItem = nextItem.nextElementSibling
+
+    // move all the form items (acorss all the different sections) into the saved-for-later state
+    this.formItemsFor(id).forEach(item => {
+      const section = item.closest('[data-save-for-later-target="section"]')
+      const savedForLaterList = section.querySelector('[data-save-for-later-target="list"]')
+      const savedItem = this.makeSavedItem(item)
+      const appt = item.querySelector('input[name$="[appointment_id]"]')
+      if (appt) {
+        appt.value = ''
+        appt.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+      const template = document.createElement('template')
+      template.content.replaceChildren(item);
+      savedItem.appendChild(template);
+      savedForLaterList.appendChild(savedItem)
+    })
+
+
     const nextCollapse = nextItem?.querySelector('.accordion-collapse')
     if (nextCollapse) Collapse.getOrCreateInstance(nextCollapse).show()
 
@@ -38,27 +47,17 @@ export default class extends Controller {
 
     const id = savedClone.dataset.contentId
 
-    this.formItemsFor(id).forEach(item => {
-      item.classList.remove('d-none')
-      item.removeAttribute('data-saved-for-later')
-      // Re-run selected-item-form validation now that the item is visible again.
-      item.querySelectorAll('[data-required-for-submit]').forEach(input => {
-        input.dispatchEvent(new Event('input', { bubbles: true }))
-      })
-    })
-
-    this.listTargets.forEach(list => {
-      list.querySelectorAll(`[data-content-id="${id}"]`).forEach(el => el.remove())
-    })
+    this.sectionTargets.forEach(section => {
+      const savedForLaterList = section.querySelector('[data-save-for-later-target="list"]')
+      const savedItem = savedForLaterList.querySelector(`[data-content-id="${id}"]`);
+      const template = savedItem.querySelector('template')
+      const rehydratedItem = document.importNode(template.content, true)
+      const selectedItemList = section.querySelector('[data-item-selector-target="selectedItems"]')
+      selectedItemList.appendChild(rehydratedItem)
+      savedItem.remove();
+    });
 
     this.dispatch('changed')
-  }
-
-  clearRequiredInputs(section, id) {
-    section.querySelectorAll(`[data-content-id="${id}"] [data-required-for-submit]`).forEach(input => {
-      input.value = ''
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-    })
   }
 
   formItemsFor(id) {

--- a/app/views/patron_requests/_activity.html.erb
+++ b/app/views/patron_requests/_activity.html.erb
@@ -4,6 +4,9 @@
       <span class="text-black fw-semibold selected-item-title">__TITLE__</span>
     </div>
   </template>
+
+  <ul class="d-none" data-save-for-later-target="list"></ul>
+
   <div class="selected-items-container px-0 gap-3 d-flex flex-row flex-wrap" data-item-selector-target="selectedItems" data-template="#activityTemplate">
   </div>
 

--- a/app/views/patron_requests/_activity.html.erb
+++ b/app/views/patron_requests/_activity.html.erb
@@ -1,4 +1,4 @@
-<div class="row p-3">
+<div class="row p-3 selected-items-container">
   <template id="activityTemplate">
     <div class="activity-item" data-content-id="__ID__">
       <span class="text-black fw-semibold selected-item-title">__TITLE__</span>
@@ -7,7 +7,7 @@
 
   <ul class="d-none" data-save-for-later-target="list"></ul>
 
-  <div class="selected-items-container px-0 gap-3 d-flex flex-row flex-wrap" data-item-selector-target="selectedItems" data-template="#activityTemplate">
+  <div class="px-0 gap-3 d-flex flex-row flex-wrap" data-item-selector-target="selectedItems" data-template="#activityTemplate">
   </div>
 
   <fieldset class="mt-4 p-2 pb-0 border rounded overflow-y-scroll overflow-x-hidden" style="max-height: 400px">

--- a/app/views/patron_requests/_digitization_options.html.erb
+++ b/app/views/patron_requests/_digitization_options.html.erb
@@ -1,8 +1,8 @@
-<div class="row p-3 pt-0 gap-3 flex-column flex-md-row">
+<div class="row p-3 pt-0 gap-3 flex-column flex-md-row selected-items-container">
   <%= render 'digitization_notice' %>
 
   <%= render 'save_for_later' %>
-  <div class="accordion digitization-accordion selected-items-container px-0" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
+  <div class="accordion digitization-accordion px-0" data-patron-request-target="digitizationItems" data-item-selector-target="selectedItems" data-template="#digitizationTemplate">
     <% if f.object.selectable_items.one? %>
       <%= render Aeon::DigitizationFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", accordion: false) %>
     <% end %>

--- a/app/views/patron_requests/_reading_options.html.erb
+++ b/app/views/patron_requests/_reading_options.html.erb
@@ -1,4 +1,4 @@
-<div class="row p-3 pt-0 gap-4 flex-column flex-md-row">
+<div class="row p-3 pt-0 gap-4 flex-column flex-md-row selected-items-container">
   <% appointments = current_user.aeon.appointments.for_site(f.object.aeon_site) %>
   <div id="new-appt-alert">
     <% if appointments.blank? %>
@@ -16,7 +16,7 @@
 
   <div>
     <%= render 'save_for_later' %>
-    <ul class="appointments-container list-unstyled selected-items-container mb-0" data-item-selector-target="selectedItems" data-template="#appointmentTemplate">
+    <ul class="appointments-container list-unstyled mb-0" data-item-selector-target="selectedItems" data-template="#appointmentTemplate">
       <% if f.object.selectable_items.one? %>
         <%= render Aeon::AppointmentFormItemComponent.new(title: f.object.selectable_items.first.callnumber, dom_id: f.object.selectable_items.first.id, base_name: "patron_request[aeon_item][#{f.object.selectable_items.first.id}]", reading_room_id: f.object.aeon_reading_room.id, appointments: appointments) %>
       <% end %>

--- a/spec/component_previews/appointment_form_item_component_preview/default.html.erb
+++ b/spec/component_previews/appointment_form_item_component_preview/default.html.erb
@@ -36,3 +36,22 @@
       ) %>
   </ul>
 </form>
+
+
+<form id="reading-accordion3" class="col-lg-9 selected-items-container">
+  <div class="save-for-later border rounded p-3 mb-3">
+    <h3 class="h4 text-cardinal"><i class="bi bi-pin-angle-fill me-2 text-digital-red"></i>Save for later</h3>
+    <ul class="list-unstyled mb-0" data-save-for-later-target="list">
+      <li class="saved-item">Saved for later item</li>
+    </ul>
+  </div>
+
+  <ul id="reading3" class="appointments-container list-unstyled">
+    <%=
+      render Aeon::AppointmentFormItemComponent.new(
+        title: 'Item 1',
+        dom_id: 'item_1',
+        appointments: appointments
+      ) %>
+  </ul>
+</form>


### PR DESCRIPTION
I don't hate it.

TODO:
- [x] update appointment counts when an item is saved for later
- [x] something funky when you save-for-later the last element (pre-existing, but maybe easier to reason about now)
- [x] decide if we want to keep the accordion styling if you have any items saved-for-later (current behavior, maybe intentional?)