### PR TITLE
Remove extra mb-3 (already added to .request-group.card)

### DIFF
--- a/app/components/aeon/request_group_per_appointment_component.rb
+++ b/app/components/aeon/request_group_per_appointment_component.rb
@@ -9,7 +9,7 @@ module Aeon
 
     attr_reader :classes
 
-    def initialize(request_group:, classes: %w[card rounded-0 px-3 py-2 mb-3])
+    def initialize(request_group:, classes: %w[card rounded-0 px-3 py-2])
       @request_group = request_group
       @classes = Array(classes)
     end


### PR DESCRIPTION
This margin is already awkwardly added by the selector `.request-group-per-appointment.request-group.card` in the css (and we remove it from the last item...)