### PR TITLE
Stop dangling orphans in item titles

### DIFF
--- a/app/assets/stylesheets/utility.css
+++ b/app/assets/stylesheets/utility.css
@@ -138,3 +138,7 @@ label.btn-close {
   border-color: rgba(var(--stanford-digital-blue-dark-rgb), 1);
   text-decoration: underline;
 }
+
+.text-pretty {
+  text-wrap: pretty;
+}

--- a/app/components/aeon/request_item_identifier_component.rb
+++ b/app/components/aeon/request_item_identifier_component.rb
@@ -7,7 +7,7 @@ module Aeon
 
     delegate :ead?, :volume, to: :request
 
-    def initialize(request:, classes: %w[request-item-identifier fw-semibold], wrapper_tag: nil, wrapper_classes: [])
+    def initialize(request:, classes: %w[request-item-identifier fw-semibold text-pretty], wrapper_tag: nil, wrapper_classes: [])
       @request = request
       @classes = Array(classes)
       @wrapper_tag = wrapper_tag


### PR DESCRIPTION
e.g. 
Before:

<img width="348" height="125" alt="Screenshot 2026-07-09 at 10 42 02" src="https://github.com/user-attachments/assets/3e93682e-cbfc-4262-90fa-0a6bd4850cc2" />

After:
<img width="412" height="121" alt="Screenshot 2026-07-09 at 10 42 16" src="https://github.com/user-attachments/assets/038bc700-9174-453f-b0bb-39eaecee21fd" />
