### PR TITLE
Add open hours to the add items modal.

### DIFF
--- a/app/views/aeon_appointments/items.html.erb
+++ b/app/views/aeon_appointments/items.html.erb
@@ -9,8 +9,8 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="d-flex flex-row justify-content-between align-items-center">
-          <div class="d-flex flex-row gap-2">
-            <%= render Aeon::AppointmentDateTimeComponent.new(appointment: @appointment, show_open_hours: false, location: @appointment.reading_room.name) %>
+          <div class="d-flex flex-row gap-2 fw-semibold">
+            <%= render Aeon::AppointmentDateTimeComponent.new(appointment: @appointment, location: @appointment.reading_room.name) %>
           </div>
           <div><%= render Aeon::AppointmentLimitComponent.from_appointment(@appointment, data: { action: 'items-updated@window->progress-bar#updateCount' }) %></div>
         </div>


### PR DESCRIPTION
Updated designs seem to have this information now.