### PR TITLE
Ensure unique dom ids.

### DIFF
--- a/app/components/aeon/cancel_appointment_modal_component.html.erb
+++ b/app/components/aeon/cancel_appointment_modal_component.html.erb
@@ -11,12 +11,12 @@
           <%= render AlertComponent.new(type: :info, classes: ['mb-0', 'mt-3', 'border-0', 'shadow-none'], with_icon: false) do %>
             <strong><%= pluralize(appointment.requests.length, 'item') %></strong> <%= 'is'.pluralize(appointment.requests.length) %> assigned to this appointment.
             <div class="d-flex gap-1">
-              <%= f.radio_button :cancel_items, false %>
-              <%= f.label :cancel_items_false, 'Save items and schedule later' %>
+              <%= f.radio_button :cancel_items, false, id: dom_id(appointment, :cancel_items_false) %>
+              <%= f.label dom_id(appointment, :cancel_items_false), 'Save items and schedule later' %>
             </div>
             <div class="d-flex gap-1">
-              <%= f.radio_button :cancel_items, true %>
-              <%= f.label :cancel_items_true, 'Delete requested items' %>
+              <%= f.radio_button :cancel_items, true, id: dom_id(appointment, :cancel_items_true) %>
+              <%= f.label dom_id(appointment, :cancel_items_true), 'Delete requested items' %>
             </div>
           <% end %>
         <% end %>

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe 'Appointments', :js do
       expect(page).to have_css '.modal'
       perform_enqueued_jobs do
         expect(page).to have_text 'Cancel appointment?'
-        choose('cancel_items_false')
+        choose('Save items and schedule later')
         expect(page).to have_text '1 item is assigned to this appointment.'
         click_on 'Yes, cancel appointment'
       end
@@ -243,7 +243,7 @@ RSpec.describe 'Appointments', :js do
       expect(page).to have_css '.modal'
       perform_enqueued_jobs do
         expect(page).to have_text 'Cancel appointment?'
-        choose('cancel_items_true')
+        choose('Delete requested items')
         expect(page).to have_text '1 item is assigned to this appointment.'
         click_on 'Yes, cancel appointment'
       end


### PR DESCRIPTION
We pre-render all these forms, so our dom id needs to include the appointment.