### PR TITLE
Fix removal of requests from the activities page

### DIFF
--- a/app/components/aeon/remove_from_activity_button_component.rb
+++ b/app/components/aeon/remove_from_activity_button_component.rb
@@ -16,7 +16,8 @@ module Aeon
     def call
       form_with(url: aeon_request_path(request), method: :delete) do
         tag.button(type: :submit, class: 'btn btn-link su-underline') do
-          tag.i(class: 'bi bi-trash align-middle me-1', aria: { hidden: true }) + tag.span('Remove from activity', class: 'visually-hidden')
+          tag.i(class: 'bi bi-trash align-middle me-1', aria: { hidden: true }) +
+            tag.span("Remove #{request.title} from activity", class: 'visually-hidden')
         end
       end
     end

--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -113,14 +113,15 @@ class AeonRequestsController < ApplicationController
 
   def load_aeon_request
     @aeon_request = @aeon_requests.find(params[:id])
-    @aeon_request_group = @aeon_request_groups.find { |request_group| request_group.requests.include?(@aeon_request.id) }
   end
 
   def load_aeon_requests
     @aeon_requests = if params[:kind] == 'activity'
-                       current_user.aeon.all_requests.for_activities
-                     else
+                       current_user.aeon.own_and_activity_requests.for_activities
+                     elsif action_name == 'index'
                        current_user.aeon.requests
+                     else
+                       current_user.aeon.own_and_activity_requests
                      end
   end
 

--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -39,7 +39,7 @@ class PatronRequestsController < ApplicationController
 
   def show
     if @patron_request.aeon_page? && use_requests_redesign? # rubocop:disable Style/GuardClause
-      @aeon_requests = Aeon::RequestGrouping.new(current_user.aeon.all_requests.select do |x|
+      @aeon_requests = Aeon::RequestGrouping.new(current_user.aeon.own_and_activity_requests.select do |x|
         x.reference_number == @patron_request.to_global_id.to_s
       end)
       request.variant = :aeon

--- a/app/models/aeon/activity.rb
+++ b/app/models/aeon/activity.rb
@@ -46,13 +46,13 @@ module Aeon
     end
 
     def requests=(requests)
-      @requests = requests.sort_by { |r| [r.title.to_s, r.sort_key] }
+      @requests = requests.submitted.sort_by { |r| [r.title.to_s, r.sort_key] }
       @grouped_requests = nil
     end
 
     def requests
       @requests ||= begin
-        requests = users.flat_map { |u| u.all_requests.for_activity(self).submitted }.sort_by { |r| [r.title.to_s, r.sort_key] }
+        requests = users.flat_map { |u| u.own_requests.for_activity(self).submitted }.sort_by { |r| [r.title.to_s, r.sort_key] }
 
         Aeon::RequestFinders.new(requests)
       end

--- a/app/models/aeon/null_user.rb
+++ b/app/models/aeon/null_user.rb
@@ -12,10 +12,14 @@ module Aeon
     end
 
     def requests
-      @requests ||= all_requests
+      @requests ||= own_requests
     end
 
-    def all_requests
+    def own_and_activity_requests
+      Aeon::RequestFinders.new([])
+    end
+
+    def own_requests
       Aeon::RequestFinders.new([])
     end
 

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -33,12 +33,20 @@ module Aeon
       auth_type == 'Default'
     end
 
-    def all_requests
-      @all_requests ||= Aeon::RequestFinders.new(self.class.aeon_client.requests_for(username:))
+    def own_requests
+      @own_requests ||= Aeon::RequestFinders.new(self.class.aeon_client.requests_for(username:))
+    end
+
+    # All requests this user can see: own records plus submitted requests
+    # from shared activities (which may be owned by other activity members).
+    def own_and_activity_requests
+      @own_and_activity_requests ||= Aeon::RequestFinders.new(
+        (own_requests.to_a + activities.flat_map { |a| a.requests.to_a }).uniq(&:id)
+      )
     end
 
     def requests
-      @requests ||= all_requests.reject(&:activity?)
+      @requests ||= own_requests.reject(&:activity?)
     end
 
     def activities

--- a/app/services/aeon/update_response_service.rb
+++ b/app/services/aeon/update_response_service.rb
@@ -57,18 +57,22 @@ module Aeon
                         end
     end
 
-    def activities_to_update # rubocop:disable Metrics/AbcSize
-      activities = requests_to_update.reject { |r1, r2| r1.activity_id == r2.activity_id }
-                                     .flat_map { |r1, r2| [r1.activity, r2.activity] }
-                                     .flatten
-                                     .compact.uniq(&:id)
-                                     .map do |activity|
-        activity.tap do |appt|
-          appt.requests = next_requests.for_activity(activity)
-        end
-      end
+    def activities_to_update
+      requests_to_update.select { |r1, r2| activity_display_affected?(r1, r2) }
+                        .flat_map { |r1, r2| [r1.activity, r2.activity] }
+                        .flatten
+                        .compact.uniq(&:id).map do |activity|
+                          activity.tap do |appt|
+                            appt.requests = next_requests.for_activity(activity)
+                          end
+                        end
+    end
 
-      activities.select { |activity| activity.requests.none? }
+    private
+
+    def activity_display_affected?(updated, original)
+      updated.activity_id != original.activity_id ||
+        (updated.activity? && updated.status != original.status)
     end
   end
 end

--- a/spec/features/aeon_activities_spec.rb
+++ b/spec/features/aeon_activities_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe 'Activities', :js do
     expect(page).to have_text(/Exhibit/m)
     expect(page).to have_no_text('Activity2')
 
-    expect(page).to have_text('title1', count: 1)
+    expect(page).to have_css('h3', text: 'title1', count: 1)
     expect(page).to have_no_text('title2')
-    expect(page).to have_text('title3', count: 1)
+    expect(page).to have_css('h3', text: 'title3', count: 1)
     expect(page).to have_text('No items have been requested for this activity.', count: 1)
   end
 end

--- a/spec/features/aeon_requests_spec.rb
+++ b/spec/features/aeon_requests_spec.rb
@@ -140,4 +140,109 @@ RSpec.describe 'Requests', :js do
       expect(page).to have_no_css('.request-group', text: 'A Book')
     end
   end
+
+  describe 'attached to an activity' do
+    let(:activity) do
+      StubAeonClient::Activity.create(
+        beginDate: Time.zone.local(2026, 2, 19, 12, 0, 0).iso8601,
+        endDate: Time.zone.local(2026, 2, 19, 13, 0, 0).iso8601,
+        name: 'A Class Visit',
+        activityType: 'Class visit',
+        active: true,
+        activityStatus: 'Pending',
+        location: 'Special Collections',
+        users: [aeon_user],
+        id: 42
+      )
+    end
+
+    let(:activity_request) do
+      StubAeonClient::Request.create(
+        requestFor: { type: 'Activity', reference: 42 },
+        itemTitle: 'An Activity Book',
+        username: aeon_user.username,
+        webRequestForm: 'multiple',
+        transactionStatus: 1
+      )
+    end
+
+    before do
+      activity
+      activity_request
+    end
+
+    it 'removes the request from its activity when deleted' do
+      visit aeon_activities_path
+
+      expect(page).to have_text('An Activity Book')
+
+      click_on 'Remove An Activity Book from activity'
+
+      expect(page).to have_no_text('An Activity Book')
+    end
+
+    context 'when the activity has other request groups' do
+      let(:other_activity_request) do
+        StubAeonClient::Request.create(
+          requestFor: { type: 'Activity', reference: 42 },
+          itemTitle: 'Another Activity Book',
+          username: aeon_user.username,
+          webRequestForm: 'multiple',
+          transactionStatus: 1
+        )
+      end
+
+      before { other_activity_request }
+
+      it 'removes the empty group card while keeping the other group visible' do
+        visit aeon_activities_path
+
+        expect(page).to have_text('An Activity Book')
+        expect(page).to have_text('Another Activity Book')
+
+        click_on 'Remove An Activity Book from activity'
+
+        expect(page).to have_no_text('An Activity Book')
+        expect(page).to have_text('Another Activity Book')
+      end
+    end
+
+    context 'when the request belongs to another member of the activity' do
+      let(:other_aeon_user) { StubAeonClient::User.create(username: 'other@stanford.edu', authType: 'Default') }
+
+      let(:activity) do
+        StubAeonClient::Activity.create(
+          beginDate: Time.zone.local(2026, 2, 19, 12, 0, 0).iso8601,
+          endDate: Time.zone.local(2026, 2, 19, 13, 0, 0).iso8601,
+          name: 'A Class Visit',
+          activityType: 'Class visit',
+          active: true,
+          activityStatus: 'Pending',
+          location: 'Special Collections',
+          users: [aeon_user, other_aeon_user],
+          id: 42
+        )
+      end
+
+      let(:activity_request) do
+        StubAeonClient::Request.create(
+          requestFor: { type: 'Activity', reference: 42 },
+          itemTitle: 'An Activity Book',
+          username: other_aeon_user.username,
+          webRequestForm: 'multiple',
+          transactionStatus: 1
+        )
+      end
+
+      it 'removes the request from its activity when deleted' do
+        visit aeon_activities_path
+
+        expect(page).to have_text('An Activity Book')
+
+        click_on 'Remove An Activity Book from activity'
+
+        expect(page).to have_no_text('An Activity Book')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/sul-requests/issues/4020

I might be re-arranging deck chairs a bit with `requests`, `own_requests`, `own_and_activity_requests` but I spent way too long trying to remember what `all_requests` encompassed.