### PR TITLE
Consistently show the Aeon appointment loading indicator

### DIFF
--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["availability", "duration", "fieldset", "selection"]
+  static targets = ["availability", "duration", "fieldset", "selection", "placeholder"]
   static values = {
     availabilityRoute: String
   }
@@ -26,6 +26,8 @@ export default class extends Controller {
 
     if (!date) return;
 
+    this.updateFormStatus();
+
     const url =new URL(this.availabilityRouteValue);
     url.searchParams.append('date', date);
     url.searchParams.append('selected', startTime);
@@ -36,17 +38,7 @@ export default class extends Controller {
   }
 
   get availabilityPlaceholder() {
-    const label = document.createElement('label');
-    label.classList.add('visually-hidden-focusable', 'required-placeholder');
-    label.textContent = 'Loading avaiable appointments.';
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.classList.add('visually-hidden-focusable');
-    input.name = 'aeon_appointment[start_time]';
-    input.required = true;
-    label.appendChild(input);
-
-    return label;
+    return this.placeholderTarget.content.cloneNode(true);
   }
 
   updateBanner() {
@@ -80,12 +72,10 @@ export default class extends Controller {
   }
 
   updateFormStatus() {
-  const formData = new FormData(this.element);
-    if (!formData.get('aeon_appointment[duration]') || !formData.get('aeon_appointment[date]')) {
-      this.availabilityTarget.classList.add('form-incomplete');
-    } else {
-      this.availabilityTarget.classList.remove('form-incomplete');
-    }
+    const formData = new FormData(this.element);
+    const hasDate = !!formData.get('aeon_appointment[date]');
+    const hasDuration = !!formData.get('aeon_appointment[duration]');
+    this.availabilityTarget.classList.toggle('form-incomplete', !hasDate || !hasDuration);
   }
 
   applyDurationFilter() {

--- a/app/views/aeon_appointments/_availability_loading.html.erb
+++ b/app/views/aeon_appointments/_availability_loading.html.erb
@@ -1,0 +1,9 @@
+<fieldset class="mb-3 radio-button-group">
+  <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
+</fieldset>
+<div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
+<div class="selection-message">Select a date and duration to see available appointments.</div>
+<label class="visually-hidden-focusable required-placeholder">
+  Loading avaiable appointments.
+  <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
+</label>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -54,22 +54,11 @@
         </p>
       <% end %>
       <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, appointment_id: @appointment.id, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
-        <fieldset class="mb-3 radio-button-group">
-          <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
-          <% if @appointment.reading_room_id && @appointment.date %>
-            <div class="spinner-border text-primary" role="status">
-              <span class="visually-hidden">Loading...</span>
-            </div>
-          <% end %>
-        </fieldset>
-
-        <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
-        <div class="selection-message">Select a date and duration to see available appointments.</div>
-        <label class="visually-hidden-focusable required-placeholder">
-          Loading avaiable appointments.
-          <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
-        </label>
+        <%= render 'availability_loading', f: f %>
       </turbo-frame>
+      <template data-appointment-target="placeholder">
+        <%= render 'availability_loading', f: f %>
+      </template>
     <% end %>
     <% if @appointment.requests.any? %>
       <%= render AlertComponent.new(type: :info, classes: ['border-0', 'shadow-none', 'w-fit'], with_icon: false) do %>


### PR DESCRIPTION
Currently for edit appointment we show two loading indicators:

<img width="523" height="293" alt="Screenshot 2026-07-09 at 3 51 21 PM" src="https://github.com/user-attachments/assets/7ae891a0-57c0-4ab6-8a2e-cb5f38be6e73" />

For create (no initial date) we show none which drives me nuts because that's an 8 second wait for me without an indicator:
<img width="649" height="250" alt="Screenshot 2026-07-09 at 4 54 02 PM" src="https://github.com/user-attachments/assets/2933c726-3bbb-4d08-b8fc-1c63d88e39bc" />

This shows the same indicator in both:
<img width="804" height="346" alt="Screenshot 2026-07-09 at 4 55 34 PM" src="https://github.com/user-attachments/assets/3ce61a1c-2806-4f23-bd57-3186a9323455" />
