### PR TITLE
Send document type to Aeon

### DIFF
--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -196,6 +196,7 @@ class AeonClient
       {
         appointmentID: appointment_id&.to_i,
         callNumber: call_number&.strip&.truncate(255, omission:),
+        documentType: document_type&.strip&.truncate(255, omission:),
         eadNumber: ead_number&.strip&.truncate(255, omission:),
         forPublication: for_publication,
         format: format&.truncate(255, omission:),


### PR DESCRIPTION
No more 'Default' now that we have `document_type` hooked up

<img width="874" height="265" alt="Screenshot 2026-07-10 at 3 05 24 PM" src="https://github.com/user-attachments/assets/86750919-46f5-4ef9-80e9-8694471f2f64" />
