### PR TITLE
Update the feedback form

### DIFF
--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag(:div, class: @classes, id:, tabindex: "-1", aria: {labelledby: title_id, hidden: false}, data:) do %>
-  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+  <div class="<%= dialog_classes.join(' ') %>">
     <div class="modal-content">
       <% if custom_header %>
         <%= custom_header %>

--- a/app/components/modal_component.rb
+++ b/app/components/modal_component.rb
@@ -4,14 +4,17 @@
 class ModalComponent < ViewComponent::Base
   attr_reader :id, :data
 
+  SIZES = { sm: 'modal-sm', lg: 'modal-lg', xl: 'modal-xl' }.freeze
+
   renders_one :title
   renders_one :banner
   renders_one :custom_header, ->(classes: %w[modal-header fw-normal], &block) { tag.div(class: classes, &block) }
   renders_one :body, ->(classes: %w[modal-body fw-normal], &block) { tag.div(class: classes, &block) }
   renders_one :footer, ->(classes: %w[modal-footer], &block) { tag.div(class: classes, &block) }
 
-  def initialize(id:, classes: %w[modal fade], header_classes: [], data: {})
+  def initialize(id:, size: nil, classes: %w[modal fade], header_classes: [], data: {})
     @id = id
+    @size = size
     @data = data
     @classes = classes
     @header_classes = header_classes
@@ -19,5 +22,9 @@ class ModalComponent < ViewComponent::Base
 
   def title_id
     "title-#{id}"
+  end
+
+  def dialog_classes
+    ['modal-dialog', 'modal-dialog-centered', 'modal-dialog-scrollable', SIZES[@size]].compact
   end
 end

--- a/app/views/feedback_forms/_form.html.erb
+++ b/app/views/feedback_forms/_form.html.erb
@@ -1,4 +1,5 @@
 <% close_button = local_assigns.fetch(:close_button, true) %>
+<% reporting_url = local_assigns.fetch(:reporting_url) %>
 <%= form_tag feedback_form_path, method: :post, class:"feedback-form" do %>
   <div class="modal-body">
     <span class="d-none">
@@ -6,7 +7,7 @@
       <%= email_field_tag :email_address %><br>
       <%= hidden_field_tag :user_agent %>
       <%= hidden_field_tag :viewport %>
-      <%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
+      <%= hidden_field_tag :url, reporting_url, class:"reporting-from-field" %>
     </span>
     <div class="mb-3">
       <%= label_tag(:name, 'Name', class:"px-0 fw-bold mb-2") %>

--- a/app/views/feedback_forms/_modal.html.erb
+++ b/app/views/feedback_forms/_modal.html.erb
@@ -10,10 +10,10 @@
   <% end %>
   <% component.with_banner do %>
     <div class="bg-stanford-10-black py-1 px-3">
-      Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
+      Reporting from: <span class="reporting-from-field"><%= request.original_url %></span>
     </div>
   <% end %>
   <% component.with_body(classes: []) do %>
-    <%= render 'feedback_forms/form' %>
+    <%= render 'feedback_forms/form', reporting_url: request.original_url %>
   <% end %>
 <% end %>

--- a/app/views/feedback_forms/_modal.html.erb
+++ b/app/views/feedback_forms/_modal.html.erb
@@ -9,7 +9,7 @@
     </div>
   <% end %>
   <% component.with_banner do %>
-    <div class="bg-stanford-10-black py-1 px-3">
+    <div class="bg-stanford-10-black py-1 px-3 border">
       Reporting from: <span class="reporting-from-field"><%= request.original_url %></span>
     </div>
   <% end %>

--- a/app/views/feedback_forms/_modal.html.erb
+++ b/app/views/feedback_forms/_modal.html.erb
@@ -1,4 +1,4 @@
-<%= render ModalComponent.new(id: "feedback-form") do |component| %>
+<%= render ModalComponent.new(id: "feedback-form", size: :lg) do |component| %>
   <% component.with_custom_header do %>
     <div class="d-flex flex-row align-items-center flex-wrap w-100">
       <h1 class="modal-title order-1 me-auto h2" id="<%= component.title_id %>">Send Feedback</h1>

--- a/app/views/feedback_forms/new.html.erb
+++ b/app/views/feedback_forms/new.html.erb
@@ -1,5 +1,6 @@
+<% reporting_url = request.referer %>
 <h1 class="mt-2 mx-3">Send feedback</h1>
 <div class="bg-stanford-10-black py-1 px-2 my-0 mx-3">
-  Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
+  Reporting from: <span class="reporting-from-field"><%= reporting_url %></span>
 </div>
-<%= render 'feedback_forms/form', close_button: false %>
+<%= render 'feedback_forms/form', close_button: false, reporting_url: reporting_url %>


### PR DESCRIPTION
* Use `request.original_url` for the reporting URL in the modal. SearchWorks uses turbo to load the form for the modal, we don't, so we can't copy SearchWork's use of `referer` here. We've been receiving empty feedback URLs.
* We still want to use `referer` for the "open in new tab" feedback page.
* Switch to a large modal for the feedback form to match SearchWorks (and because it's nicer to type in)