### PR TITLE
Stop excluding proxy checkouts from the list of a patron's checkouts.

### DIFF
--- a/app/models/folio/null_patron.rb
+++ b/app/models/folio/null_patron.rb
@@ -72,7 +72,6 @@ module Folio
       true
     end
 
-    def all_checkouts = []
     def checkouts = []
     def all_accounts = []
     def fines = []

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -228,13 +228,8 @@ module Folio
       all_accounts.select(&:closed?)
     end
 
-    def all_checkouts
-      @all_checkouts ||= patron_graphql_response['loans']&.map { |checkout| Checkout.new(checkout, patron_group_id) }
-    end
-
-    # Self checkouts
     def checkouts
-      all_checkouts.reject(&:proxy_checkout?) || []
+      @checkouts ||= patron_graphql_response['loans']&.map { |checkout| Checkout.new(checkout, patron_group_id) } || []
     end
 
     # this is all requests including self and group/proxy
@@ -244,7 +239,7 @@ module Folio
 
     # Self requests from FOLIO
     def requests
-      @requests ||= folio_requests.reject(&:proxy_request?)
+      @requests ||= folio_requests
     end
 
     # ILLIAD requests are retrieved separately

--- a/app/models/folio/proxy_group.rb
+++ b/app/models/folio/proxy_group.rb
@@ -17,7 +17,7 @@ module Folio
     end
 
     def checkouts
-      sponsor.all_checkouts.select(&:proxy_checkout?)
+      sponsor.checkouts.select(&:proxy_checkout?)
     end
 
     def requests

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe CheckoutsController do
   let(:user) { CurrentUser.new(username: 'somesunetid', patron_key: '513a9054-5897-11ee-8c99-0242ac120002', shibboleth: true) }
-  let(:mock_patron) { instance_double(Folio::Patron, key: '513a9054-5897-11ee-8c99-0242ac120002', checkouts:, all_checkouts: checkouts) }
+  let(:mock_patron) { instance_double(Folio::Patron, key: '513a9054-5897-11ee-8c99-0242ac120002', checkouts: checkouts) }
   let(:mock_client) { instance_double(FolioClient, ping: true) }
   let(:checkouts) { [] }
 

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Checkout Page' do
     visit checkouts_path
 
     expect(page).to have_css('ul.checkouts-list', count: 1)
-    expect(page).to have_css('ul.checkouts-list li', count: 1)
+    expect(page).to have_css('ul.checkouts-list li', count: 3)
 
     within(first('ul.checkouts-list li')) do
       expect(page).to have_text(/Blue-collar Broadway/)
@@ -87,7 +87,7 @@ RSpec.describe 'Checkout Page' do
       visit checkouts_path
 
       expect(page).to have_css('ul.checkouts-list', count: 1)
-      expect(page).to have_css('ul.checkouts-list li', count: 1)
+      expect(page).to have_css('ul.checkouts-list li', count: 3)
 
       within(first('ul.checkouts-list li')) do
         expect(page).to have_text 'NOTE: This item must be returned to the Green Library'

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Home Page' do
 
       expect(page).to have_css('.card', count: 7)
       expect(page).to have_css('.card', text: 'Pickup requests')
-      expect(page).to have_css('.card', text: '1 item currently loaned')
+      expect(page).to have_css('.card', text: '3 items currently loaned')
       expect(page).to have_css('.card', text: 'Digitization requests')
     end
 

--- a/spec/features/renew_item_spec.rb
+++ b/spec/features/renew_item_spec.rb
@@ -8,7 +8,16 @@ RSpec.describe 'Renew item', :js do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:mock_client) { instance_double(FolioClient, ping: true, find_effective_loan_policy: {}) }
-  let(:patron) do
+  let(:patron) { patron_with_a_single_checkout }
+
+  let(:patron_with_a_single_checkout) do
+    loans = sponsor_patron.send(:patron_graphql_response).fetch('loans').first(1)
+    patron_graphql_response = sponsor_patron.send(:patron_graphql_response).merge('loans' => loans)
+
+    Folio::Patron.new(patron_graphql_response:)
+  end
+
+  let(:sponsor_patron) do
     build(:sponsor_patron)
   end
 


### PR DESCRIPTION
MyLibrary had these in different tabs, but we're showing them in the same place now.