### PR TITLE
Derive day-only appointment time server-side from reading room hours

### DIFF
--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -90,7 +90,8 @@ class AeonAppointmentsController < ApplicationController
       name: appointment_params[:name],
       reading_room_id: reading_room&.id,
       reading_room: reading_room,
-      username: current_user.aeon.username
+      username: current_user.aeon.username,
+      user: current_user.aeon
     )
   end
 
@@ -113,31 +114,30 @@ class AeonAppointmentsController < ApplicationController
   end
 
   def start_time_param
-    return day_only_range&.begin if reading_room&.day_only_appointments?
+    return day_only_appointment_range&.begin if day_only_appointment_range
     return unless appointment_params[:start_time]
 
-    parse_time(appointment_params[:start_time])
+    parse_time(appointment_params[:date], appointment_params[:start_time])
   end
 
   def stop_time_param
-    return day_only_range&.end if reading_room&.day_only_appointments?
+    return day_only_appointment_range&.end if day_only_appointment_range
 
     stop_time = appointment_params[:stop_time]
     duration = appointment_params[:duration]
-    return parse_time(stop_time) if stop_time
+    return parse_time(appointment_params[:date], stop_time) if stop_time
 
     start_time_param + duration.to_i.seconds if start_time_param && duration
   end
 
-  def parse_time(time)
-    Time.zone.parse("#{appointment_params[:date]}T#{time}")
+  def parse_time(date, time)
+    Time.zone.parse("#{date}T#{time}")
   end
 
-  def day_only_range
+  def day_only_appointment_range
     return if appointment_params[:date].blank?
 
-    date = Date.parse(appointment_params[:date])
-    reading_room&.open_hours_on(date)&.range_on(date)
+    reading_room&.day_only_appointment_range(Date.parse(appointment_params[:date]))
   end
 
   def appointment_params

--- a/app/controllers/aeon_appointments_controller.rb
+++ b/app/controllers/aeon_appointments_controller.rb
@@ -84,7 +84,6 @@ class AeonAppointmentsController < ApplicationController
   end
 
   def build_appointment
-    reading_room = Aeon::ReadingRoom.find(appointment_params[:reading_room_id])
     @appointment = Aeon::Appointment.new(
       start_time: start_time_param,
       stop_time: stop_time_param,
@@ -93,6 +92,12 @@ class AeonAppointmentsController < ApplicationController
       reading_room: reading_room,
       username: current_user.aeon.username
     )
+  end
+
+  def reading_room
+    return unless appointment_params[:reading_room_id]
+
+    @reading_room ||= Aeon::ReadingRoom.find(appointment_params[:reading_room_id])
   end
 
   def load_appointments
@@ -108,19 +113,31 @@ class AeonAppointmentsController < ApplicationController
   end
 
   def start_time_param
+    return day_only_range&.begin if reading_room&.day_only_appointments?
     return unless appointment_params[:start_time]
 
-    Time.zone.parse("#{appointment_params[:date]}T#{appointment_params[:start_time]}")
+    parse_time(appointment_params[:start_time])
   end
 
-  def stop_time_param # rubocop:disable Metrics/AbcSize
-    return unless appointment_params[:stop_time] || (start_time_param && appointment_params[:duration])
+  def stop_time_param
+    return day_only_range&.end if reading_room&.day_only_appointments?
 
-    if appointment_params[:stop_time]
-      Time.zone.parse("#{appointment_params[:date]}T#{appointment_params[:stop_time]}")
-    else
-      start_time_param + appointment_params[:duration].to_i.seconds
-    end
+    stop_time = appointment_params[:stop_time]
+    duration = appointment_params[:duration]
+    return parse_time(stop_time) if stop_time
+
+    start_time_param + duration.to_i.seconds if start_time_param && duration
+  end
+
+  def parse_time(time)
+    Time.zone.parse("#{appointment_params[:date]}T#{time}")
+  end
+
+  def day_only_range
+    return if appointment_params[:date].blank?
+
+    date = Date.parse(appointment_params[:date])
+    reading_room&.open_hours_on(date)&.range_on(date)
   end
 
   def appointment_params

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -21,7 +21,7 @@ class AeonReadingRoomsController < ApplicationController
   def unavailable_dates
     month = Date.strptime(params.expect(:month), '%Y-%m')
     dates = bookable_dates_in(month).reject do |date|
-      deconflict(@reading_room.available_appointments(date)).any?
+      @reading_room.deconflicted_available_appointments(date, user: current_user.aeon, excluding_id: appointment_id_param).any?
     end
     render json: { month: params[:month], unavailable_dates: dates.map(&:iso8601) }
   end
@@ -33,17 +33,8 @@ class AeonReadingRoomsController < ApplicationController
     month.all_month.select { |date| @reading_room.open_hours_on(date) && closed.exclude?(date) }
   end
 
-  def deconflict(available_appointments)
-    Aeon::AppointmentDeconflictionService.new(
-      available_appointments:,
-      existing_appointments: existing_appointments_for_deconfliction
-    ).call
-  end
-
-  def existing_appointments_for_deconfliction
-    current_user.aeon.appointments
-                .for_reading_room(@reading_room)
-                .reject { |a| a.id == params[:appointment_id].to_i }
+  def appointment_id_param
+    params[:appointment_id]&.to_i
   end
 
   def load_reading_room
@@ -52,8 +43,9 @@ class AeonReadingRoomsController < ApplicationController
 
   def load_appointments
     @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
-    @available_appointments = @reading_room.available_appointments(@date, include_next_available: true)
-    @available_appointments_on_selected_date = deconflict(@available_appointments)
-    @appointment_lengths = @available_appointments_on_selected_date.map(&:maximum_appointment_length)
+    @available_appointments = @reading_room.deconflicted_available_appointments(
+      @date, user: current_user.aeon, excluding_id: appointment_id_param, include_next_available: true
+    )
+    @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
   end
 end

--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -18,6 +18,8 @@ export default class extends Controller {
   }
 
   refreshAvailability() {
+    if (!this.hasAvailabilityTarget) return;
+
     const formData = new FormData(this.element);
 
     const date = formData.get('aeon_appointment[date]');
@@ -72,6 +74,8 @@ export default class extends Controller {
   }
 
   updateFormStatus() {
+    if (!this.hasAvailabilityTarget) return;
+
     const formData = new FormData(this.element);
     const hasDate = !!formData.get('aeon_appointment[date]');
     const hasDuration = !!formData.get('aeon_appointment[duration]');

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -14,6 +14,7 @@ module Aeon
     validate :stop_after_start,    if: -> { start_time && stop_time }
     validate :within_open_hours,   if: -> { reading_room && start_time && stop_time }
     validate :not_during_closure,  if: -> { reading_room && start_time && stop_time }
+    validate :slot_available,      if: -> { reading_room && start_time && stop_time && user && errors.empty? }
 
     def self.from_dynamic(dyn) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       new(
@@ -87,7 +88,7 @@ module Aeon
 
     def persisted? = id.present?
 
-    def save # rubocop:disable Metrics/AbcSize, Naming/PredicateMethod
+    def save # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       return false unless valid?
 
       if persisted?
@@ -100,6 +101,15 @@ module Aeon
         self.available_to_proxies = saved.available_to_proxies
       end
       true
+    rescue AeonClient::ApiError => e
+      Honeybadger.notify(e)
+      action = persisted? ? 'updated' : 'created'
+      errors.add(:base, "This appointment could not be #{action}. Please refresh and try again.")
+      false
+    end
+
+    def range
+      start_time..stop_time if start_time && stop_time
     end
 
     private
@@ -108,27 +118,28 @@ module Aeon
       errors.add(:stop_time, 'must be after start time') if stop_time <= start_time
     end
 
-    def within_open_hours # rubocop:disable Metrics/AbcSize
+    def within_open_hours
       hours = reading_room.open_hours_on(start_time)
-
-      unless hours
-        return errors.add(:date, 'is outside reading room hours') if reading_room.day_only_appointments?
-
-        return errors.add(:start_time, 'is outside reading room hours')
-      end
+      return errors.add(time_error_field, 'is outside reading room hours') unless hours
 
       range = hours.range_on(start_time.to_date)
-      errors.add(:start_time, 'is outside reading room hours') if start_time < range.begin || stop_time > range.end
+      errors.add(time_error_field, 'is outside reading room hours') if start_time < range.begin || stop_time > range.end
     end
 
     def not_during_closure
-      return unless reading_room.closures.any? { |c| c.range.overlap?(start_time..stop_time) }
+      return unless reading_room.closures.any? { |c| c.range.overlap?(range) }
 
-      if reading_room.day_only_appointments?
-        errors.add(:date, 'is during a reading room closure')
-      else
-        errors.add(:start_time, 'is during a reading room closure')
-      end
+      errors.add(time_error_field, 'is during a reading room closure')
+    end
+
+    def slot_available
+      return if reading_room.available_at?(range:, user:, excluding_id: id)
+
+      errors.add(time_error_field, 'is not available')
+    end
+
+    def time_error_field
+      reading_room.day_only_appointments? ? :date : :start_time
     end
   end
 end

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -50,6 +50,8 @@ module Aeon
     end
 
     def requests
+      return [] unless persisted?
+
       @requests ||= (user&.requests&.for_appointment(self) || []).reject(&:cancelled?)
     end
 

--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -69,6 +69,13 @@ module Aeon
       open_hours.find { |h| h.day_of_week == date.wday }
     end
 
+    # For day-only reading rooms, the appointment range covering the room's open hours on the given date.
+    def day_only_appointment_range(date)
+      return unless day_only_appointments? && date
+
+      open_hours_on(date)&.range_on(date)
+    end
+
     # Dates where a closure covers the entire span of open hours for that day.
     def fully_closed_dates
       @fully_closed_dates ||= closures.flat_map do |closure|
@@ -119,9 +126,30 @@ module Aeon
       @next_appointment ||= available_appointments(Time.zone.now.to_date, include_next_available: true)&.first
     end
 
+    # Available appointments for a date, deconflicted against the user's other appointments in this room.
+    def deconflicted_available_appointments(date, user:, excluding_id: nil, include_next_available: false)
+      Aeon::AppointmentDeconflictionService.new(
+        available_appointments: available_appointments(date, include_next_available:),
+        existing_appointments: existing_appointments_for(user, excluding_id:)
+      ).call
+    end
+
+    # Whether Aeon has an available slot covering the given range, after deconflicting against the
+    # user's other appointments in this reading room.
+    def available_at?(range:, user:, excluding_id: nil)
+      duration = range.end - range.begin
+      deconflicted_available_appointments(range.begin.to_date, user:, excluding_id:).any? do |a|
+        a.start_time.to_i == range.begin.to_i && a.maximum_appointment_length >= duration
+      end
+    end
+
     def persisted? = id.present?
 
     private
+
+    def existing_appointments_for(user, excluding_id:)
+      user.appointments.for_reading_room(self).reject { |a| a.id == excluding_id }
+    end
 
     def format_hours(reading_room_open_hours)
       "#{reading_room_open_hours.open_time.strftime('%-l:%M')} - #{reading_room_open_hours.close_time.strftime('%-l:%M %P')}"

--- a/app/views/aeon_appointments/_availability_loading.html.erb
+++ b/app/views/aeon_appointments/_availability_loading.html.erb
@@ -4,6 +4,6 @@
 <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
 <div class="selection-message">Select a date and duration to see available appointments.</div>
 <label class="visually-hidden-focusable required-placeholder">
-  Loading avaiable appointments.
+  Loading available appointments.
   <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
 </label>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -13,6 +13,12 @@
       </ul>
     <% end %>
 
+    <% if @appointment.errors[:base].any? %>
+      <p class="error-message text-danger">
+        <%= @appointment.errors.full_messages_for(:base).join(", ") %>
+      </p>
+    <% end %>
+
     <div class="mb-3">
       <%= f.label :date, class: "form-label fw-semibold redesign-required-label" %>
       <% existing_appointments = @appointments.for_reading_room(@appointment.reading_room).map(&:date).map(&:iso8601) %>

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -33,11 +33,6 @@
       <%# if it's a day-only appointment, we still use the turboframe to check if the reading room is open at all, but we don't need any of the other controls. %>
       <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date, appointment_id: @appointment.id) %>">
         <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
-
-        <label class="visually-hidden-focusable required-placeholder">
-          Checking avaiable appointments
-          <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
-        </label>
       </turbo-frame>
     <% elsif @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
       <div class="mb-3">

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -35,34 +35,31 @@
       <% end %>
     </div>
 
-    <% if @appointment&.reading_room&.day_only_appointments? %>
-      <%# if it's a day-only appointment, we still use the turboframe to check if the reading room is open at all, but we don't need any of the other controls. %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-appointment-target="availability" src="<%= available_aeon_reading_room_url(id: @appointment.reading_room_id, date: @appointment.date, appointment_id: @appointment.id) %>">
-        <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
-      </turbo-frame>
-    <% elsif @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
-      <div class="mb-3">
-        <%= f.label :start_time, class: 'd-block fw-semibold' %>
-        <%= f.time_field :start_time, required: true %>
-      </div>
-      <div class="mb-3">
-        <%= f.label :stop_time, class: 'd-block fw-semibold' %>
-        <%= f.time_field :stop_time, required: true %>
-      </div>
-    <% else %>
-      <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
+    <% unless @appointment&.reading_room&.day_only_appointments? %>
+      <% if @appointment.start_time && @appointment.stop_time && (!@appointment.start_time.min.in?([0,15,30,45]) || !(@appointment.stop_time - @appointment.start_time).in?([30.minutes, 1.hour, 1.5.hours, 2.hours, 3.hours, 4.hours])) %>
+        <div class="mb-3">
+          <%= f.label :start_time, class: 'd-block fw-semibold' %>
+          <%= f.time_field :start_time, required: true %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :stop_time, class: 'd-block fw-semibold' %>
+          <%= f.time_field :stop_time, required: true %>
+        </div>
+      <% else %>
+        <%= render Aeon::AppointmentDurationSelectorComponent.new(form: f, reading_room: @appointment.reading_room, selected: @appointment.duration) %>
 
-      <% if f.object.errors[:start_time].any? %>
-        <p class="error-message text-danger">
-          <%= f.object.errors.full_messages_for(:start_time).join(", ") %>
-        </p>
+        <% if f.object.errors[:start_time].any? %>
+          <p class="error-message text-danger">
+            <%= f.object.errors.full_messages_for(:start_time).join(", ") %>
+          </p>
+        <% end %>
+        <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, appointment_id: @appointment.id, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
+          <%= render 'availability_loading', f: f %>
+        </turbo-frame>
+        <template data-appointment-target="placeholder">
+          <%= render 'availability_loading', f: f %>
+        </template>
       <% end %>
-      <turbo-frame id="available_appointments" <% unless @appointment.id %>class="form-incomplete"<% end %> data-action="turbo:frame-load->appointment#applyDurationFilter turbo:frame-load->appointment#filterDurationFields" data-appointment-target="availability" src="<%= available_aeon_reading_room_url(@appointment.reading_room_id, date: (@appointment.date unless @appointment.persisted?), duration: @appointment.duration, appointment_id: @appointment.id, selected: (l(@appointment.start_time, format: :time_only) if @appointment.start_time)) if @appointment.reading_room_id %>">
-        <%= render 'availability_loading', f: f %>
-      </turbo-frame>
-      <template data-appointment-target="placeholder">
-        <%= render 'availability_loading', f: f %>
-      </template>
     <% end %>
     <% if @appointment.requests.any? %>
       <%= render AlertComponent.new(type: :info, classes: ['border-0', 'shadow-none', 'w-fit'], with_icon: false) do %>

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -1,28 +1,24 @@
 <%= form_with(model: Aeon::Appointment.new) do |f| %>
   <turbo-frame id="available_appointments">
-    <% unless @reading_room.day_only_appointments? %>
-      <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments.count %>">
-        <fieldset class="mb-3 radio-button-group" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
-          <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
-          <div class="flex-wrap gap-3 appointment-slots">
-            <% @available_appointments.each do |appointment| %>
-              <%= f.radio_button :start_time, l(appointment.start_time, format: :time_only), required: true, id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { timestamp: appointment.start_time.to_i, maximum_appointment_length: appointment.maximum_appointment_length, action: 'click->appointment#updateBanner'  }, class: 'btn-check', checked: @selected_time == l(appointment.start_time, format: :time_only) %>
-              <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border px-1' %>
-            <% end %>
-          </div>
-        </fieldset>
-        <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
-        <div class="selection-message">Select a date and duration to see available appointments.</div>
-      </div>
-    <% end %>
+    <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments.count %>">
+      <fieldset class="mb-3 radio-button-group" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
+        <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
+        <div class="flex-wrap gap-3 appointment-slots">
+          <% @available_appointments.each do |appointment| %>
+            <%= f.radio_button :start_time, l(appointment.start_time, format: :time_only), required: true, id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { timestamp: appointment.start_time.to_i, maximum_appointment_length: appointment.maximum_appointment_length, action: 'click->appointment#updateBanner'  }, class: 'btn-check', checked: @selected_time == l(appointment.start_time, format: :time_only) %>
+            <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border px-1' %>
+          <% end %>
+        </div>
+      </fieldset>
+      <div class="loading-overlay p-2 mb-2" aria-hidden="true">Loading...</div>
+      <div class="selection-message">Select a date and duration to see available appointments.</div>
+    </div>
     <% if params[:date] && next_appt = @available_appointments.find { |x| x.start_time.to_date > @date } %>
       <div>There are no appointments on <%= l(@date, format: :short) %>. The next available appointment is on <%= l(next_appt.start_time, format: :date_only) %>.</div>
-      <% unless @reading_room.day_only_appointments? %>
-        <label class="visually-hidden-focusable required-placeholder">
-          No avaiable appointments.
-          <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
-        </label>
-      <% end %>
+      <label class="visually-hidden-focusable required-placeholder">
+        No available appointments.
+        <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
+      </label>
     <% end %>
   </turbo-frame>
   <turbo-frame id="earliest_appointment">

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -1,11 +1,6 @@
 <%= form_with(model: Aeon::Appointment.new) do |f| %>
   <turbo-frame id="available_appointments">
-    <% if @reading_room.day_only_appointments? %>
-      <% if @available_appointments.first&.start_time&.to_date == @date %>
-        <%= f.hidden_field :start_time, value: l(@available_appointments.first.start_time, format: :time_only) %>
-        <%= f.hidden_field :duration, value: @available_appointments.first.maximum_appointment_length.to_i %>
-      <% end %>
-    <% else %>
+    <% unless @reading_room.day_only_appointments? %>
       <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments_on_selected_date.count %>">
         <fieldset class="mb-3 radio-button-group" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
@@ -22,10 +17,12 @@
     <% end %>
     <% if params[:date] && next_appt = @available_appointments.find { |x| x.start_time.to_date > @date } %>
       <div>There are no appointments on <%= l(@date, format: :short) %>. The next available appointment is on <%= l(next_appt.start_time, format: :date_only) %>.</div>
-      <label class="visually-hidden-focusable required-placeholder">
-        No avaiable appointments.
-        <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
-      </label>
+      <% unless @reading_room.day_only_appointments? %>
+        <label class="visually-hidden-focusable required-placeholder">
+          No avaiable appointments.
+          <%= f.text_field :start_time, class: 'visually-hidden-focusable', required: true %>
+        </label>
+      <% end %>
     <% end %>
   </turbo-frame>
   <turbo-frame id="earliest_appointment">

--- a/app/views/aeon_reading_rooms/available.html.erb
+++ b/app/views/aeon_reading_rooms/available.html.erb
@@ -1,11 +1,11 @@
 <%= form_with(model: Aeon::Appointment.new) do |f| %>
   <turbo-frame id="available_appointments">
     <% unless @reading_room.day_only_appointments? %>
-      <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments_on_selected_date.count %>">
+      <div class="appointment-slots-container" style="--appointment-slots: <%= @available_appointments.count %>">
         <fieldset class="mb-3 radio-button-group" data-appointment-target="fieldset" data-max-slot="<%= @appointment_lengths.max %>" data-min-slot="<%= @appointment_lengths.min %>">
           <legend class="fs-6 fw-semibold redesign-required-label">Available time slots</legend>
           <div class="flex-wrap gap-3 appointment-slots">
-            <% @available_appointments_on_selected_date.each do |appointment| %>
+            <% @available_appointments.each do |appointment| %>
               <%= f.radio_button :start_time, l(appointment.start_time, format: :time_only), required: true, id: "aeon_appointment_start_time_#{appointment.start_time.to_i}", data: { timestamp: appointment.start_time.to_i, maximum_appointment_length: appointment.maximum_appointment_length, action: 'click->appointment#updateBanner'  }, class: 'btn-check', checked: @selected_time == l(appointment.start_time, format: :time_only) %>
               <%= f.label "start_time_#{appointment.start_time.to_i}", l(appointment.start_time, format: :time_only), class: 'btn border px-1' %>
             <% end %>

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Appointments', :js do
   end
 
   describe 'create appointment modal' do
-    it 'opens and closes the create new appointment modal for field reading room' do
+    it 'opens and closes the create new appointment modal for field reading room' do # rubocop:disable RSpec/ExampleLength
       click_on 'Create new appointment'
       expect(page).to have_css '.modal'
       within '.modal' do
@@ -65,11 +65,18 @@ RSpec.describe 'Appointments', :js do
         click_on 'Next month'
 
         first('td[role="gridcell"]:not(:has(button:disabled))').click
-        expect(page).to have_css('#aeon_appointment_start_time', visible: :all)
 
         click_on 'Save'
       end
       expect(page).to have_no_css '.modal'
+
+      # For day-only rooms, the server derives the appointment span from the reading room's open hours
+      created = StubAeonClient::Appointment.last
+      start_time = Time.zone.parse(created.startTime)
+      stop_time = Time.zone.parse(created.stopTime)
+      hours = reading_room.open_range_on(start_time.to_date)
+      expect(start_time).to eq hours.begin
+      expect(stop_time).to eq hours.end
     end
 
     it 'opens and closes the create new appointment modal for ARS' do # rubocop:disable RSpec/ExampleLength
@@ -120,7 +127,6 @@ RSpec.describe 'Appointments', :js do
         click_on 'Next month'
 
         first('td[role="gridcell"]:not(:has(button:disabled))').click
-        expect(page).to have_css('#aeon_appointment_start_time', visible: :all)
 
         click_on 'Save'
       end

--- a/spec/features/aeon_requests_spec.rb
+++ b/spec/features/aeon_requests_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe 'Requests', :js do
         click_on 'Next month'
 
         first('td[role="gridcell"]:not(:has(button:disabled))').click
-        expect(page).to have_css('#aeon_appointment_start_time', visible: :all)
         click_on 'Save'
 
         within '#aeon-appointments-frame[complete] #aeon_appointments_sidebar' do

--- a/spec/models/aeon/appointment_spec.rb
+++ b/spec/models/aeon/appointment_spec.rb
@@ -180,6 +180,40 @@ RSpec.describe Aeon::Appointment do
         end
       end
 
+      context 'when the Aeon client rejects the create' do
+        let(:client) { instance_double(AeonClient) }
+
+        before do
+          allow(Current).to receive(:aeon_client).and_return(client)
+          allow(client).to receive(:create_appointment).and_raise(AeonClient::ApiError.new('boom'))
+          allow(Honeybadger).to receive(:notify)
+        end
+
+        it 'returns false, notifies Honeybadger, and adds a base error mentioning "created"' do
+          expect(appointment.save).to be false
+          expect(Honeybadger).to have_received(:notify).with(instance_of(AeonClient::ApiError))
+          expect(appointment.errors[:base].first).to include('could not be created')
+        end
+      end
+
+      context 'when the Aeon client rejects the update' do
+        let(:appointment) do
+          build(:aeon_appointment, id: 42, reading_room: reading_room, start_time: start_time, stop_time: stop_time)
+        end
+        let(:client) { instance_double(AeonClient) }
+
+        before do
+          allow(Current).to receive(:aeon_client).and_return(client)
+          allow(client).to receive(:update_appointment).and_raise(AeonClient::ApiError.new('boom'))
+          allow(Honeybadger).to receive(:notify)
+        end
+
+        it 'returns false and adds a base error mentioning "updated"' do
+          expect(appointment.save).to be false
+          expect(appointment.errors[:base].first).to include('could not be updated')
+        end
+      end
+
       context 'when persisted' do
         let(:appointment) do
           build(:aeon_appointment, id: 42, reading_room: reading_room, start_time: start_time, stop_time: stop_time)
@@ -206,6 +240,56 @@ RSpec.describe Aeon::Appointment do
             expect(client).not_to have_received(:update_appointment)
           end
         end
+      end
+    end
+
+    context 'when validating slot availability' do
+      let(:user) { instance_double(Aeon::User, appointments: user_appointments) }
+      let(:user_appointments) { instance_double(Aeon::AppointmentFinders) }
+      let(:appointment) do
+        build(:aeon_appointment, reading_room: reading_room, start_time: start_time, stop_time: stop_time, user: user)
+      end
+      let(:start_time) { Time.zone.parse('2026-03-16T09:00:00-07:00') }
+      let(:stop_time)  { Time.zone.parse('2026-03-16T16:45:00-07:00') }
+
+      before do
+        allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([])
+      end
+
+      context 'when Aeon returns no availability for the date' do
+        before do
+          allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return([])
+        end
+
+        it 'is invalid on :date for day-only rooms' do
+          expect(appointment).not_to be_valid
+          expect(appointment.errors[:date]).to include('is not available')
+        end
+      end
+
+      context 'when Aeon returns a slot but not long enough for the requested duration' do
+        before do
+          allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return(
+            [Aeon::AvailableAppointment.new(start_time: start_time, maximum_appointment_length: 1.hour)]
+          )
+        end
+
+        it { expect(appointment).not_to be_valid }
+      end
+
+      context 'when the user already has an appointment covering the requested span' do
+        let(:existing) do
+          build(:aeon_appointment, id: 99, start_time: start_time, stop_time: stop_time)
+        end
+
+        before do
+          allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([existing])
+          allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return(
+            [Aeon::AvailableAppointment.new(start_time: start_time, maximum_appointment_length: 8.hours)]
+          )
+        end
+
+        it { expect(appointment).not_to be_valid }
       end
     end
 


### PR DESCRIPTION
Avoids the refreshAvailability roundtrip with day only appointments.

Adds server-side appointment time validation, which required a bit of re-arranging of the appointment deconfliction code.