### PR TITLE
Disable expensive cancelled appointment check

### DIFF
--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -70,7 +70,9 @@ module Aeon
     end
 
     def cancelled?
-      appointment_status == 'Cancelled' || (requests.none? && !editable?)
+      appointment_status == 'Cancelled'
+      # TODO: Restore or delete this requests/editable check (e.g., after caching, remediation)
+      # appointment_status == 'Cancelled' || (requests.none? && !editable?)
     end
 
     def edit_policy

--- a/spec/models/aeon/appointment_spec.rb
+++ b/spec/models/aeon/appointment_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Aeon::Appointment do
     end
 
     it 'is cancelled if the appointment is not editable and has no requests assigned' do
+      pending 'an approach that determines emptiness without an expensive requests fetch'
       appointment = build(:aeon_appointment, requests: [], start_time: 1.week.ago)
 
       expect(appointment).to be_cancelled


### PR DESCRIPTION
This is doing an Aeon requests fetch, which is the more time consuming Aeon request, in places where it's unexpected to need to fetch requests (e.g., the "new appointment" page).

Caching might solve this? Alternatively we could remediate Aeon appointments and treat the Aeon appointment status as the source of truth.