### PR TITLE
Skip authorization for async loading, so we clear the placeholder card

### DIFF
--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -15,7 +15,7 @@ class AeonRequestsController < ApplicationController
   before_action :set_variant, only: [:index, :edit]
 
   def index
-    authorize! :read, Aeon::Request
+    authorize! :read, Aeon::Request unless params[:async]
 
     render 'async' and return if params[:async]
   end

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Request Page' do
+RSpec.describe 'FOLIO Request Page' do
   let(:mock_client) { instance_double(FolioClient, ping: true) }
   let(:patron) do
     build(:sponsor_patron)

--- a/spec/features/unified_requests_spec.rb
+++ b/spec/features/unified_requests_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Request Page', :js do
+  use_stub_aeon_client
+  let(:user) { create(:sso_user) }
+  let(:current_user) { CurrentUser.new(username: user.sunetid, shibboleth: true) }
+
+  before do
+    login_as(current_user)
+  end
+
+  it 'loads the page and clears all the visible placeholders' do
+    visit unified_requests_path
+
+    expect(page).to have_text('Submitted requests')
+    expect(page).to have_no_css('.placeholder-glow')
+  end
+end


### PR DESCRIPTION
I'm pretty sure we don't need the `authorize!` at all now, but 🤷 