### PR TITLE
make sure pasted otp code updates form

### DIFF
--- a/app/javascript/controllers/otp_input_controller.js
+++ b/app/javascript/controllers/otp_input_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
     const firstEmptyDigit = this.digitTargets.find(el => el.value === "");
 
     (firstEmptyDigit || this.digitTargets[this.digitTargets.length - 1]).focus();
+    this.update()
   }
 
   shift(event) {


### PR DESCRIPTION
closes #3933 

When there user copies and pastes the otp code into the form what gets submitted is an empty form because it isn't running the update function