### PR TITLE
add current fees/fines no fines messaging, update past messaging

### DIFF
--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -28,6 +28,8 @@
             <%= render Folio::FineComponent.new(fine: item, patron: patron_or_group) %>
           <% end %>
         </ul>
+      <% else %>
+        <span>There are no fees or fines on this account.</span>
       <% end %>
       <% if params[:group] && patron.sponsor? %>
         Fines incurred by proxy borrowers appear in the list of fines under their sponsor's Self tab.

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -16,7 +16,7 @@
         </div>
       </div>
     <% else %>
-      <span>There is no history on this account.</span>
+      <span>There are no past fees or fines on this account.</span>
     <% end %>
 
     <% if @payments.any? %>

--- a/spec/features/fines_spec.rb
+++ b/spec/features/fines_spec.rb
@@ -56,5 +56,9 @@ RSpec.describe 'Fines Page' do
     it 'does not render headers' do
       expect(page).to have_text('Fees and fines')
     end
+
+    it 'has a message' do
+      expect(page).to have_text('There are no fees or fines on this account.')
+    end
   end
 end

--- a/spec/features/payments_spec.rb
+++ b/spec/features/payments_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Payments History' do
     it 'does not load table', :js do
       click_on 'Past'
 
-      expect(page).to have_css('span', text: 'There is no history on this account')
+      expect(page).to have_css('span', text: 'There are no past fees or fines on this account.')
     end
   end
 end


### PR DESCRIPTION
Before:
<img width="801" height="121" alt="Screenshot 2026-07-14 at 5 27 08 PM" src="https://github.com/user-attachments/assets/684fecad-865b-4eb3-9d0b-75833eb025f1" />
After:
<img width="795" height="158" alt="Screenshot 2026-07-14 at 5 27 41 PM" src="https://github.com/user-attachments/assets/961e49a8-ef15-4e63-907b-5545c61a7726" />


The "history" text is from mylibrary. I just updated it to be more modern until Darcy can decide on what text she wants.
Before:
<img width="774" height="155" alt="Screenshot 2026-07-14 at 5 27 11 PM" src="https://github.com/user-attachments/assets/e7c2c229-4dbf-408c-a43d-534f16670279" />

After:
<img width="817" height="168" alt="Screenshot 2026-07-14 at 5 27 49 PM" src="https://github.com/user-attachments/assets/dc47d37b-eea3-4860-ad83-dcbec6d22a25" />
