### PR TITLE
Always use the searchworks-flavor of document type.

### DIFF
--- a/app/models/folio/instance.rb
+++ b/app/models/folio/instance.rb
@@ -22,7 +22,6 @@ module Folio
         pub_date: json.fetch('publication', []).pick('dateOfPublication'),
         pub_place: json.fetch('publication', []).pick('place'),
         publisher: json.fetch('publication', []).pick('publisher'),
-        format: json.dig('instanceType', 'name'),
         isbn: json.fetch('identifiers', []).filter_map do |identifier|
           identifier.fetch('value') if identifier.dig('identifierTypeObject', 'name') == 'ISBN'
         end,
@@ -38,7 +37,7 @@ module Folio
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
-    def initialize(id:, hrid: '', title: '', contributors: [], pub_date: nil, pub_place: nil, publisher: nil, format: nil,
+    def initialize(id:, hrid: '', title: '', contributors: [], pub_date: nil, pub_place: nil, publisher: nil,
                    isbn: [], oclcn: [], electronic_access: [], edition: [], holdings_records: [], marc_hash: nil)
       @id = id
       @hrid = hrid
@@ -47,7 +46,6 @@ module Folio
       @pub_date = pub_date
       @pub_place = pub_place
       @publisher = publisher
-      @format = Array(format)
       @isbn = isbn
       @oclcn = oclcn
       @electronic_access = electronic_access
@@ -70,7 +68,7 @@ module Folio
       contributor&.fetch('name')
     end
 
-    attr_reader :id, :pub_date, :pub_place, :publisher, :format
+    attr_reader :id, :pub_date, :pub_place, :publisher
     alias date pub_date
 
     def isbn
@@ -88,10 +86,7 @@ module Folio
     alias base_callnumber call_number
 
     def document_type
-      return document_formats.first if document_formats.any?
-      return single_item&.type if format == ['unspecified']
-
-      format.presence&.first || single_item&.type
+      document_formats&.first
     end
 
     def marc_record

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -2,11 +2,9 @@
 
 module Folio
   # Represents an item returned from the /inventory-hierarchy/items-and-holdings Folio API
-  # TODO: This wants a "type" attribute, but I don't know how we get the folio version of a holding type.
-  #       See https://github.com/sul-dlss/searchworks_traject_indexer/blob/02192452815de3861dcfafb289e1be8e575cb000/lib/traject/config/sirsi_config.rb#L2379
   # NOTE, barcode and callnumber may be nil. see instance_hrid: 'in00000063826'
   class Item
-    attr_reader :id, :barcode, :status, :type, :public_note, :effective_location, :permanent_location, :temporary_location,
+    attr_reader :id, :barcode, :status, :public_note, :effective_location, :permanent_location, :temporary_location,
                 :material_type, :loan_type, :holdings_record_id, :enumeration, :base_callnumber, :full_enumeration, :queue_length,
                 :instance, :bound_with_holdings_per_item, :bound_with_child_holdings_record
 
@@ -61,9 +59,8 @@ module Folio
     ].freeze
 
     # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength, Metrics/AbcSize
-    def initialize(barcode:, status:,
-                   effective_location:, permanent_location: nil, temporary_location: nil,
-                   type: nil, public_note: nil, material_type: nil, loan_type: nil, enumeration: nil,
+    def initialize(barcode:, status:, effective_location:, permanent_location: nil, temporary_location: nil,
+                   public_note: nil, material_type: nil, loan_type: nil, enumeration: nil,
                    full_enumeration: nil,
                    due_date: nil, id: nil, holdings_record_id: nil, suppressed_from_discovery: false,
                    base_callnumber: nil, queue_length: 0, instance: nil, bound_with_holdings_per_item: [])
@@ -71,7 +68,6 @@ module Folio
       @holdings_record_id = holdings_record_id
       @barcode = barcode.presence || id
       @status = status
-      @type = type
       @public_note = public_note
       @effective_location = effective_location
       @permanent_location = permanent_location || effective_location
@@ -229,7 +225,6 @@ module Folio
             Folio::HoldingsRecord.from_hash(v)
           end || [],
           base_callnumber: dyn.dig('effectiveCallNumberComponents', 'callNumber'),
-          type: dyn.dig('materialType', 'name'),
           full_enumeration: [dyn['volume'], dyn['enumeration'],
                              dyn['chronology']].filter_map(&:presence).join(' '),
           public_note: dyn.fetch('notes').find { |note| note.dig('itemNoteType', 'name') == 'Public' }&.fetch('note'),

--- a/spec/components/record_header_component_spec.rb
+++ b/spec/components/record_header_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RecordHeaderComponent, type: :component do
   end
 
   context 'with folio_item with unspecified format' do
-    let(:record) { build(:unspecified_not_on_order) }
+    let(:record) { build(:map_instance) }
 
     it 'shows the header with correct information' do
       expect(page).to have_css 'h2', text: 'Outline map of the Empire of Brazil and adjacent territories.'

--- a/spec/factories/folio_api_json.rb
+++ b/spec/factories/folio_api_json.rb
@@ -110,7 +110,6 @@ FactoryBot.define do
     full_enumeration { '' }
     status { 'Available' }
     public_note { '' }
-    type { '' }
     material_type { build(:book_material_type) }
     loan_type { Folio::LoanType.new(id: '') }
     effective_location { build(:location, code: 'GRE-STACKS') }
@@ -128,7 +127,6 @@ FactoryBot.define do
   factory :instance, class: 'Folio::Instance' do
     id { '1234' }
     title { 'Item Title' }
-    format { 'Book' }
     holdings_records { [build(:holdings_record, items:)] }
     items { [build(:item)] }
 
@@ -139,7 +137,7 @@ FactoryBot.define do
     id { '1234' }
     hrid { 'a1234' }
     title { 'Item Title' }
-    format { 'Book' }
+
     items do
       [
         build(:item,
@@ -162,7 +160,7 @@ FactoryBot.define do
     id { '12345' }
     hrid { 'a12345' }
     title { 'Item Title' }
-    format { 'Book' }
+
     items do
       [
         build(:item,
@@ -177,7 +175,7 @@ FactoryBot.define do
     id { '12345' }
     hrid { 'a12345' }
     title { 'Item Title' }
-    format { 'Book' }
+
     items do
       [
         build(:item,
@@ -192,8 +190,6 @@ FactoryBot.define do
     id { '123' }
 
     title { 'Item Title' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -210,8 +206,6 @@ FactoryBot.define do
 
     title { 'Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -227,8 +221,6 @@ FactoryBot.define do
 
     title { 'Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -243,15 +235,12 @@ FactoryBot.define do
     id { '1234' }
     title { 'Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
               barcode: '12345678',
               base_callnumber: 'ABC 123',
-              effective_location: build(:sal_temp_location),
-              type: 'NONCIRC')
+              effective_location: build(:sal_temp_location))
       ]
     end
   end
@@ -262,8 +251,6 @@ FactoryBot.define do
     title { 'Special Collections Item Title' }
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
     pub_date { '2018' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -288,7 +275,11 @@ FactoryBot.define do
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
     pub_date { '2018' }
 
-    format { ['Book'] }
+    marc_hash do
+      {
+        'leader' => '00000naa a2200000 a 4500'
+      }
+    end
 
     items do
       [
@@ -314,8 +305,6 @@ FactoryBot.define do
       ]
     end
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -330,8 +319,6 @@ FactoryBot.define do
   factory :sal3_holdings, parent: :instance do
     id { '123456' }
     title { 'SAL3 Item Title' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -353,8 +340,6 @@ FactoryBot.define do
     id { '1234' }
     title { 'SAL Item Title' }
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
-
-    format { ['Book'] }
 
     items do
       [
@@ -378,8 +363,6 @@ FactoryBot.define do
     id { '1234' }
     title { 'Green Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -394,8 +377,6 @@ FactoryBot.define do
   factory :page_lp_holdings, parent: :instance do
     id { '1234' }
     title { 'PAGE-LP Item Title' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -412,8 +393,6 @@ FactoryBot.define do
     id { '1234' }
     title { 'PAGE-EN Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -428,8 +407,6 @@ FactoryBot.define do
   factory :page_mp_holdings, parent: :instance do
     id { '1234' }
     title { 'PAGE-MP Item Title' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -450,8 +427,6 @@ FactoryBot.define do
   factory :many_holdings, parent: :instance do
     id { '1234' }
     title { 'Item title' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -488,15 +463,12 @@ FactoryBot.define do
     id { '1234' }
     title { 'Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
               barcode: '12345678',
               base_callnumber: 'ABC 123',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK')
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'))
       ]
     end
   end
@@ -505,15 +477,12 @@ FactoryBot.define do
     id { '1234' }
     title { 'Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
               barcode: '12345678',
               base_callnumber: 'ABC 123',
-              effective_location: build(:location, code: 'ART-STACKS'),
-              type: 'STKS')
+              effective_location: build(:location, code: 'ART-STACKS'))
       ]
     end
   end
@@ -522,73 +491,61 @@ FactoryBot.define do
     id { '1234' }
     title { 'Item Title' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
               id: 'a',
               barcode: '12345678',
               base_callnumber: 'ABC 123',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'b',
               barcode: '23456789',
               base_callnumber: 'ABC 456',
               effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              public_note: 'note for 23456789',
-              type: 'LCKSTK'),
+              public_note: 'note for 23456789'),
         build(:item,
               id: 'c',
               barcode: '34567890',
               base_callnumber: 'ABC 789',
               effective_location: build(:mediated_location, code: 'ART-NEWBOOK'),
-              permanent_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              permanent_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'd',
               barcode: '45678901',
               base_callnumber: 'ABC 012',
               effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              public_note: 'note for 45678901',
-              type: 'LCKSTK'),
+              public_note: 'note for 45678901'),
         build(:item,
               id: 'e',
               barcode: '56789012',
               base_callnumber: 'ABC 345',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'f',
               barcode: '67890123',
               base_callnumber: 'ABC 678',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'g',
               barcode: '78901234',
               base_callnumber: 'ABC 901',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'h',
               barcode: '89012345',
               base_callnumber: 'ABC 234',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'i',
               barcode: '90123456',
               base_callnumber: 'ABC 567',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK'),
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE')),
         build(:item,
               id: 'j',
               barcode: '01234567',
               base_callnumber: 'ABC 890',
-              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'),
-              type: 'LCKSTK')
+              effective_location: build(:mediated_location, code: 'ART-LOCKED-LARGE'))
       ]
     end
   end
@@ -596,8 +553,6 @@ FactoryBot.define do
   factory :searchable_spec_holdings, parent: :instance do
     id { '1234' }
     title { 'Item Title' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -658,8 +613,6 @@ FactoryBot.define do
     publisher { 'Walter de Gruyter GmbH' }
     edition { ['1st ed.'] }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -681,8 +634,6 @@ FactoryBot.define do
     id { '1234' }
     title { 'SAL3 stacks item' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -698,21 +649,23 @@ FactoryBot.define do
 
     title { 'HAZARDOUS MATERIALS : MANAGING THE INCIDENT.' }
 
-    format { 'unspecified' }
-
     items { [] }
   end
 
-  factory :unspecified_not_on_order, parent: :instance do
+  factory :map_instance, parent: :instance do
     id { 'a43e597a-d4b4-50ec-ad16-7fd49920831a' }
 
     title { 'Outline map of the Empire of Brazil and adjacent territories.' }
 
-    format { 'unspecified' }
+    marc_hash do
+      {
+        'leader' => '00000nem a2200000 a 4500'
+      }
+    end
 
     items do
       [
-        build(:item, type: 'Map')
+        build(:item)
       ]
     end
   end
@@ -724,7 +677,11 @@ FactoryBot.define do
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
     pub_date { '2018' }
 
-    format { ['Book'] }
+    marc_hash do
+      {
+        'leader' => '00000naa a2200000 a 4500'
+      }
+    end
 
     items do
       [
@@ -748,8 +705,6 @@ FactoryBot.define do
     title { 'Mixed CREZ holdings' }
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
     pub_date { '2018' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -776,8 +731,6 @@ FactoryBot.define do
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
     pub_date { '2018' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -796,8 +749,6 @@ FactoryBot.define do
     title { 'Empty Barcode Item Title' }
     contributors { [{ 'primary' => true, 'name' => 'John Q. Public' }] }
     pub_date { '2018' }
-
-    format { ['Book'] }
 
     items do
       [
@@ -821,8 +772,6 @@ FactoryBot.define do
     id { '1234' }
     title { 'One Missing item' }
 
-    format { ['Book'] }
-
     items do
       [
         build(:item,
@@ -842,8 +791,6 @@ FactoryBot.define do
   factory :aged_to_lost_holdings, parent: :instance do
     id { '1234' }
     title { 'One lost item' }
-
-    format { ['Book'] }
 
     items do
       [

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe RequestsHelper do
     let(:item) do
       Folio::Item.new(
         barcode: '123',
-        type: 'LC',
         base_callnumber: '456',
         material_type: 'book',
         permanent_location: nil,

--- a/spec/models/folio/instance_spec.rb
+++ b/spec/models/folio/instance_spec.rb
@@ -495,12 +495,6 @@ RSpec.describe Folio::Instance do
     it { is_expected.to eq 'c2007' }
   end
 
-  describe '#format' do
-    subject { data.format }
-
-    it { is_expected.to eq ['unspecified'] }
-  end
-
   describe '#document_formats' do
     subject(:document_formats) { data.document_formats }
 


### PR DESCRIPTION
I think falling back to the instanceType or materialType is only because we weren't calculating the format from the MARC record. Maybe there's an argument we need to do something for FOLIO records without attached MARC data, but I think the indexer should drive that first.