### PR TITLE
Fix appointment validation for reading rooms with split open hours

### DIFF
--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -21,7 +21,7 @@ class AeonReadingRoomsController < ApplicationController
   def unavailable_dates
     month = Date.strptime(params.expect(:month), '%Y-%m')
     dates = bookable_dates_in(month).reject do |date|
-      @reading_room.deconflicted_available_appointments(date, user: current_user.aeon, excluding_id: appointment_id_param).any?
+      slot_availability.slots_on(date, excluding_id: appointment_id_param).any?
     end
     render json: { month: params[:month], unavailable_dates: dates.map(&:iso8601) }
   end
@@ -43,9 +43,13 @@ class AeonReadingRoomsController < ApplicationController
 
   def load_appointments
     @date = (Date.parse(params.expect(:date)) if params[:date]) || Time.zone.now.to_date
-    @available_appointments = @reading_room.deconflicted_available_appointments(
-      @date, user: current_user.aeon, excluding_id: appointment_id_param, include_next_available: true
+    @available_appointments = slot_availability.slots_on(
+      @date, excluding_id: appointment_id_param, include_next_available: true
     )
     @appointment_lengths = @available_appointments.map(&:maximum_appointment_length)
+  end
+
+  def slot_availability
+    Aeon::AppointmentSlotAvailability.new(reading_room: @reading_room, user: current_user.aeon)
   end
 end

--- a/app/controllers/aeon_reading_rooms_controller.rb
+++ b/app/controllers/aeon_reading_rooms_controller.rb
@@ -30,7 +30,7 @@ class AeonReadingRoomsController < ApplicationController
 
   def bookable_dates_in(month)
     closed = @reading_room.fully_closed_dates.to_set
-    month.all_month.select { |date| @reading_room.open_hours_on(date) && closed.exclude?(date) }
+    month.all_month.select { |date| @reading_room.open_hours_on(date).any? && closed.exclude?(date) }
   end
 
   def appointment_id_param

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -133,7 +133,7 @@ module Aeon
     end
 
     def slot_available
-      return if reading_room.available_at?(range:, user:, excluding_id: id)
+      return if AppointmentSlotAvailability.new(reading_room:, user:).available_at?(range:, excluding_id: id)
 
       errors.add(time_error_field, 'is not available')
     end

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -118,12 +118,12 @@ module Aeon
       errors.add(:stop_time, 'must be after start time') if stop_time <= start_time
     end
 
-    def within_open_hours
-      hours = reading_room.open_hours_on(start_time)
-      return errors.add(time_error_field, 'is outside reading room hours') unless hours
+    def within_open_hours # rubocop:disable Metrics/AbcSize
+      ranges = reading_room.open_hours_on(start_time).map { |h| h.range_on(start_time.to_date) }
+      return errors.add(time_error_field, 'is outside reading room hours') if ranges.empty?
+      return if ranges.any? { |r| start_time >= r.begin && stop_time <= r.end }
 
-      range = hours.range_on(start_time.to_date)
-      errors.add(time_error_field, 'is outside reading room hours') if start_time < range.begin || stop_time > range.end
+      errors.add(time_error_field, 'is outside reading room hours')
     end
 
     def not_during_closure

--- a/app/models/aeon/appointment_slot_availability.rb
+++ b/app/models/aeon/appointment_slot_availability.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Aeon
+  # Aeon appointment slot availability for a specific user in a specific reading room.
+  class AppointmentSlotAvailability
+    def initialize(reading_room:, user:)
+      @reading_room = reading_room
+      @user = user
+    end
+
+    def slots_on(date, excluding_id: nil, include_next_available: false)
+      AppointmentDeconflictionService.new(
+        available_appointments: @reading_room.available_appointments(date, include_next_available:),
+        existing_appointments: existing_appointments(excluding_id:)
+      ).call
+    end
+
+    def available_at?(range:, excluding_id: nil)
+      duration = range.end - range.begin
+      slots_on(range.begin.to_date, excluding_id:).any? do |slot|
+        slot.start_time.to_i == range.begin.to_i && slot.maximum_appointment_length >= duration
+      end
+    end
+
+    private
+
+    def existing_appointments(excluding_id:)
+      @user.appointments.for_reading_room(@reading_room).reject { |a| a.id == excluding_id }
+    end
+  end
+end

--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -126,30 +126,9 @@ module Aeon
       @next_appointment ||= available_appointments(Time.zone.now.to_date, include_next_available: true)&.first
     end
 
-    # Available appointments for a date, deconflicted against the user's other appointments in this room.
-    def deconflicted_available_appointments(date, user:, excluding_id: nil, include_next_available: false)
-      Aeon::AppointmentDeconflictionService.new(
-        available_appointments: available_appointments(date, include_next_available:),
-        existing_appointments: existing_appointments_for(user, excluding_id:)
-      ).call
-    end
-
-    # Whether Aeon has an available slot covering the given range, after deconflicting against the
-    # user's other appointments in this reading room.
-    def available_at?(range:, user:, excluding_id: nil)
-      duration = range.end - range.begin
-      deconflicted_available_appointments(range.begin.to_date, user:, excluding_id:).any? do |a|
-        a.start_time.to_i == range.begin.to_i && a.maximum_appointment_length >= duration
-      end
-    end
-
     def persisted? = id.present?
 
     private
-
-    def existing_appointments_for(user, excluding_id:)
-      user.appointments.for_reading_room(self).reject { |a| a.id == excluding_id }
-    end
 
     def format_hours(reading_room_open_hours)
       "#{reading_room_open_hours.open_time.strftime('%-l:%M')} - #{reading_room_open_hours.close_time.strftime('%-l:%M %P')}"

--- a/app/models/aeon/reading_room.rb
+++ b/app/models/aeon/reading_room.rb
@@ -66,22 +66,22 @@ module Aeon
     end
 
     def open_hours_on(date)
-      open_hours.find { |h| h.day_of_week == date.wday }
+      open_hours.select { |h| h.day_of_week == date.wday }
     end
 
     # For day-only reading rooms, the appointment range covering the room's open hours on the given date.
     def day_only_appointment_range(date)
       return unless day_only_appointments? && date
 
-      open_hours_on(date)&.range_on(date)
+      open_hours_on(date).first&.range_on(date)
     end
 
-    # Dates where a closure covers the entire span of open hours for that day.
+    # Dates where a closure covers the entire span of open hours for that day, across every open-hours block.
     def fully_closed_dates
       @fully_closed_dates ||= closures.flat_map do |closure|
         closure.start_date.to_date.upto(closure.end_date.to_date).select do |date|
           hours_on_day = open_hours_on(date)
-          hours_on_day && closure.cover?(hours_on_day.range_on(date))
+          hours_on_day.any? && hours_on_day.all? { |h| closure.cover?(h.range_on(date)) }
         end
       end
     end

--- a/spec/models/aeon/appointment_slot_availability_spec.rb
+++ b/spec/models/aeon/appointment_slot_availability_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::AppointmentSlotAvailability do
+  let(:reading_room) { instance_double(Aeon::ReadingRoom) }
+  let(:user_appointments) { instance_double(Aeon::AppointmentFinders) }
+  let(:user) { instance_double(Aeon::User, appointments: user_appointments) }
+  let(:availability) { described_class.new(reading_room: reading_room, user: user) }
+
+  def slot(start_at, max_minutes)
+    Aeon::AvailableAppointment.new(start_time: Time.zone.parse(start_at), maximum_appointment_length: max_minutes.minutes)
+  end
+
+  before do
+    allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([])
+  end
+
+  describe '#slots_on' do
+    let(:date) { Date.parse('2026-06-15') }
+
+    it 'delegates the raw available slots fetch to the reading room' do
+      allow(reading_room).to receive(:available_appointments).with(date, include_next_available: false).and_return([])
+      availability.slots_on(date)
+      expect(reading_room).to have_received(:available_appointments).with(date, include_next_available: false)
+    end
+
+    it 'passes include_next_available through to the reading room' do
+      allow(reading_room).to receive(:available_appointments).with(date, include_next_available: true).and_return([])
+      availability.slots_on(date, include_next_available: true)
+      expect(reading_room).to have_received(:available_appointments).with(date, include_next_available: true)
+    end
+
+    it "returns the reading room's slots when the user has no existing appointments" do
+      one_slot = slot('2026-06-15 10:00', 120)
+      allow(reading_room).to receive(:available_appointments).and_return([one_slot])
+      expect(availability.slots_on(date)).to eq([one_slot])
+    end
+
+    it "excludes the user's existing appointments from the deconfliction set when excluding_id matches" do
+      excluded = build(:aeon_appointment, id: 42, start_time: Time.zone.parse('2026-06-15 10:00'),
+                                          stop_time: Time.zone.parse('2026-06-15 11:00'))
+      allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([excluded])
+      one_slot = slot('2026-06-15 10:00', 120)
+      allow(reading_room).to receive(:available_appointments).and_return([one_slot])
+
+      expect(availability.slots_on(date, excluding_id: 42)).to eq([one_slot])
+    end
+
+    it 'deconflicts against the users other existing appointments' do
+      conflicting = build(:aeon_appointment, id: 99, start_time: Time.zone.parse('2026-06-15 10:00'),
+                                             stop_time: Time.zone.parse('2026-06-15 11:00'))
+      allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([conflicting])
+      allow(reading_room).to receive(:available_appointments).and_return([slot('2026-06-15 10:00', 120)])
+
+      expect(availability.slots_on(date)).to be_empty
+    end
+  end
+
+  describe '#available_at?' do
+    let(:range) { Time.zone.parse('2026-06-15 10:00')..Time.zone.parse('2026-06-15 11:00') }
+
+    it 'is true when a slot starts at the range start and covers the requested duration' do
+      allow(reading_room).to receive(:available_appointments).and_return([slot('2026-06-15 10:00', 120)])
+      expect(availability.available_at?(range: range)).to be true
+    end
+
+    it 'is false when the slot starts at a different time' do
+      allow(reading_room).to receive(:available_appointments).and_return([slot('2026-06-15 10:15', 120)])
+      expect(availability.available_at?(range: range)).to be false
+    end
+
+    it 'is false when the slot is shorter than the requested duration' do
+      allow(reading_room).to receive(:available_appointments).and_return([slot('2026-06-15 10:00', 30)])
+      expect(availability.available_at?(range: range)).to be false
+    end
+
+    it 'is false when the reading room has no availability' do
+      allow(reading_room).to receive(:available_appointments).and_return([])
+      expect(availability.available_at?(range: range)).to be false
+    end
+
+    it 'ignores an existing appointment matching excluding_id' do
+      excluded = build(:aeon_appointment, id: 7, start_time: range.begin, stop_time: range.end)
+      allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([excluded])
+      allow(reading_room).to receive(:available_appointments).and_return([slot('2026-06-15 10:00', 120)])
+      expect(availability.available_at?(range: range, excluding_id: 7)).to be true
+    end
+  end
+end

--- a/spec/models/aeon/appointment_spec.rb
+++ b/spec/models/aeon/appointment_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Aeon::Appointment do
       end
     end
 
-    context 'when validating slot availability' do
+    context 'when a slot_available error is attached' do
       let(:user) { instance_double(Aeon::User, appointments: user_appointments) }
       let(:user_appointments) { instance_double(Aeon::AppointmentFinders) }
       let(:appointment) do
@@ -254,42 +254,12 @@ RSpec.describe Aeon::Appointment do
 
       before do
         allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([])
+        allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return([])
       end
 
-      context 'when Aeon returns no availability for the date' do
-        before do
-          allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return([])
-        end
-
-        it 'is invalid on :date for day-only rooms' do
-          expect(appointment).not_to be_valid
-          expect(appointment.errors[:date]).to include('is not available')
-        end
-      end
-
-      context 'when Aeon returns a slot but not long enough for the requested duration' do
-        before do
-          allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return(
-            [Aeon::AvailableAppointment.new(start_time: start_time, maximum_appointment_length: 1.hour)]
-          )
-        end
-
-        it { expect(appointment).not_to be_valid }
-      end
-
-      context 'when the user already has an appointment covering the requested span' do
-        let(:existing) do
-          build(:aeon_appointment, id: 99, start_time: start_time, stop_time: stop_time)
-        end
-
-        before do
-          allow(user_appointments).to receive(:for_reading_room).with(reading_room).and_return([existing])
-          allow(reading_room).to receive(:available_appointments).with(start_time.to_date, include_next_available: false).and_return(
-            [Aeon::AvailableAppointment.new(start_time: start_time, maximum_appointment_length: 8.hours)]
-          )
-        end
-
-        it { expect(appointment).not_to be_valid }
+      it 'attaches the error to :date for day-only reading rooms' do
+        expect(appointment).not_to be_valid
+        expect(appointment.errors[:date]).to include('is not available')
       end
     end
 

--- a/spec/models/aeon/appointment_spec.rb
+++ b/spec/models/aeon/appointment_spec.rb
@@ -132,6 +132,33 @@ RSpec.describe Aeon::Appointment do
       it { expect(appointment).not_to be_valid }
     end
 
+    context 'when a reading room has multiple open-hour blocks on the same day' do
+      # ARS-style Thursday: 9:00-11:00 am and 12:00-3:00 pm
+      let(:reading_room) do
+        build(:aeon_reading_room, open_hours: [
+                build(:aeon_reading_room_open_hours, day_of_week: 4, day_name: 'Thursday',
+                                                     open_time: Time.zone.parse('09:00'), close_time: Time.zone.parse('11:00')),
+                build(:aeon_reading_room_open_hours, day_of_week: 4, day_name: 'Thursday',
+                                                     open_time: Time.zone.parse('12:00'), close_time: Time.zone.parse('15:00'))
+              ])
+      end
+
+      context 'when the appointment falls in the afternoon block' do
+        # Thursday 1:30 - 3:00 pm PT
+        let(:start_time) { Time.zone.parse('2026-07-23T13:30:00-07:00') }
+        let(:stop_time)  { Time.zone.parse('2026-07-23T15:00:00-07:00') }
+
+        it { expect(appointment).to be_valid }
+      end
+
+      context 'when the appointment straddles the gap between the two blocks' do
+        let(:start_time) { Time.zone.parse('2026-07-23T10:30:00-07:00') }
+        let(:stop_time)  { Time.zone.parse('2026-07-23T12:30:00-07:00') }
+
+        it { expect(appointment).not_to be_valid }
+      end
+    end
+
     context 'when stop_time is not after start_time' do
       let(:start_time) { Time.zone.parse('2026-03-16T10:00:00-07:00') }
       let(:stop_time)  { Time.zone.parse('2026-03-16T10:00:00-07:00') }


### PR DESCRIPTION
I hit a validation bug with ARS's split hours. I started refactoring, trying to find it, figuring I just broke it with https://github.com/sul-dlss/sul-requests/pull/4051. The refactor ended up not being necessary, but I *think* I'd rather have a new little `AppointmentSlotAvailability` guy than have `ReadingRoom` need to know things about a user, etc.