### PR TITLE
fix scan not working with checked out items due to required fields being enabled

### DIFF
--- a/app/javascript/controllers/patron_request_controller.js
+++ b/app/javascript/controllers/patron_request_controller.js
@@ -32,9 +32,15 @@ export default class extends Controller {
   }
 
   showHideItemGroups(event) {
+    const formData = new FormData(this.element);
+    const requestType = formData.get('patron_request[request_type]');
     const itemGroups = this.element.querySelectorAll('.selected-items-container');
 
     Array.from(itemGroups).forEach(itemGroup => {
+      const itemGroupType = itemGroup.closest('.accordion-item').dataset.patronrequestForrequesttype
+      // We don't want to enable required pickup fields when the user has selected scan and visa versa
+      if (itemGroupType != requestType) { return }
+
       if (!itemGroup.querySelector('[data-content-id]')) {
         itemGroup.classList.add('d-none');
         this.disableRequiredInputs(itemGroup);

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -517,7 +517,34 @@ RSpec.describe 'Creating a request', :js do
 
     before do
       allow(Folio::Patron).to receive(:find_by).with(patron_key: user.patron_key).and_return(patron)
+      stub_request(:post, 'https://illiad-test/ILLiadWebPlatform/Transaction/')
       login_as(current_user)
+    end
+
+    it 'submits scan request and does not enable required pickup fields' do
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS')
+
+      choose 'Email digital scan'
+      click_on 'Continue'
+
+      choose 'ABC 123'
+      click_on 'Continue'
+
+      fill_in 'Page range', with: '1-15'
+      fill_in 'Title of article or chapter', with: 'Some title'
+      fill_in 'Author(s)', with: 'Some author'
+
+      expect do
+        perform_enqueued_jobs do
+          click_on 'Submit request'
+        end
+        expect(page).to have_text 'We received your scan request'
+      end.to change(PatronRequest, :count).by(1)
+
+      expect(PatronRequest.last).to have_attributes(
+        scan_title: 'Some title',
+        scan_authors: 'Some author'
+      )
     end
 
     it 'enables the submit button when selecting only the available item after choosing pickup' do


### PR DESCRIPTION
The fulfillment type is getting enabled after it is disabled. This only happens on items that have the fulfillment_preference because the fulfillment_preference is getting enabled by   showHideItemGroups. We need to just not enable if pickup isn't checked/not enable if scan isn't checked.
closes #4102 