### PR TITLE
Pass requested_barcodes through the request lifecycle

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -165,7 +165,7 @@ class PatronRequestsController < ApplicationController
                                    :fulfillment_type, :request_type,
                                    :scan_page_range, :scan_authors, :scan_title,
                                    :aeon_reading_special, :aeon_terms, :ead_url,
-                                   { barcodes: [] }, { activity_ids: [] }, { aeon_item: aeon_term_params }])
+                                   { barcodes: [], requested_barcodes: [], activity_ids: [], aeon_item: aeon_term_params }])
   end
 
   def handle_ead_client_error

--- a/app/views/patron_requests/new.html+aeon.erb
+++ b/app/views/patron_requests/new.html+aeon.erb
@@ -55,6 +55,9 @@
   <% scan_or_pickup_step = nil %>
   <%= f.hidden_field :instance_hrid %>
   <%= f.hidden_field :origin_location_code %>
+  <% f.object.requested_barcodes&.each do |barcode| %>
+    <%= f.hidden_field :requested_barcodes, multiple: true, value: barcode %>
+  <% end if f.object.selectable_items.any? %>
   <%= f.hidden_field :aeon_system_id, name: 'SystemID', value: 'sul-requests' %>
   <%= f.hidden_field :aeon_request_form, name: 'WebRequestForm', value: 'GenericRequestMonograph' %>
   <%= f.hidden_field :aeon_document_type, name: 'DocumentType', value: 'Monograph' %>
@@ -64,9 +67,9 @@
   <%= f.hidden_field :aeon_author, name: 'ItemAuthor', value: f.object.folio_instance.author %>
   <%= f.hidden_field :aeon_date, name: 'ItemDate', value: f.object.folio_instance.pub_date %>
   <%= f.hidden_field :item_url, name: 'ItemInfo1', value: f.object.view_url %>
-  <% if f.object.selectable_items.one? || f.object.barcodes&.one? %>
+  <% if f.object.selectable_items.one? %>
     <% single_item = f.object.selectable_items.first %>
-    <% single_barcode = f.object.barcodes&.first || (single_item&.barcode || single_item&.id) %>
+    <% single_barcode = single_item&.barcode || single_item&.id %>
     <%= f.hidden_field :barcodes, multiple: true, value: single_barcode %>
     <%= f.hidden_field :aeon_request_index, name: 'Request', value: 1 %>
     <%= f.hidden_field :aeon_callnumber, name: 'CallNumber_1', value: single_item.callnumber %>

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -30,9 +30,12 @@
 <% scan_or_pickup_step = nil %>
 <%= f.hidden_field :instance_hrid %>
 <%= f.hidden_field :origin_location_code %>
-<% if f.object.selectable_items.one? || f.object.barcodes&.one? %>
+<% f.object.requested_barcodes&.each do |barcode| %>
+  <%= f.hidden_field :requested_barcodes, multiple: true, value: barcode %>
+<% end if f.object.selectable_items.any? %>
+<% if f.object.selectable_items.one? %>
   <% single_item = f.object.selectable_items.first %>
-  <% single_barcode = f.object.barcodes&.first || (single_item&.barcode || single_item&.id) %>
+  <% single_barcode = single_item&.barcode || single_item&.id %>
   <%= f.hidden_field :barcodes, multiple: true, value: single_barcode %>
 <% end %>
 <%= f.hidden_field :ead_url if f.object.ead_url.present? %>

--- a/app/views/patron_requests/new.html.erb
+++ b/app/views/patron_requests/new.html.erb
@@ -55,9 +55,12 @@
   <% scan_or_pickup_step = nil %>
   <%= f.hidden_field :instance_hrid %>
   <%= f.hidden_field :origin_location_code %>
-  <% if f.object.selectable_items.one? || f.object.barcodes&.one? %>
+  <% f.object.requested_barcodes&.each do |barcode| %>
+    <%= f.hidden_field :requested_barcodes, multiple: true, value: barcode %>
+  <% end if f.object.selectable_items.any? %>
+  <% if f.object.selectable_items.one? %>
     <% single_item = f.object.selectable_items.first %>
-    <% single_barcode = f.object.barcodes&.first || (single_item&.barcode || single_item&.id) %>
+    <% single_barcode = single_item&.barcode || single_item&.id %>
     <%= f.hidden_field :barcodes, multiple: true, value: single_barcode %>
   <% end %>
   <%# only allow submitting on enter if the final submit button is focused %>


### PR DESCRIPTION
I puzzled over this condition for too long.

I think the goal is:
 - if there's only one item, don't show the item selector
 - if the user has pre-selected an item (using an item-level request button in searchworks), don't show the item selector
 - if the user had pre-selected an item, submitted the form, and one of the validation checks failed, keep showing the form as the user initially saw it

It's the last condition that's a little funky because we weren't passing `requested_barcodes` through to `patron_requests#create`, so we approximated it by seeing if the user only selected a single barcode. I think it's much clearer to just pass the initially requested barcodes back through (maybe the check for whether that actually yielded selectable items is over-the-top but 🤷‍♂️) 