### PR TITLE
Use the full month-day-year to avoid ambiguity.

### DIFF
--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe 'Creating a request', :js do
         click_on 'Select a date'
         next_monday = today.next_week(:monday)
         click_on 'Next month' if today.month != next_monday.month
-        click_on next_monday.day.to_s
+        click_on next_monday.strftime('%B %-d, %Y')
 
         expect do
           perform_enqueued_jobs do

--- a/spec/features/mediation_table_spec.rb
+++ b/spec/features/mediation_table_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe 'Mediation table', :js do
           click_on I18n.l(Time.zone.today, format: :quick)
           click_on I18n.l(Time.zone.today, format: :short)
           click_on 'Next month'
-          click_on new_date.day.to_s
+          click_on new_date.strftime('%B %-d, %Y')
           click_on 'ok'
         end
       end


### PR DESCRIPTION
I guess when `day` returns e.g. "1", we end up matching lots of values. 