### PR TITLE
Update navigation to reflect when user is acting as proxy

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,10 @@ module ApplicationHelper
     respond_to?(:patron_or_group) && controller_name != 'patron_requests'
   end
 
+  def acting_as_proxy?
+    respond_to?(:patron_or_group) && patron_or_group.is_a?(Folio::ProxyGroup)
+  end
+
   def dialog_column_class
     'col-lg-6 offset-lg-3'
   end

--- a/app/views/layouts/application_redesign.html.erb
+++ b/app/views/layouts/application_redesign.html.erb
@@ -46,14 +46,18 @@
           <%= link_to 'Borrowed items', checkouts_path, class: 'nav-link fw-semibold' %>
         <% end if current_user.patron.present? %>
 
-        <% if current_user.aeon.present? || current_user.patron.present? %>
+        <% if acting_as_proxy? && !can?(:manage, :site) %>
+          <% component.with_nav_item do %>
+            <%= link_to 'Submitted requests', unified_requests_url, class: 'nav-link fw-semibold' %>
+          <% end %>
+        <% elsif current_user.aeon.present? || current_user.patron.present? %>
           <% component.with_nav_item(classes: ['dropdown']) do %>
             <button class="nav-link dropdown-toggle fw-semibold" data-bs-toggle="dropdown" aria-expanded="false">
               Requests
             </button>
             <ul class="dropdown-menu">
               <li><%= link_to 'Submitted requests', unified_requests_url, class: 'dropdown-item' %></li>
-              <% if current_user.aeon.present? %>
+              <% if current_user.aeon.present? && !acting_as_proxy? %>
               <li><%= link_to 'Saved for later', aeon_requests_url(kind: 'saved_for_later'), class: 'dropdown-item' %></li>
               <li><%= link_to 'Cancelled requests', aeon_requests_url(kind: 'cancelled'), class: 'dropdown-item' %></li>
               <li><%= link_to 'Completed requests', aeon_requests_url(kind: 'completed'), class: 'dropdown-item' %></li>
@@ -69,7 +73,7 @@
           <% end %>
         <% end %>
 
-        <% if current_user.aeon.present? %>
+        <% if current_user.aeon.present? && !acting_as_proxy? %>
           <% component.with_nav_item do %>
             <%= link_to 'Activities', aeon_activities_url, class: 'nav-link fw-semibold' %>
           <% end if current_user.aeon.activities.present? %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -77,7 +77,7 @@
         </div>
       <% end %>
     <% end %>
-  <% end unless patron_or_group.is_a? Folio::ProxyGroup %>
+  <% end unless acting_as_proxy? %>
 
   <%= turbo_frame_tag :ill_requests, src: ill_requests_path(async: true) %>
   <%= turbo_frame_tag :mediated_requests, src: mediated_requests_path(async: true) %>

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -79,6 +79,38 @@ RSpec.describe 'Proxy User' do
     end
   end
 
+  context 'when acting as a proxy' do
+    let(:aeon_user) { instance_double(Aeon::User, present?: true, activities: [double(present?: true)]) }
+
+    before do
+      allow(Aeon::User).to receive(:find_by).and_return(aeon_user)
+    end
+
+    it 'hides Aeon-specific nav items' do
+      visit checkouts_path
+
+      expect(page).to have_link('Appointments')
+
+      click_on 'Switch to proxy'
+      click_on 'Proxy for: Shea Sponsor'
+
+      expect(page).to have_no_link('Appointments')
+      expect(page).to have_no_link('Activities')
+    end
+
+    it 'collapses the Requests dropdown to a flat Submitted requests link' do
+      visit checkouts_path
+
+      expect(page).to have_button('Requests')
+
+      click_on 'Switch to proxy'
+      click_on 'Proxy for: Shea Sponsor'
+
+      expect(page).to have_no_button('Requests')
+      expect(page).to have_link('Submitted requests')
+    end
+  end
+
   context 'when on the home page', :js do
     it 'displays the sponsor information' do
       visit root_path


### PR DESCRIPTION
Part of #3831 

Hopefully we were thinking of something like this.

User cannot manage:
<img width="1158" height="147" alt="Screenshot 2026-07-17 at 2 12 03 PM" src="https://github.com/user-attachments/assets/47a812ac-aa37-411a-8559-768f16ddaa2a" />
<img width="1158" height="162" alt="Screenshot 2026-07-17 at 2 12 35 PM" src="https://github.com/user-attachments/assets/246c8c63-c8c8-4cdf-a42b-1bd2e7d65832" />

User can manage:
<img width="1141" height="362" alt="Screenshot 2026-07-17 at 2 19 37 PM" src="https://github.com/user-attachments/assets/df1535bc-8059-4435-ad91-c2cdbbb3bc0c" />
<img width="1160" height="287" alt="Screenshot 2026-07-17 at 2 19 18 PM" src="https://github.com/user-attachments/assets/4f2fe938-cf45-4a5e-a43f-4ae8a28c0917" />


