### PR TITLE
Extract a manual-items-controller from the item selector

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("password-visibility", PasswordVisibilityController)
 import ItemSelectorController from "./item_selector_controller"
 application.register("item-selector", ItemSelectorController)
 
+import ManualItemsController from "./manual_items_controller"
+application.register("manual-items", ManualItemsController)
+
 import TableController from "./table_controller"
 application.register("table", TableController)
 

--- a/app/javascript/controllers/item_selector_controller.js
+++ b/app/javascript/controllers/item_selector_controller.js
@@ -15,7 +15,7 @@ function typecast(value) {
 }
 
 export default class extends Controller {
-  static targets = ['item', 'toast', 'selectedItems', 'manualInputContainer']
+  static targets = ['item', 'toast', 'selectedItems']
   static values = { itemLimit: { type: Number, default: -1 }, requestType: String, selectedItems: Array }
 
   connect() { }
@@ -69,50 +69,11 @@ export default class extends Controller {
     }
   }
 
-  input(event) {
-    if (event.currentTarget.value) {
-      const value = event.currentTarget.value;
-      const index = parseInt(event.currentTarget.dataset.index);
-      // This id needs to take the user input because selectedItemsValueChanged won't update the form if the id is the same
-      const id = `${event.currentTarget.dataset.prepend}-${value.trim().replace(/[^a-zA-Z0-9]/g, '').replaceAll(' ', '-').toLowerCase()}`;
-      const prevId = event.currentTarget.dataset.id;
-
-      // We need to mutate the form so that when we submit the form the elements end up in the same hash
-      // so manual-input-1 becomes manual-input-1-box-1
-      document.querySelectorAll(`[data-id="${prevId}"`).forEach(elem => {
-        elem.name = elem.name.replace(prevId, id);
-        elem.dataset.id = id;
-      })
-
-      this.selectedItemsValue = this.selectedItemsValue.filter((item) => item.index !== index);
-      this.selectedItemsValue = this.selectedItemsValue.concat([{titleParts: [value],
-                                                                 id: id,
-                                                                 index: index}]);
-    }
-  }
-
-  addInputField(event) {
-    event.preventDefault();
-    let template = document.querySelector(event.currentTarget.dataset.template);
-    if (template) {
-      const inputElements =  document.querySelectorAll('[data-index]');
-      const index = parseInt(inputElements[inputElements.length - 1].dataset.index);
-      const element = document.importNode(template.content, true);
-      const rootNode = element.querySelector('[data-root-node]');
-      rootNode.innerHTML = rootNode.innerHTML.replaceAll('__INDEX__', index + 1);
-      this.manualInputContainerTarget.appendChild(rootNode);
-    }
-  }
-
-  removeInputField(event) {
-    event.preventDefault()
-    event.currentTarget.parentElement.remove();
-    const index = parseInt(event.currentTarget.dataset.index);
-    this.selectedItemsValue = this.selectedItemsValue.filter((item) => item.index !== index);
-
-    // This has to be done here because after removal of the element the check doesn't run if attatched to the element.
-    const accordionController = this.application.getControllerForElementAndIdentifier(this.element, 'accordion-form');
-    accordionController.reenableNextButtons();
+  syncFromManualItems(event) {
+    this.selectedItemsValue = event.detail.entries.map(entry => ({
+      id: entry.id,
+      titleParts: [entry.title]
+    }));
   }
 
   remove(event) {
@@ -154,6 +115,16 @@ export default class extends Controller {
   selectedItemsValueChanged(value, previousValue) {
     const removed = (previousValue || []).filter(item => !value.find(v => v.id == item.id));
     const added = value.filter(item => !(previousValue || []).find(v => v.id == item.id));
+    const retitled = value.filter(item => {
+      const prev = (previousValue || []).find(v => v.id == item.id);
+      return prev && JSON.stringify(prev.titleParts) !== JSON.stringify(item.titleParts);
+    });
+
+    retitled.forEach(item => {
+      this.element.querySelectorAll(`[data-content-id="${item.id}"] .selected-item-title`).forEach(el => {
+        el.innerHTML = this.formatItemTitle(item);
+      });
+    });
 
     removed.forEach(item => {
       // remove the digitization section, physical item section, and hidden inputs for the item

--- a/app/javascript/controllers/manual_items_controller.js
+++ b/app/javascript/controllers/manual_items_controller.js
@@ -1,0 +1,67 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ['rows', 'template'];
+
+  connect() {
+    if (this.rowElements().length === 0) this.createRow();
+    else this.rowElements().forEach(row => this.normalizeRow(row));
+    this.emitChange();
+  }
+
+  addRow(event) {
+    event.preventDefault();
+    this.createRow();
+    this.emitChange();
+  }
+
+  removeRow(event) {
+    event.preventDefault();
+    event.currentTarget.closest('[data-manual-items-row]').remove();
+    this.emitChange();
+  }
+
+  // Hide rows the user saved for later.
+  syncSavedForLater() {
+    const savedIds = new Set(
+      Array.from(document.querySelectorAll('[data-save-for-later-target="list"] [data-content-id]'))
+        .map(el => el.dataset.contentId)
+    );
+
+    this.rowElements().forEach(row => {
+      row.classList.toggle('d-none', savedIds.has(row.dataset.contentId));
+    });
+  }
+
+  // Set the row's UUID as both the aeon_item hash key (server-side identity)
+  // and data-content-id (cross-controller handle).
+  normalizeRow(row) {
+    const uuid = row.querySelector('input[type="hidden"]').value;
+    row.dataset.contentId = uuid;
+    row.querySelectorAll('input').forEach(input => {
+      input.name = input.name.replace(/\[aeon_item\]\[[^\]]+\]/, `[aeon_item][${uuid}]`);
+    });
+  }
+
+  emitChange() {
+    const entries = this.rowElements().map(row => ({
+      id: row.dataset.contentId,
+      title: row.querySelector('input[type="text"]').value,
+    }));
+
+    this.dispatch('changed', { detail: { entries } });
+  }
+
+  createRow() {
+    const fragment = document.importNode(this.templateTarget.content, true);
+    const rootNode = fragment.querySelector('[data-manual-items-row]');
+
+    this.rowsTarget.appendChild(rootNode);
+    rootNode.querySelector('input[type="hidden"]').value = crypto.randomUUID();
+    this.normalizeRow(rootNode);
+  }
+
+  rowElements() {
+    return Array.from(this.rowsTarget.querySelectorAll('[data-manual-items-row]'));
+  }
+}

--- a/app/javascript/controllers/save_for_later_controller.js
+++ b/app/javascript/controllers/save_for_later_controller.js
@@ -68,7 +68,7 @@ export default class extends Controller {
 
   formItemsFor(id) {
     return Array.from(this.element.querySelectorAll(`[data-content-id="${id}"]:not([data-toggle-disabled])`))
-      .filter(el => !this.listTargets.some(list => list.contains(el)))
+      .filter(el => el.closest('[data-save-for-later-target="section"]') && !this.listTargets.some(list => list.contains(el)))
   }
 
   makeSavedItem(formItem) {

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -19,7 +19,7 @@
     <%= form_for(@patron_request,
                  data: {
                    controller: 'patron-request accordion-form item-selector save-for-later view-container-contents',
-                   action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->accordion-form#typeValueChanged',
+                   action: 'item-selector:changed->patron-request#showItemSelector item-selector:changed->accordion-form#typeValueChanged manual-items:changed->item-selector#syncFromManualItems manual-items:changed->accordion-form#reenableNextButtons',
                    'patron-request-type-value': 'aeon',
                  },
                  html: { class: 'accordion' },
@@ -107,30 +107,25 @@
         </div>
       <% else %>
         <p>Enter the containers you want to request.</p>
-        <div id="manual-input-container" data-item-selector-target="manualInputContainer" class="d-flex flex-column">
-          <div>
-            <%= fields_for "patron_request[aeon_item][manual-input-1]" do |form_fields| %>
-              <%= form_fields.text_field :title, placeholder: 'e.g., Box 1, Reel 5', required: true, data: { prepend: 'manual-input-1', id: 'manual-input-1', action: 'item-selector#input', index: 1 } %>
-              <%= form_fields.hidden_field :id, data: { id: 'manual-input-1' }, value: SecureRandom.uuid %>
-            <% end %>
-          </div>
+        <div id="manual-items-container" data-controller="manual-items" data-action="save-for-later:changed@document->manual-items#syncSavedForLater" class="d-flex flex-column">
+          <div data-manual-items-target="rows"></div>
+
+          <button class="btn btn-link px-0 text-black mt-1 align-self-start" data-action="manual-items#addRow accordion-form#enableNextButton">
+            <i class="bi bi-plus-square-fill text-green me-1"></i>Add container
+          </button>
+
+          <template data-manual-items-target="template">
+            <div data-manual-items-row class="mt-2">
+              <%= fields_for "patron_request[aeon_item][__NEW_ROW__]" do |form_fields| %>
+                <%= form_fields.text_field :title, placeholder: 'e.g., Box 1, Reel 5', required: true, data: { action: 'manual-items#emitChange' } %>
+                <%= form_fields.hidden_field :id %>
+              <% end %>
+              <button class="btn btn-link px-0 text-black" data-action="manual-items#removeRow">
+                <i class="bi bi-dash-square-fill text-danger me-1"></i>Delete
+              </button>
+            </div>
+          </template>
         </div>
-
-        <button class="btn btn-link px-0 text-black mt-1" data-action="item-selector#addInputField accordion-form#enableNextButton" data-template="#inputForm">
-          <i class="bi bi-plus-square-fill text-green me-1"></i>Add container
-        </button>
-
-        <template id="inputForm">
-          <div data-root-node="true" class="mt-2">
-            <%= fields_for "patron_request[aeon_item][manual-input-__INDEX__]" do |form_fields| %>
-              <%= form_fields.text_field :title, placeholder: 'e.g., Box 1, Reel 5', required: true, data: { prepend: 'manual-input-__INDEX__',  id: 'manual-input-__INDEX__', action: 'item-selector#input', index: "__INDEX__" } %>
-              <%= form_fields.hidden_field :id, value: SecureRandom.uuid, data: { id: 'manual-input-__INDEX__' } %>
-            <% end %>
-            <button class="btn btn-link px-0 text-black" data-index="__INDEX__" data-action="item-selector#removeInputField">
-              <i class="bi bi-dash-square-fill text-danger me-1"></i>Delete
-            </button>
-          </div>
-        </template>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -462,6 +462,77 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect(page).to have_no_checked_field('Activity')
     end
 
+    it 'preserves saved-for-later manually added items' do # rubocop:disable RSpec/ExampleLength
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+
+      first('[data-manual-items-row] input[type=text]').set('Box 1')
+      click_button 'Add container'
+      all('[data-manual-items-row] input[type=text]')[1].set('Box 2')
+      click_button 'Continue'
+
+      # Row title edits round-trip through the accordion summary
+      within('#items-accordion') { click_button 'Edit' }
+      first('[data-manual-items-row] input[type=text]').set('Renamed')
+      click_button 'Continue'
+      expect(page).to have_text 'Renamed'
+      expect(page).to have_no_text 'Box 1'
+
+      within('#items-accordion') { click_button 'Edit' }
+      first('[data-manual-items-row] input[type=text]').set('Box 1')
+      click_button 'Continue'
+
+      first('[data-content-id]', text: 'Box 1').click_button('Save for later')
+      first('[data-content-id]', text: 'Box 2').click_button('Save for later')
+      expect(page).to have_css('.saved-item', text: 'Box 1')
+      expect(page).to have_css('.saved-item', text: 'Box 2')
+
+      within('#items-accordion') { click_button 'Edit' }
+
+      # Saved for later manual items are hidden but still in the DOM so they submit
+      expect(page).to have_css('[data-manual-items-row].d-none', count: 2, visible: :hidden)
+      expect(page).to have_no_field(with: 'Box 1')
+      expect(page).to have_no_field(with: 'Box 2')
+
+      # Add a new, not saved for later manual item
+      click_button 'Add container'
+      first('[data-manual-items-row]:not(.d-none) input[type=text]').set('Box 3')
+      click_button 'Continue'
+
+      expect(page).to have_css('.saved-item', text: 'Box 1')
+      expect(page).to have_css('.saved-item', text: 'Box 2')
+      expect(page).to have_css('[data-content-id] .selected-item-title', text: 'Box 3')
+
+      fill_in 'Requested pages', with: 'Pages 1-10'
+      click_button 'Submit request'
+      expect(page).to have_css('.confirmation')
+      expect(PatronRequest.last.aeon_item.values.pluck('title')).to contain_exactly('Box 1', 'Box 2', 'Box 3')
+    end
+
+    it 'disables the "Continue" button while a manual-input row is empty' do
+      visit new_archives_request_path(value: 'http://example.com/ead.xml')
+
+      choose 'Digitization'
+      check 'I agree to these terms'
+      click_button 'Continue'
+
+      within('#items-accordion') do
+        expect(page).to have_button('Continue', disabled: true)
+
+        first('[data-manual-items-row] input[type=text]').set('Box 1')
+        expect(page).to have_button('Continue', disabled: false)
+
+        click_button 'Add container'
+        expect(page).to have_button('Continue', disabled: true)
+
+        all('[data-manual-items-row] input[type=text]')[1].set('Box 2')
+        expect(page).to have_button('Continue', disabled: false)
+      end
+    end
+
     it 'allows users to input boxes manually' do # rubocop:disable RSpec/ExampleLength
       visit new_archives_request_path(value: 'http://example.com/ead.xml')
 
@@ -472,12 +543,12 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'I agree to these terms'
       click_button 'Continue'
 
-      find('input[data-prepend="manual-input-1"]').set('Box 1')
+      first('[data-manual-items-row] input[type=text]').set('Box 1')
       click_button 'Add container'
-      find('input[data-prepend="manual-input-2"]').set('Box 24 ')
+      all('[data-manual-items-row] input[type=text]')[1].set('Box 24 ')
       click_button 'Add container'
-      find('input[data-prepend="manual-input-3"]').set('Box 25 ')
-      find('button[data-index="2"]').click
+      all('[data-manual-items-row] input[type=text]')[2].set('Box 25 ')
+      within(all('[data-manual-items-row]')[1]) { click_button 'Delete' }
 
       click_button 'Continue'
 
@@ -498,7 +569,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       expect do
         perform_enqueued_jobs
       end.to change(StubAeonClient::Request, :count).by(2)
-      expect(PatronRequest.last.aeon_item.keys).to eq ['manual-input-1-box1', 'manual-input-3-box25']
+      expect(PatronRequest.last.aeon_item.length).to eq 2
 
       expect(StubAeonClient::Request.last(2)).to contain_exactly(
         have_attributes(
@@ -525,9 +596,9 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       choose 'Reading room appointment'
       click_button 'Continue'
 
-      find('input[data-prepend="manual-input-1"]').set('Box 1')
+      first('[data-manual-items-row] input[type=text]').set('Box 1')
       click_button 'Add container'
-      find('input[data-prepend="manual-input-2"]').set('Box 24 ')
+      all('[data-manual-items-row] input[type=text]')[1].set('Box 24 ')
       click_button 'Continue'
 
       # Expect no viewing modal links
@@ -540,9 +611,9 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       check 'I agree to these terms'
       click_button 'Continue'
 
-      find('input[data-prepend="manual-input-1"]').set('Box 1')
+      first('[data-manual-items-row] input[type=text]').set('Box 1')
       click_button 'Add container'
-      find('input[data-prepend="manual-input-2"]').set('Box 24 ')
+      all('[data-manual-items-row] input[type=text]')[1].set('Box 24 ')
       click_button 'Continue'
 
       # Expect no viewing modal links


### PR DESCRIPTION
Extracts the EAD no container/manual item handling from the item selector. Also makes save for later in this case work a bit more like the regular flows.