### PR TITLE
Reverse-sort the date modified / update sort defaults for request kinds

### DIFF
--- a/app/controllers/concerns/aeon_sortable.rb
+++ b/app/controllers/concerns/aeon_sortable.rb
@@ -21,8 +21,6 @@ module AeonSortable
     }
   }.freeze
 
-  DEFAULT_SORT = 'request_timing'
-
   included do
     helper_method :current_aeon_sort, :available_aeon_sort_options
   end
@@ -33,11 +31,28 @@ module AeonSortable
     SORT_OPTIONS[current_aeon_sort][:sort].call(requests)
   end
 
+  def default_sort
+    case params[:kind]
+    when 'submitted'
+      'request_timing'
+    when 'saved_for_later'
+      'title'
+    else
+      'date'
+    end
+  end
+
   def current_aeon_sort
-    available_aeon_sort_options.key?(params[:sort]) ? params[:sort] : DEFAULT_SORT
+    available_aeon_sort_options.key?(params[:sort]) ? params[:sort] : default_sort
+  end
+
+  def sort_option_keys
+    return %w[title date request_timing] if default_sort == 'request_timing'
+
+    %w[title date]
   end
 
   def available_aeon_sort_options
-    SORT_OPTIONS
+    SORT_OPTIONS.slice(*sort_option_keys)
   end
 end

--- a/app/models/aeon/request.rb
+++ b/app/models/aeon/request.rb
@@ -4,6 +4,7 @@ module Aeon
   # Wraps an Aeon request record
   class Request
     include ActiveModel::Model
+    include RequestSorting
 
     # appointment attributes
     attr_accessor :appointment, :appointment_id
@@ -195,7 +196,7 @@ module Aeon
                  when :title
                    [title, default_sort_key]
                  when :date
-                   [(transaction_date || 100.years.from_now.end_of_day).strftime('%FT%T'), title, default_sort_key]
+                   [reverse_sort((transaction_date || 100.years.from_now.end_of_day).strftime('%FT%T')), title, default_sort_key]
                  when :default
                    [(appointment&.start_time || 100.years.from_now.end_of_day).strftime('%FT%T'), title, default_sort_key]
                  else

--- a/app/models/concerns/request_sorting.rb
+++ b/app/models/concerns/request_sorting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Helpers for sorting different types of requests
+module RequestSorting
+  def reverse_sort(str)
+    return if str.blank?
+
+    str.tr('0123456789', '9876543210')
+  end
+end

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -5,6 +5,7 @@ module Folio
   class Request
     include Folio::FolioRecord
     include ActiveModel::Model
+    include RequestSorting
 
     attr_reader :record
 
@@ -99,7 +100,7 @@ module Folio
     def sort_key(key)
       sort_key = case key
                  when :date
-                   [placed_date&.strftime('%FT%T'), title, author, shelf_key]
+                   [reverse_sort(placed_date&.strftime('%FT%T')), title, author, shelf_key]
                  when :title
                    [title, author, shelf_key]
                  when :default

--- a/app/models/illiad/request.rb
+++ b/app/models/illiad/request.rb
@@ -6,6 +6,8 @@
 module Illiad
   # ILLiad Request class (that duck-types our Folio::Request class)
   class Request
+    include RequestSorting
+
     def self.where(user_id:)
       IlliadClient.new.user_transactions(user_id).reject(&:inactive?)
     end
@@ -51,7 +53,7 @@ module Illiad
     def sort_key(key)
       sort_key = case key
                  when :date
-                   [placed_date.strftime('%FT%T'), title, author, call_number]
+                   [reverse_sort(placed_date.strftime('%FT%T')), title, author, call_number]
                  when :title
                    [title, author, call_number]
                  when :default

--- a/spec/controllers/concerns/aeon_sortable_spec.rb
+++ b/spec/controllers/concerns/aeon_sortable_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AeonSortable do
 
   let(:controller) { controller_class.new }
   let(:now) { Time.zone.now }
+  let(:kind_param) { 'submitted' }
 
   let(:request_a_with_appointment) do
     build(:aeon_request,
@@ -40,7 +41,7 @@ RSpec.describe AeonSortable do
   end
 
   before do
-    allow(controller).to receive(:params).and_return(ActionController::Parameters.new(sort: sort_param))
+    allow(controller).to receive(:params).and_return(ActionController::Parameters.new(sort: sort_param, kind: kind_param))
   end
 
   describe '#sort_aeon_requests' do
@@ -79,6 +80,26 @@ RSpec.describe AeonSortable do
         expect(result.map(&:title)).to eq %w[Apples Carrots Bananas]
       end
     end
+
+    context 'with cancelled request type' do
+      let(:kind_param) { 'cancelled' }
+      let(:sort_param) { 'invalid' }
+
+      it 'falls back to default sort date' do
+        result = controller.send(:sort_aeon_requests, requests)
+        expect(result.map(&:title)).to eq %w[Carrots Apples Bananas]
+      end
+    end
+
+    context 'with saved_for_later request type' do
+      let(:kind_param) { 'saved_for_later' }
+      let(:sort_param) { 'invalid' }
+
+      it 'falls back to default sort title' do
+        result = controller.send(:sort_aeon_requests, requests)
+        expect(result.map(&:title)).to eq %w[Apples Bananas Carrots]
+      end
+    end
   end
 
   describe '#current_aeon_sort' do
@@ -105,6 +126,24 @@ RSpec.describe AeonSortable do
         expect(controller.send(:current_aeon_sort)).to eq 'request_timing'
       end
     end
+
+    context 'with cancelled request type' do
+      let(:kind_param) { 'cancelled' }
+      let(:sort_param) { nil }
+
+      it 'falls back to default sort date' do
+        expect(controller.send(:current_aeon_sort)).to eq 'date'
+      end
+    end
+
+    context 'with saved_for_later request type' do
+      let(:kind_param) { 'saved_for_later' }
+      let(:sort_param) { nil }
+
+      it 'falls back to default sort title' do
+        expect(controller.send(:current_aeon_sort)).to eq 'title'
+      end
+    end
   end
 
   describe '#available_aeon_sort_options' do
@@ -117,15 +156,14 @@ RSpec.describe AeonSortable do
 
     let(:filterable_controller) { filterable_controller_class.new }
     let(:sort_param) { nil }
+    let(:filter_param) { nil }
 
     before do
       allow(filterable_controller).to receive(:params)
-        .and_return(ActionController::Parameters.new(sort: sort_param, filter: filter_param))
+        .and_return(ActionController::Parameters.new(sort: sort_param, filter: filter_param, kind: kind_param))
     end
 
     context 'without a filter' do
-      let(:filter_param) { nil }
-
       it 'includes all sort options' do
         expect(filterable_controller.send(:available_aeon_sort_options).keys)
           .to eq %w[title date request_timing]
@@ -156,6 +194,24 @@ RSpec.describe AeonSortable do
 
       it 'falls back to default sort' do
         expect(filterable_controller.send(:current_aeon_sort)).to eq 'request_timing'
+      end
+    end
+
+    context 'with cancelled request type' do
+      let(:kind_param) { 'cancelled' }
+
+      it 'does not include request_timing' do
+        expect(filterable_controller.send(:available_aeon_sort_options).keys)
+          .to eq %w[title date]
+      end
+    end
+
+    context 'with saved_for_later request type' do
+      let(:kind_param) { 'saved_for_later' }
+
+      it 'does not include request_timing' do
+        expect(filterable_controller.send(:available_aeon_sort_options).keys)
+          .to eq %w[title date]
       end
     end
   end

--- a/spec/controllers/concerns/aeon_sortable_spec.rb
+++ b/spec/controllers/concerns/aeon_sortable_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe AeonSortable do
 
       it 'sorts by request created/modified time' do
         result = controller.send(:sort_aeon_requests, requests)
-        expect(result.map(&:title)).to eq %w[Bananas Apples Carrots]
+        expect(result.map(&:title)).to eq %w[Carrots Apples Bananas]
       end
     end
 


### PR DESCRIPTION
closes #4124 
closes #4121 
closes #4120 

I could swear I saw a ticket that saved_for_later should be sorted by title. I can't find it anymore. Is that correct or should I fix this ticket?