### PR TITLE
Support per-user item limits.

### DIFF
--- a/app/components/aeon/appointment_component.rb
+++ b/app/components/aeon/appointment_component.rb
@@ -16,7 +16,7 @@ module Aeon
     def add_item_allowed?
       return false unless helpers.can?(:update, appointment)
 
-      appointment.reading_room.appointment_item_limit.nil? || appointment.requests.count < appointment.reading_room.appointment_item_limit
+      appointment.item_limit.nil? || appointment.requests.count < appointment.item_limit
     end
 
     def eligible_saved_for_later_requests

--- a/app/components/aeon/appointment_limit_component.rb
+++ b/app/components/aeon/appointment_limit_component.rb
@@ -6,7 +6,7 @@ module Aeon
     attr_reader :count, :limit, :label, :data
 
     def self.from_appointment(appointment, **)
-      new(count: appointment.requests.count, limit: appointment.reading_room.appointment_item_limit, **)
+      new(count: appointment.requests.count, limit: appointment.item_limit, **)
     end
 
     def initialize(count:, limit:, data: {})

--- a/app/components/aeon/appointment_option_component.rb
+++ b/app/components/aeon/appointment_option_component.rb
@@ -14,7 +14,7 @@ module Aeon
     end
 
     def at_limit?
-      appointment.requests.count >= (appointment.reading_room.appointment_item_limit || 100)
+      appointment.requests.count >= (appointment.item_limit || 100)
     end
   end
 end

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -86,6 +86,10 @@ module Aeon
       start_time.after?(edit_policy.days.from_now)
     end
 
+    def item_limit
+      reading_room&.appointment_item_limit
+    end
+
     def persisted? = id.present?
 
     def save # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -87,7 +87,7 @@ module Aeon
     end
 
     def item_limit
-      reading_room&.appointment_item_limit
+      user&.request_limit || reading_room&.appointment_item_limit
     end
 
     def persisted? = id.present?

--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -87,6 +87,8 @@ module Aeon
     end
 
     def item_limit
+      return nil if user&.request_limit && user.request_limit >= 200
+
       user&.request_limit || reading_room&.appointment_item_limit
     end
 

--- a/app/models/aeon/user.rb
+++ b/app/models/aeon/user.rb
@@ -12,14 +12,15 @@ module Aeon
     end
 
     def self.from_dynamic(data)
-      new(username: data['username'], auth_type: data['authType'])
+      new(username: data['username'], auth_type: data['authType'], request_limit: data['requestLimit'])
     end
 
-    attr_reader :username, :auth_type
+    attr_reader :username, :auth_type, :request_limit
 
-    def initialize(username:, auth_type: nil)
+    def initialize(username:, auth_type: nil, request_limit: nil)
       @username = username
       @auth_type = auth_type
+      @request_limit = request_limit
     end
 
     def ==(other)

--- a/app/views/aeon_appointments/create.turbo_stream.erb
+++ b/app/views/aeon_appointments/create.turbo_stream.erb
@@ -19,8 +19,8 @@
           <span class="fw-normal">New appointment: </span><%= render AppointmentTimeRangeComponent.new(appointment: @appointment, location: @appointment.reading_room.name) %>
         </li>
         <li>Items can be scheduled for this appointment.</li>
-        <% if @appointment.reading_room.appointment_item_limit %>
-          <li>Up to <%= @appointment.reading_room.appointment_item_limit %> items are allowed for this appointment.</li>
+        <% if @appointment.item_limit %>
+          <li>Up to <%= @appointment.item_limit %> items are allowed for this appointment.</li>
         <% end %>
       </ul>
     </div>

--- a/spec/models/aeon/appointment_spec.rb
+++ b/spec/models/aeon/appointment_spec.rb
@@ -324,4 +324,23 @@ RSpec.describe Aeon::Appointment do
       end
     end
   end
+
+  describe '#item_limit' do
+    it 'returns the reading room item limit' do
+      reading_room = build(:aeon_reading_room)
+      appointment = build(:aeon_appointment, reading_room: reading_room)
+
+      expect(appointment.item_limit).to eq(10)
+    end
+
+    context 'with a user who has a custom request limit' do
+      let(:user) { instance_double(Aeon::User, request_limit: 1500) }
+      let(:reading_room) { build(:aeon_reading_room) }
+      let(:appointment) { build(:aeon_appointment, reading_room: reading_room, user: user) }
+
+      it 'returns the user request limit' do
+        expect(appointment.item_limit).to eq(1500)
+      end
+    end
+  end
 end

--- a/spec/models/aeon/appointment_spec.rb
+++ b/spec/models/aeon/appointment_spec.rb
@@ -334,12 +334,22 @@ RSpec.describe Aeon::Appointment do
     end
 
     context 'with a user who has a custom request limit' do
+      let(:user) { instance_double(Aeon::User, request_limit: 22) }
+      let(:reading_room) { build(:aeon_reading_room) }
+      let(:appointment) { build(:aeon_appointment, reading_room: reading_room, user: user) }
+
+      it 'returns the user request limit' do
+        expect(appointment.item_limit).to eq(22)
+      end
+    end
+
+    context 'with a user who has a huge request limit' do
       let(:user) { instance_double(Aeon::User, request_limit: 1500) }
       let(:reading_room) { build(:aeon_reading_room) }
       let(:appointment) { build(:aeon_appointment, reading_room: reading_room, user: user) }
 
       it 'returns the user request limit' do
-        expect(appointment.item_limit).to eq(1500)
+        expect(appointment.item_limit).to be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes #4069 

Most users with a limit have something absurdly high (1k, 10k, etc). One external researchers has a limit of 110. There's also a user with a request limit of 0, probably worth finding out what Aeon does with them.

If the user has a huge limit (say, 200+), we should suppress the bar entirely because the user is unlikely to get there (and even if they do, presumably staff would just raise the limit in practice anyway.. why 1000 items and not 1001 🤷 )


