### PR TITLE
Capture Aeon username on PatronRequest at create time

### DIFF
--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -52,6 +52,8 @@ class PatronRequestsController < ApplicationController
   end
 
   def create
+    @patron_request.aeon_username = current_user.aeon.username if @patron_request.aeon_page?
+
     if @patron_request.save && @patron_request.submit_later
       redirect_to @patron_request
     else

--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -93,7 +93,7 @@ class SubmitAeonPatronRequestJob < ApplicationJob
                        elsif volume_params['appointment_id'].present?
                          patron_request.aeon_reading_special
                        end,
-      username: patron_request.user.aeon.username,
+      username: patron_request.aeon_username,
       activity_id:
     )
   end

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -13,7 +13,7 @@ class PatronRequest < ApplicationRecord
   store :data, accessors: [
     :barcodes, :folio_responses, :illiad_response_data, :scan_page_range, :scan_authors, :scan_title, :activity_ids,
     :proxy, :for_sponsor, :for_sponsor_id, :estimated_delivery, :patron_name, :item_title, :requested_barcodes, :item_mediation_data,
-    :aeon_reading_special, :aeon_item, :aeon_terms, :ead_url
+    :aeon_reading_special, :aeon_item, :aeon_terms, :aeon_username, :ead_url
   ], coder: JSON
 
   delegate :instance_id, :finding_aid, :finding_aid?, to: :folio_instance

--- a/spec/jobs/submit_aeon_patron_request_job_spec.rb
+++ b/spec/jobs/submit_aeon_patron_request_job_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe SubmitAeonPatronRequestJob do
 
   let(:request) do
     PatronRequest.create!(request_type:, instance_hrid: 'a1234', patron:, barcodes: ['12345678'],
-                          origin_location_code: 'SPEC-STACKS', data:, user: build(:sso_user))
+                          origin_location_code: 'SPEC-STACKS',
+                          data: data.merge(aeon_username: 'aeon_user'),
+                          user: build(:sso_user))
   end
   let(:folio_instance) { build(:special_collections_single_holding) }
   let(:stub_aeon_client) { instance_double(AeonClient, find_user: stub_aeon_user, create_request: Aeon::Request.new, update_request_route: nil) }


### PR DESCRIPTION
For visitor patrons (OTP), submitting an Aeon request currently fails, because we don't persist `otp_authenticated`, so when we pass patron request to the external job, the visitor patron is a NullUser:

```
sul-requests(dev):011> pr.user.aeon
=> #<Aeon::NullUser:0x000000013af728b8 @auth_type=nil, @username=nil>
```

Given that we only depend on the Aeon username in the job, I wonder if it's nicer to store the Aeon username we're submitting the job on behalf of at the time of creation.

Working out the persistence of OTPs users would be valid too.