### PR TITLE
Add the dialog role to the modal component

### DIFF
--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag(:div, class: @classes, id:, tabindex: "-1", aria: {labelledby: title_id, hidden: false}, data:) do %>
+<%= content_tag(:div, class: @classes, id:, tabindex: "-1", aria: {labelledby: title_id, hidden: false}, data:, role: 'dialog') do %>
   <div class="<%= dialog_classes.join(' ') %>">
     <div class="modal-content">
       <% if custom_header %>


### PR DESCRIPTION
We need a role for the `aria-labelledby` to be valid.