### PR TITLE
Add an association between PatronRequestItem and the API response.

### DIFF
--- a/app/jobs/submit_aeon_patron_request_job.rb
+++ b/app/jobs/submit_aeon_patron_request_job.rb
@@ -54,14 +54,13 @@ class SubmitAeonPatronRequestJob < ApplicationJob
   def perform_folio_request(requested_item, activity_id: nil)
     patron_request = requested_item.patron_request
     request = as_aeon_create_request_data(patron_request, requested_item, activity_id)
-    record_aeon_response(patron_request, requested_item.item_id, request) { submit_aeon_request(request) }
+    record_aeon_response(requested_item, request) { submit_aeon_request(request) }
   end
 
   def perform_ead_request(requested_item, activity_id: nil)
     patron_request = requested_item.patron_request
     request = as_aeon_create_ead_request_data(patron_request, requested_item, activity_id)
-    item_id = "#{request.call_number} #{request.item_volume}"
-    record_aeon_response(patron_request, item_id, request) { submit_aeon_request(request) }
+    record_aeon_response(requested_item, request) { submit_aeon_request(request) }
   end
 
   def common_aeon_data_from_patron_request(patron_request, item, activity_id) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
@@ -120,17 +119,16 @@ class SubmitAeonPatronRequestJob < ApplicationJob
 
   private
 
-  def record_aeon_response(patron_request, item_id, request)
+  def record_aeon_response(patron_request_item, request)
     response_data = yield.as_json
-    write_aeon_response(patron_request, item_id, request, response_data)
+    write_aeon_response(patron_request_item, request, response_data)
   rescue AeonClient::ApiError => e
-    write_aeon_response(patron_request, item_id, request, e.to_honeybadger_context)
+    write_aeon_response(patron_request_item, request, e.to_honeybadger_context)
     raise
   end
 
-  def write_aeon_response(patron_request, item_id, request, response_data)
-    patron_request.aeon_api_responses.where(item_id: item_id).delete_all
-    patron_request.aeon_api_responses.create(item_id: item_id, request_data: request.as_json, response_data: response_data)
+  def write_aeon_response(patron_request_item, request, response_data)
+    patron_request_item.aeon_api_responses.create(request_data: request.as_json, response_data: response_data)
   end
 
   def report_failures(patron_request, failures)

--- a/app/jobs/submit_folio_patron_request_job.rb
+++ b/app/jobs/submit_folio_patron_request_job.rb
@@ -14,7 +14,7 @@ class SubmitFolioPatronRequestJob < ApplicationJob
 
     handle_folio_errors(response, patron_request_item) if response&.dig('errors')
 
-    patron_request_item.create_folio_api_response(request_data:, response_data: response)
+    patron_request_item.folio_api_responses.create(request_data:, response_data: response)
   end
 
   private

--- a/app/jobs/submit_illiad_patron_request_job.rb
+++ b/app/jobs/submit_illiad_patron_request_job.rb
@@ -16,10 +16,10 @@ class SubmitIlliadPatronRequestJob < ApplicationJob
 
   def record_illiad_response(patron_request_item)
     record = yield
-    patron_request_item.create_illiad_api_response(response_data: record.as_json)
+    patron_request_item.illiad_api_responses.create(response_data: record.as_json)
     record
   rescue IlliadClient::ApiError => e
-    patron_request_item.create_illiad_api_response(response_data: e.to_honeybadger_context)
+    patron_request_item.illiad_api_responses.create(response_data: e.to_honeybadger_context)
     IlbMailer.failed_ilb_notification(patron_request_item, e.response.body).deliver_later
     nil
   end

--- a/app/models/api_response.rb
+++ b/app/models/api_response.rb
@@ -3,8 +3,14 @@
 # Abstract base class for API responses from e.g. FOLIO or Illiad
 class ApiResponse < ApplicationRecord
   belongs_to :patron_request
+  belongs_to :patron_request_item, optional: true
   store :request_data, coder: JSON
   store :response_data, coder: JSON
 
   default_scope { order(created_at: :desc) }
+
+  after_initialize do
+    self.patron_request_id ||= patron_request_item&.patron_request_id
+    self.item_id ||= patron_request_item&.item_id
+  end
 end

--- a/app/models/patron_request_item.rb
+++ b/app/models/patron_request_item.rb
@@ -3,6 +3,10 @@
 # A single requested item
 class PatronRequestItem < ApplicationRecord
   belongs_to :patron_request
+  has_many :api_responses, dependent: :delete_all
+  has_many :folio_api_responses, dependent: :delete_all
+  has_many :illiad_api_responses, dependent: :delete_all
+  has_many :aeon_api_responses, dependent: :delete_all
   has_many :admin_comments, as: :request, dependent: :delete_all
   delegate :patron, to: :patron_request
 
@@ -37,24 +41,6 @@ class PatronRequestItem < ApplicationRecord
     self.item_id = @folio_item.id
     self.barcode = @folio_item.barcode
     self.item_callnumber = @folio_item.callnumber
-  end
-
-  def create_folio_api_response(**)
-    patron_request.folio_api_responses.where(item_id: item_id).delete_all
-    patron_request.folio_api_responses.create(item_id: item_id, **)
-  end
-
-  def folio_api_responses
-    patron_request.folio_api_responses.where(item_id: item_id)
-  end
-
-  def create_illiad_api_response(**)
-    patron_request.illiad_api_responses.where(item_id: item_id).delete_all
-    patron_request.illiad_api_responses.create(item_id: item_id, **)
-  end
-
-  def illiad_api_responses
-    patron_request.illiad_api_responses.where(item_id: item_id)
   end
 
   def illiad_request_params
@@ -122,6 +108,11 @@ class PatronRequestItem < ApplicationRecord
 
     assign_attributes(**aeon_item.slice(:title, :hierarchy, :for_publication, :requested_pages, :additional_information, # rubocop:disable Style/MultilineIfModifier
                                         :appointment_id)) if aeon_item.present?
+
+    patron_request.folio_api_responses.where(item_id: item_id).update_all(patron_request_item_id: id) # rubocop:disable Rails/SkipsModelValidations
+    patron_request.illiad_api_responses.where(item_id: item_id).update_all(patron_request_item_id: id) # rubocop:disable Rails/SkipsModelValidations
+    patron_request.aeon_api_responses.where(item_id: item_id).update_all(patron_request_item_id: id) # rubocop:disable Rails/SkipsModelValidations
+
     save
   end
 end

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -52,7 +52,7 @@
             <td><%= item.permanent_location&.name || @request.library_location&.location_name || @request.origin_location_code %></td>
             <td><%= current_location_for_mediated_item(item) %></td>
             <td><%= item.callnumber %></td>
-            <td><%= i18n_status_text(item) if @request.folio_api_response_for(item.id).present? %></td>
+            <td><%= i18n_status_text(item) if request_item.folio_api_responses.any? %></td>
           <% else %>
             <td colspan="4">Item not found in FOLIO</td>
           <% end %>

--- a/db/aeon_schema.rb
+++ b/db/aeon_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_175711) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_175759) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "comment"
     t.string "commenter"
@@ -25,12 +25,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_175711) do
     t.datetime "created_at", null: false
     t.string "item_id"
     t.bigint "patron_request_id", null: false
+    t.integer "patron_request_item_id"
     t.binary "request_data"
     t.binary "response_data"
     t.string "type"
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_api_responses_on_item_id"
     t.index ["patron_request_id"], name: "index_api_responses_on_patron_request_id"
+    t.index ["patron_request_item_id"], name: "index_api_responses_on_patron_request_item_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -137,6 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_175711) do
     t.index ["sunetid"], name: "unique_users_by_sunetid", unique: true
   end
 
+  add_foreign_key "api_responses", "patron_request_items"
   add_foreign_key "api_responses", "patron_requests"
   add_foreign_key "patron_request_items", "patron_requests"
   add_foreign_key "patron_requests", "users"

--- a/db/migrate/20260722175759_add_patron_request_item_id_to_api_response.rb
+++ b/db/migrate/20260722175759_add_patron_request_item_id_to_api_response.rb
@@ -1,0 +1,24 @@
+class AddPatronRequestItemIdToApiResponse < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :api_responses, :patron_request_item, null: true, foreign_key: true
+
+    reversible do |dir|
+      dir.up do
+        # reload tables to ensure the new table is available for the model
+        PatronRequest.reset_column_information
+        PatronRequestItem.reset_column_information
+
+        # populate the new table with data from the existing table
+        PatronRequest.includes(:patron_request_items, :folio_api_responses, :illiad_api_responses, :aeon_api_responses).find_each do |request|
+          request.patron_request_items.find_each do |item|
+            next if item.migrated_item_id_or_barcode.present? || item.item_id.blank?
+
+            request.folio_api_responses.where(item_id: item.item_id).update_all(patron_request_item_id: item.id)
+            request.illiad_api_responses.where(item_id: item.item_id).update_all(patron_request_item_id: item.id)
+            request.aeon_api_responses.where(item_id: item.item_id).update_all(patron_request_item_id: item.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_175711) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_175759) do
   create_table "admin_comments", force: :cascade do |t|
     t.string "comment"
     t.string "commenter"
@@ -25,12 +25,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_175711) do
     t.datetime "created_at", null: false
     t.string "item_id"
     t.bigint "patron_request_id", null: false
+    t.integer "patron_request_item_id"
     t.binary "request_data"
     t.binary "response_data"
     t.string "type"
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_api_responses_on_item_id"
     t.index ["patron_request_id"], name: "index_api_responses_on_patron_request_id"
+    t.index ["patron_request_item_id"], name: "index_api_responses_on_patron_request_item_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -137,6 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_175711) do
     t.index ["sunetid"], name: "unique_users_by_sunetid", unique: true
   end
 
+  add_foreign_key "api_responses", "patron_request_items"
   add_foreign_key "api_responses", "patron_requests"
   add_foreign_key "patron_request_items", "patron_requests"
   add_foreign_key "patron_requests", "users"


### PR DESCRIPTION
Needs to wait until we're passing PatronRequestItem further down the stack (#4161) so we can create new `ApiResponse` data.