### PR TITLE
Use the api_responses association to display consistent debug information for items.

### DIFF
--- a/app/components/item_debug_status_component.html.erb
+++ b/app/components/item_debug_status_component.html.erb
@@ -1,0 +1,4 @@
+<details>
+  <summary><%= item.barcode || item.item_id %></summary>
+  <pre class="card p-2"><%= JSON.pretty_generate(item.latest_api_response.as_json) %></pre>
+</details>

--- a/app/components/item_debug_status_component.rb
+++ b/app/components/item_debug_status_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# display admin-level debug information about the item, including the latest API response
+class ItemDebugStatusComponent < ViewComponent::Base
+  with_collection_parameter :item
+
+  attr_reader :item
+
+  def initialize(item:)
+    @item = item
+  end
+end

--- a/app/models/patron_request.rb
+++ b/app/models/patron_request.rb
@@ -4,6 +4,7 @@
 #  Main Request class for Requests WC.
 ###
 class PatronRequest < ApplicationRecord
+  has_many :api_responses, dependent: :delete_all
   has_many :folio_api_responses, dependent: :delete_all
   has_many :illiad_api_responses, dependent: :delete_all
   has_many :aeon_api_responses, dependent: :delete_all
@@ -77,10 +78,6 @@ class PatronRequest < ApplicationRecord
         end
       end
     end
-  end
-
-  def folio_api_response_for(item_id)
-    folio_api_responses.find { |x| x.item_id == item_id }
   end
 
   # Evaluate if this is a title only request

--- a/app/models/patron_request_item.rb
+++ b/app/models/patron_request_item.rb
@@ -22,6 +22,10 @@ class PatronRequestItem < ApplicationRecord
 
   attr_writer :barcode_or_item_id
 
+  def latest_api_response
+    @latest_api_response ||= api_responses.order(created_at: :desc).first
+  end
+
   def update_item_metadata # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength
     return if item_id.blank? && barcode.blank? && @barcode_or_item_id.blank?
 

--- a/app/views/admin/holdings.html.erb
+++ b/app/views/admin/holdings.html.erb
@@ -52,7 +52,7 @@
             <td><%= item.permanent_location&.name || @request.library_location&.location_name || @request.origin_location_code %></td>
             <td><%= current_location_for_mediated_item(item) %></td>
             <td><%= item.callnumber %></td>
-            <td><%= i18n_status_text(item) if request_item.folio_api_responses.any? %></td>
+            <td><%= i18n_status_text(item) if request_item.latest_api_response.present? %></td>
           <% else %>
             <td colspan="4">Item not found in FOLIO</td>
           <% end %>

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -68,9 +68,7 @@
     <% if can? :debug, @patron_request %>
       <hr>
       <h2>Aeon Response</h2>
-      <% @patron_request.aeon_api_responses.each do |r| %>
-        <pre class="card p-2"><%= JSON.pretty_generate(r.as_json) %></pre>
-      <% end %>
+      <%= render ItemDebugStatusComponent.with_collection(@patron_request.patron_request_items) %>
     <% end %>
   </div>
   <%= render 'contact_aside' %>

--- a/app/views/patron_requests/show.html.erb
+++ b/app/views/patron_requests/show.html.erb
@@ -13,13 +13,11 @@
 
 <% if can? :debug, @patron_request %>
   <hr>
-  <% if @patron_request.folio_api_responses.present? %>
-    <h4>ILS Response</h4>
-    <pre class="card p-2"><%= JSON.pretty_generate(@patron_request.folio_api_responses.map(&:as_json)) %></pre>
-  <% end %>
 
-  <% if current_request.illiad_api_responses.present? %>
-    <h4>Illiad Response</h4>
-    <pre class="card p-2"><%= JSON.pretty_generate(@patron_request.illiad_api_responses.map(&:as_json)) %></pre>
+  <%= render ItemDebugStatusComponent.with_collection(@patron_request.patron_request_items) %>
+
+  <% if @patron_request.api_responses.where(item_id: nil).present? %>
+    <h4>Title level API response</h4>
+    <pre class="card p-2"><%= JSON.pretty_generate(@patron_request.api_responses.where(item_id: nil).first.map(&:as_json)) %></pre>
   <% end %>
 <% end %>


### PR DESCRIPTION
Includes #4160