### PR TITLE
Remove temporary code now that data migrations are finished.

### DIFF
--- a/app/models/patron_request_item.rb
+++ b/app/models/patron_request_item.rb
@@ -79,30 +79,6 @@ class PatronRequestItem < ApplicationRecord
     mediation_data&.dig('error').present?
   end
 
-  def item_id
-    update_record_from_folio if migrated_item_id_or_barcode.present?
-
-    super
-  end
-
-  def barcode
-    update_record_from_folio if migrated_item_id_or_barcode.present?
-
-    super
-  end
-
-  def item_callnumber
-    update_record_from_folio if migrated_item_id_or_barcode.present?
-
-    super
-  end
-
-  def mediation_data
-    update_record_from_folio if migrated_item_id_or_barcode.present?
-
-    super
-  end
-
   def update_record_from_folio # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
     return if ead_url || migrated_item_id_or_barcode.blank?
 


### PR DESCRIPTION
I think `update_record_from_folio` could probably go too, but I think it's a slightly useful reminder of what we did...