### PR TITLE
[WIP] Defer and batch item circulation status loading on request forms

### DIFF
--- a/app/controllers/item_selectors_controller.rb
+++ b/app/controllers/item_selectors_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Loads an item selector with circulation data outside the initial page render.
+class ItemSelectorsController < ApplicationController
+  include FolioController
+
+  def show
+    @patron_request = PatronRequest.new(item_selector_params)
+    FolioGraphqlClient.new.hydrate_circulation_status(items: @patron_request.selectable_items)
+  end
+
+  private
+
+  def item_selector_params
+    params.require(:instance_hrid)
+    params.require(:origin_location_code)
+    params.permit(:instance_hrid, :origin_location_code, requested_barcodes: [])
+  end
+end

--- a/app/controllers/patron_requests_controller.rb
+++ b/app/controllers/patron_requests_controller.rb
@@ -47,6 +47,9 @@ class PatronRequestsController < ApplicationController
   end
 
   def new
+    items = @patron_request.selectable_items
+    FolioGraphqlClient.new.hydrate_circulation_status(items:) if items.one?
+
     request.variant = :aeon if @patron_request.aeon_page?
     request.variant = :aeonredesign if (@patron_request.ead_url || @patron_request.aeon_page?) && use_requests_redesign?
   end

--- a/app/javascript/controllers/item_selector_controller.js
+++ b/app/javascript/controllers/item_selector_controller.js
@@ -21,15 +21,15 @@ export default class extends Controller {
   connect() { }
 
   itemLimitValueChanged() {
-    const switchtype = this.itemLimitValue == 1 ? 'radio' : 'checkbox';
-
     this.itemTargets.forEach(elem => {
-      elem.type = switchtype;
-      if (switchtype == 'radio') { elem.checked = false };
+      this.setItemInputType(elem);
+      if (elem.type == 'radio') { elem.checked = false };
     })
   }
 
   itemTargetConnected(element) {
+    this.setItemInputType(element);
+
     if (!element.checked) return;
 
     const params = this.getStimulusParams(element);
@@ -39,6 +39,10 @@ export default class extends Controller {
     } else if (!this.selectedItemsValue.find((item) => item.id == params.id)) {
       this.selectedItemsValue = this.selectedItemsValue.concat([params]);
     }
+  }
+
+  setItemInputType(element) {
+    element.type = this.itemLimitValue == 1 ? 'radio' : 'checkbox';
   }
 
   filter(event) {

--- a/app/jobs/submit_patron_request_job.rb
+++ b/app/jobs/submit_patron_request_job.rb
@@ -12,6 +12,9 @@ class SubmitPatronRequestJob < ApplicationJob
     return place_title_hold(patron_request) if patron_request.patron_request_items.blank?
     return perform_scan_request(patron_request) if patron_request.scan?
 
+    items = patron_request.patron_request_items.filter_map(&:folio_item)
+    FolioGraphqlClient.new.hydrate_circulation_status(items:)
+
     ilb_items, folio_items = patron_request.patron_request_items.partition do |item|
       send_to_illiad?(patron_request, item.folio_item)
     end

--- a/app/models/folio/item.rb
+++ b/app/models/folio/item.rb
@@ -94,6 +94,12 @@ module Folio
       self
     end
 
+    def with_circulation_status(queue_length:, due_date:)
+      @queue_length = queue_length || 0
+      @due_date = due_date
+      self
+    end
+
     def suppressed_from_discovery?
       @suppressed_from_discovery
     end

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -141,6 +141,38 @@ class FolioGraphqlClient
     data&.dig('data', 'instances', 0)
   end
 
+  # Batch size chosen to stay well under the limit where we'd encounter
+  # /item-storage/items 414: URI Too Long errors in graphql.
+  ITEM_CIRCULATION_STATUS_BATCH_SIZE = 50
+  ITEM_CIRCULATION_STATUS_QUERY = <<~GQL
+    query ItemCirculationStatus($item_ids: [String]) {
+      items(id: $item_ids) {
+        id
+        queueTotalLength
+        dueDate
+      }
+    }
+  GQL
+
+  def item_circulation_status(item_ids:)
+    return [] if item_ids.blank?
+
+    item_ids.each_slice(ITEM_CIRCULATION_STATUS_BATCH_SIZE).flat_map do |chunk|
+      item_circulation_status_batch(chunk)
+    end
+  end
+
+  def hydrate_circulation_status(items:)
+    status_by_id = item_circulation_status(item_ids: items.filter_map(&:id)).index_by { |status| status['id'] }
+
+    items.each do |item|
+      status = status_by_id[item.id]
+      next unless status
+
+      item.with_circulation_status(queue_length: status['queueTotalLength'], due_date: status['dueDate'])
+    end
+  end
+
   def service_points
     data = post_json('/', json:
     {
@@ -508,11 +540,9 @@ class FolioGraphqlClient
       barcode
       discoverySuppress
       volume
-      queueTotalLength
       status {
         name
       }
-      dueDate
       materialType {
         id
         name
@@ -626,6 +656,13 @@ class FolioGraphqlClient
   end
 
   private
+
+  def item_circulation_status_batch(item_ids)
+    data = post_json('/', json: { variables: { item_ids: item_ids }, query: ITEM_CIRCULATION_STATUS_QUERY })
+    raise data['errors'].pluck('message').join("\n") if data&.key?('errors')
+
+    data&.dig('data', 'items') || []
+  end
 
   def parse(response)
     return nil if response.body.empty?

--- a/app/views/item_selectors/show.html.erb
+++ b/app/views/item_selectors/show.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag :item_selector_circulation do %>
+  <%= fields_for @patron_request, @patron_request do |f| %>
+    <%= render Folio::ItemSelectorComponent.new(f:) %>
+  <% end %>
+<% end %>

--- a/app/views/patron_requests/_item_selector.html.erb
+++ b/app/views/patron_requests/_item_selector.html.erb
@@ -1,6 +1,35 @@
 <%= render AccordionStepComponent.new(id: 'items', step_index: step_enum.next, form_id: f.id, data: { 'switch-selector': true }) do |c| %>
   <% c.with_title.with_content('Select item(s)') %>
   <% c.with_body do %>
-    <%= render Folio::ItemSelectorComponent.new(f: f) %>
+    <%= turbo_frame_tag :item_selector_circulation, src: item_selector_path(instance_hrid: f.object.instance_hrid, origin_location_code: f.object.origin_location_code, requested_barcodes: f.object.requested_barcodes), data: { action: 'turbo:frame-load->accordion-form#reenableNextButtons' } do %>
+      <%= f.hidden_field :item_ids, multiple: true, value: '' %>
+      <div class="visually-hidden" role="status" aria-live="polite">Loading item availability</div>
+      <div class="item-selector-loading placeholder-glow" aria-hidden="true">
+        <% if f.object.selectable_items.length >= 10 %>
+          <div>
+            <span class="placeholder col-2 my-2"></span>
+            <span class="placeholder d-block w-75 rounded" style="height: 2.375rem"></span>
+          </div>
+        <% end %>
+        <div class="item-table my-4">
+          <table class="table mb-0 border">
+            <thead>
+              <tr>
+                <th class="text-start"><span class="placeholder col-4"></span></th>
+                <th class="text-end"><span class="placeholder col-4"></span></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% 4.times do %>
+                <tr>
+                  <td><span class="placeholder col-5"></span></td>
+                  <td class="text-end"><span class="placeholder col-4"></span></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     resource :needed_date, only: [:edit, :update, :show]
     resources :admin_comments
   end
+  resource :item_selector, only: :show
 
   resources :paging_schedule, only: :index
   get 'paging_schedule/from/:origin_library(/to/:destination)' => 'paging_schedule#show', as: :paging_schedule

--- a/spec/controllers/item_selectors_controller_spec.rb
+++ b/spec/controllers/item_selectors_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ItemSelectorsController do
+  render_views
+
+  let(:folio_instance) { build(:checkedout_holdings) }
+  let(:checked_out_item) { folio_instance.items.second }
+  let(:circulation_status) do
+    [
+      {
+        'id' => checked_out_item.id,
+        'queueTotalLength' => 2,
+        'dueDate' => '2026-08-12T12:00:00.000+00:00'
+      }
+    ]
+  end
+
+  before do
+    stub_folio_instance_json(folio_instance)
+    allow_any_instance_of(FolioGraphqlClient).to receive(:item_circulation_status).and_return(circulation_status) # rubocop:disable RSpec/AnyInstance
+    allow(controller).to receive(:current_ability).and_return(double(can?: false, cannot?: false))
+    request.headers['Turbo-Frame'] = 'item_selector_circulation'
+  end
+
+  it 'renders the hydrated item selector in a turbo frame' do
+    get :show, params: { instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS' }
+
+    document = response.parsed_body
+    checkbox = document.at_css("[data-item-selector-id-param='#{checked_out_item.id}']")
+
+    expect(response).to be_successful
+    expect(response.body).to include('<turbo-frame id="item_selector_circulation">')
+    expect(document.text).to include('Due Aug 12, 2026')
+    expect(checkbox['data-item-selector-duequeueinfo-param']).to include('There is a waitlist')
+  end
+end

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -503,6 +503,22 @@ RSpec.describe 'Creating a request', :js do
       expect(page).to have_button 'Submit'
       expect(page).to have_no_css 'h2', text: 'Select item(s)'
     end
+
+    it 'loads circulation status for a single item selected by barcode' do
+      checked_out_item = folio_instance.items.second
+      circulation_status = [
+        {
+          'id' => checked_out_item.id,
+          'queueTotalLength' => 2,
+          'dueDate' => '2026-08-12T12:00:00.000+00:00'
+        }
+      ]
+      allow_any_instance_of(FolioGraphqlClient).to receive(:item_circulation_status).and_return(circulation_status)
+
+      visit new_patron_request_path(instance_hrid: 'a1234', origin_location_code: 'SAL3-STACKS', barcode: '87654321')
+
+      expect(page).to have_text 'Item status: Checked out - Due Aug 12, 2026 | There is a waitlist'
+    end
   end
 
   context 'with multiple scannable items where one is checked out' do

--- a/spec/jobs/submit_patron_request_job_spec.rb
+++ b/spec/jobs/submit_patron_request_job_spec.rb
@@ -134,14 +134,36 @@ RSpec.describe SubmitPatronRequestJob do
       end
     end
 
-    context 'when the item has a request queue' do
+    context 'when the refreshed item has a request queue' do
       before do
-        allow(folio_instance.items[0]).to receive(:queue_length).and_return(1)
+        circulation_status = {
+          'id' => folio_instance.items[0].id,
+          'queueTotalLength' => 1,
+          'dueDate' => nil
+        }
+        allow_any_instance_of(FolioGraphqlClient).to receive(:item_circulation_status).and_return([circulation_status]) # rubocop:disable RSpec/AnyInstance
       end
 
       it 'requests items via ILLiad' do
         described_class.perform_now(request)
         expect(SubmitIlliadPatronRequestJob).to have_received(:perform_now)
+          .with(an_object_having_attributes(patron_request: request, item_id: folio_instance.items[0].id))
+      end
+    end
+
+    context 'when the refreshed item does not have a request queue' do
+      before do
+        circulation_status = {
+          'id' => folio_instance.items[0].id,
+          'queueTotalLength' => 0,
+          'dueDate' => nil
+        }
+        allow_any_instance_of(FolioGraphqlClient).to receive(:item_circulation_status).and_return([circulation_status]) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it 'requests items via FOLIO' do
+        described_class.perform_now(request)
+        expect(SubmitFolioPatronRequestJob).to have_received(:perform_now)
           .with(an_object_having_attributes(patron_request: request, item_id: folio_instance.items[0].id))
       end
     end

--- a/spec/services/folio_graphql_client_spec.rb
+++ b/spec/services/folio_graphql_client_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FolioGraphqlClient do
+  let(:client) { described_class.new }
+
+  describe '#item_circulation_status' do
+    it 'queries item IDs in bounded batches' do
+      item_ids = Array.new(51) { |index| "item-#{index}" }
+      allow(client).to receive(:item_circulation_status_batch).and_return([])
+
+      client.item_circulation_status(item_ids:)
+
+      expect(client).to have_received(:item_circulation_status_batch).with(item_ids.first(50)).ordered
+      expect(client).to have_received(:item_circulation_status_batch).with(item_ids.last(1)).ordered
+    end
+  end
+
+  describe '#hydrate_circulation_status' do
+    let(:item) { build(:item, queue_length: 0) }
+    let(:unchanged_item) { build(:item, queue_length: 3) }
+    let(:circulation_status) do
+      [
+        {
+          'id' => item.id,
+          'queueTotalLength' => 2,
+          'dueDate' => '2026-08-12T12:00:00.000+00:00'
+        }
+      ]
+    end
+
+    before do
+      allow(client).to receive(:item_circulation_status).and_return(circulation_status)
+    end
+
+    it 'assigns returned circulation data to the matching items' do
+      client.hydrate_circulation_status(items: [item, unchanged_item])
+
+      expect(item).to have_attributes(queue_length: 2, due_date: 'Aug 12, 2026')
+    end
+
+    it 'does not overwrite items omitted from the response' do
+      client.hydrate_circulation_status(items: [item, unchanged_item])
+
+      expect(unchanged_item.queue_length).to eq 3
+    end
+  end
+end

--- a/spec/support/ils_helpers.rb
+++ b/spec/support/ils_helpers.rb
@@ -2,4 +2,5 @@
 
 def stub_folio_instance_json(folio_instance)
   allow(Folio::Instance).to receive(:fetch).and_return(folio_instance)
+  allow_any_instance_of(FolioGraphqlClient).to receive(:item_circulation_status).and_return([]) # rubocop:disable RSpec/AnyInstance
 end


### PR DESCRIPTION
Consolidating my thoughts on another attempt at https://github.com/sul-dlss/sul-requests/issues/1676

Splits out `dueDate` and `queueTotalLength` into a separate query and loads the items in a turbo frame:
<img width="851" height="620" alt="Screenshot 2026-07-23 at 2 06 42 PM" src="https://github.com/user-attachments/assets/b7729cfd-5f64-4009-bb29-44186871fab6" />

This is best when combined with some corresponding `folio-graphql` work. Currently:
* [typecache-dedupe-inflight](https://github.com/sul-dlss/folio-graphql/compare/main...typecache-dedupe-inflight)
* [batch-holdings-record](https://github.com/sul-dlss/folio-graphql/compare/main...batch-holdings-record)
* [batch-bound-with-parts](https://github.com/sul-dlss/folio-graphql/compare/main...batch-bound-with-parts)
* [batch-item-duedate](https://github.com/sul-dlss/folio-graphql/compare/main...batch-item-duedate)
* Another to facilitate the removal of the awkward batching of `dueDate` and `queueTotalLength` done here

With this branch and all those graphql branches combined, [L284](https://requests.stanford.edu/patron_requests/new?instance_hrid=L284&origin_location_code=LANE-SAL3) goes from 34s to 6s LCP, plus some time for the turbo frame (harder to measure, 6-10 seconds?).

If we're open to these DataLoader patterns in graphql, it's possible we could get to a place where performance is acceptable without this PR at all.