### PR TITLE
Update styles for EAD no container manual item input

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -155,6 +155,10 @@ summary .disclosure-icon::before {
   }
 }
 
+[data-manual-items-row]:only-child button[data-action*="removeRow"] {
+  display: none;
+}
+
 #patron_request_service_point_code,
 #patron_request_needed_date {
   width: 100%;

--- a/app/views/patron_requests/new.html+aeonredesign.erb
+++ b/app/views/patron_requests/new.html+aeonredesign.erb
@@ -105,7 +105,7 @@
           </div>
         </div>
       <% else %>
-        <p>Enter the containers you want to request.</p>
+        <p class="mb-2">Enter the containers you want to request.</p>
         <div id="manual-items-container" data-controller="manual-items" data-action="save-for-later:changed@document->manual-items#syncSavedForLater" class="d-flex flex-column">
           <div data-manual-items-target="rows"></div>
 
@@ -119,7 +119,7 @@
                 <%= form_fields.text_field :title, placeholder: 'e.g., Box 1, Reel 5', required: true, data: { action: 'manual-items#emitChange' } %>
                 <%= form_fields.hidden_field :id %>
               <% end %>
-              <button class="btn btn-link px-0 text-black" data-action="manual-items#removeRow">
+              <button class="btn btn-link ms-1 px-0 text-black" data-action="manual-items#removeRow">
                 <i class="bi bi-dash-square-fill text-danger me-1"></i>Delete
               </button>
             </div>

--- a/spec/features/ead_patron_request_spec.rb
+++ b/spec/features/ead_patron_request_spec.rb
@@ -520,6 +520,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
       click_button 'Continue'
 
       within('#items-accordion') do
+        expect(page).to have_no_button 'Delete'
         expect(page).to have_button('Continue', disabled: true)
 
         first('[data-manual-items-row] input[type=text]').set('Box 1')
@@ -529,6 +530,7 @@ RSpec.describe 'Requesting an item from an EAD', :js do
         expect(page).to have_button('Continue', disabled: true)
 
         all('[data-manual-items-row] input[type=text]')[1].set('Box 2')
+        expect(page).to have_button 'Delete', count: 2
         expect(page).to have_button('Continue', disabled: false)
       end
     end


### PR DESCRIPTION
Maybe the user doesn't need to delete the only input, it's a free text field, they can make it work (somewhat supported by the designs)?

<img width="834" height="267" alt="Screenshot 2026-07-24 at 2 14 57 PM" src="https://github.com/user-attachments/assets/c3c7e4c1-e523-4efc-b3fa-7cdf44e39cdd" />

<img width="330" height="276" alt="Screenshot 2026-07-24 at 2 17 29 PM" src="https://github.com/user-attachments/assets/40404238-0119-4f06-915a-2fc7c215b016" />


[Figma](https://www.figma.com/design/sqzYVhfRgn3nMArUAdrs0n/My-Account---Requests?node-id=5351-80747&t=OQsHIDiunXbECoJp-0)