### PR TITLE
Standardize on h2 with h3 styling for request headings

### DIFF
--- a/app/components/folio/ill_request_component.html.erb
+++ b/app/components/folio/ill_request_component.html.erb
@@ -6,7 +6,7 @@
       </div>
 
       <div>
-        <%= tag.h2 request.title || 'Not available', class: @title_classes %>
+        <%= tag.h2 request.title || 'Not available', class: 'h3' %>
         <div class="d-flex column-gap-md-3 flex-md-row flex-column flex-wrap">
           <% if request.call_number.present? %>
             <span>Call number: <%= request.call_number %></span>

--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -6,7 +6,7 @@
       </div>
 
       <div>
-        <%= tag.h2 request.title || 'Not available', class: @title_classes %>
+        <%= tag.h2 request.title || 'Not available', class: 'h3' %>
         <div class="d-flex column-gap-md-3 flex-md-row flex-column flex-wrap">
           <%= render FormatIndicatorComponent.new(record: request) %>
           <% if request.full_call_number.present? %>

--- a/app/components/mediated_request_component.html.erb
+++ b/app/components/mediated_request_component.html.erb
@@ -6,7 +6,7 @@
       </div>
 
       <div>
-        <%= tag.h2 request.item_title || 'Not available', class: @title_classes %>
+        <%= tag.h2 request.item_title || 'Not available', class: 'h3' %>
       </div>
     </div>
   <% end %>

--- a/app/components/record_header_component.rb
+++ b/app/components/record_header_component.rb
@@ -4,7 +4,7 @@
 class RecordHeaderComponent < ViewComponent::Base
   attr_reader :record, :title_classes
 
-  def initialize(record: nil, brief: false, title_classes: ['fs-5'])
+  def initialize(record: nil, brief: false, title_classes: ['h3'])
     @record = record
     @brief = brief
     @title_classes = Array(title_classes)


### PR DESCRIPTION
As far as I can tell all these `@title_classes` ivars were unused.

We must have had a good reason for using `fs-5` at some point, but it eludes me. The designs seem to call for h3 style.