### PR TITLE
Keep the saved for later dropdown visible after animation

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -987,6 +987,10 @@ main:not(:has(#requests li, turbo-frame[busy])) .no-requests {
 }
 
 #saved_for_later_aeon_requests_sidebar .request {
+  &:has(.dropdown-toggle.show) {
+    z-index: 5;
+  }
+
   --bs-list-group-item-padding-x: 0;
   margin-inline-start: -1rem;
   margin-inline-end: -1rem;


### PR DESCRIPTION
When I "Save for later" an existing appointment that then is placed above an existing saved for later request, I get this situation. I admittedly did not dig into why, but some z fixes it 🤷 

<img width="521" height="305" alt="Screenshot 2026-07-24 at 4 48 36 PM" src="https://github.com/user-attachments/assets/35085bf8-8e31-4182-90dc-d54623dbec67" />
