### PR TITLE
Inset the Aeon appointment transition style

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -973,10 +973,20 @@ main:not(:has(#requests li, turbo-frame[busy])) .no-requests {
 }
 
 .request.flash-on-add {
+  position: relative;
+  isolation: isolate;
+  animation: slideUp 0.5s ease-out forwards;
+}
+
+.request.flash-on-add::before {
+  content: '';
+  position: absolute;
+  inset: 0.25rem 0.5rem;
+  z-index: -1;
+  pointer-events: none;
   border-radius: 4px;
   box-shadow: inset 0px 0px 0px 0.5px rgb(var(--stanford-digital-green-rgb)), inset 0px 0px 0px 50px rgb(235, 243, 241);
-  animation: slideUp 0.5s ease-out forwards,
-             flash 1s ease-out 4s forwards;
+  animation: flash 1s ease-out 4s forwards;
 }
 
 .appointment .request.flash-on-add {


### PR DESCRIPTION
Awkward, but an option to get sort of the style Darcy wants.

<img width="794" height="147" alt="Screenshot 2026-07-24 at 4 46 21 PM" src="https://github.com/user-attachments/assets/dbed7220-b9ae-4a96-95fa-fd7d15c70e9c" />
<img width="443" height="198" alt="Screenshot 2026-07-24 at 4 44 55 PM" src="https://github.com/user-attachments/assets/032c85cd-c713-45aa-8fd3-3d57abdacddb" />

I'm not opinionated on this
