### PR TITLE
Don't restrict location-specific access points by user.

### DIFF
--- a/app/services/folio_request_service_point_options_service.rb
+++ b/app/services/folio_request_service_point_options_service.rb
@@ -16,7 +16,7 @@ class FolioRequestServicePointOptionsService
       # always include the currently selected service point
       service_points += [current_service_point] if current_service_point.present?
 
-      service_points += location_restricted_service_points.select { |sp| patron_is_eligible_for_service_point?(sp) }
+      service_points += location_restricted_service_points
 
       if location_restricted_service_points.empty?
         service_points += default_pickup_service_points

--- a/spec/services/folio_request_service_point_options_service_spec.rb
+++ b/spec/services/folio_request_service_point_options_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FolioRequestServicePointOptionsService do
+  subject(:service) { described_class.new([item], patron:) }
+
+  context 'with a location-restricted item for a guest' do
+    let(:patron) { Folio::NullPatron.new }
+    let(:item) { build(:page_mp_holdings).items.first }
+
+    it 'allows the patron to select the location-restricted service point' do
+      expect(service.possible_service_points.map(&:code)).to contain_exactly('EARTH-SCI')
+    end
+  end
+
+  context 'with a regular circulating item for a guest' do
+    let(:item) { build(:sal3_holding).items.first }
+    let(:patron) { Folio::NullPatron.new }
+
+    it 'requires the patron to select a service point they can access' do
+      expect(service.possible_service_points.map(&:code)).to contain_exactly('GREEN-LOAN', 'ART', 'EAST-ASIA', 'MUSIC', 'LANE-DESK')
+    end
+  end
+end


### PR DESCRIPTION
Presumably fixes #4186. The two implementations (new request from requests, edit request from mylibrary) had a key difference in how it enforced patron eligibility to use an access point. Requests previously had no such restrictions for items that only goes to specific access points, but mylibrary happened to enforce it (although in practice, I think if a user got to mylibrary, the service point restriction didn't apply to the patron anyway..)