### PR TITLE
Add a nightly job to check Aeon for repeated items.

### DIFF
--- a/app/jobs/check_for_upcoming_aeon_requests_for_the_same_item_job.rb
+++ b/app/jobs/check_for_upcoming_aeon_requests_for_the_same_item_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+##
+# Rails Job to figure out which items are being reused in the reading room within a window.
+class CheckForUpcomingAeonRequestsForTheSameItemJob < ApplicationJob
+  def perform(upcoming_time: 14.days) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
+    # get all the upcoming appointments for SPEC
+    upcoming_appointments = aeon_client.appointments(range: (1.day.ago)..(upcoming_time.from_now)).select do |appointment|
+      appointment.reading_room.sites.include?('SPECUA')
+    end
+    appointment_ids = upcoming_appointments.map(&:id)
+    # get the users that have those appointments (because there's no direct way to get the requests for a given appointment)
+    usernames = upcoming_appointments.map(&:username).uniq
+    users = usernames.filter_map { |username| Aeon::User.find_by(email_address: username) }
+    # get the users' requests for those appointments (and get rid of items with the same appointment)
+    requests = users.flat_map(&:requests).select { |request| appointment_ids.include?(request.appointment_id) }.uniq do |request|
+      [request.appointment_id, request.item_number.presence || [request.call_number, request.item_volume]]
+    end
+
+    # select the requests for the same item (same callnumber + volume or same item number)
+    grouped_requests = requests.group_by do |request|
+      request.item_number.presence || [request.call_number, request.item_volume]
+    end
+
+    # send an email to the staff with the report of items that are likely in the reading room now and being re-used soon
+    salient_requests = grouped_requests.select do |_, requests|
+      requests.size > 1 && requests.any? do |r|
+        r.appointment.start_time.before?(3.days.from_now)
+      end
+    end.values
+    AeonMailer.repeated_requests(salient_requests).deliver_now
+  end
+
+  def aeon_client
+    @aeon_client ||= AeonClient.new
+  end
+end

--- a/app/mailers/aeon_mailer.rb
+++ b/app/mailers/aeon_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+###
+#  Mailer class to send emails that Aeon ought to be able to do.
+###
+class AeonMailer < ApplicationMailer
+  def repeated_requests(request_groups)
+    return if request_groups.blank?
+
+    @request_groups = request_groups
+    mail(
+      to: Settings.libraries['SPEC-COLL'].contact_info.email,
+      subject: 'Repeated Aeon Requests Notification'
+    )
+  end
+end

--- a/app/services/aeon_client.rb
+++ b/app/services/aeon_client.rb
@@ -96,6 +96,12 @@ class AeonClient
     handle_response(response, as_class: Aeon::Request)
   end
 
+  def appointments(range:)
+    response = get('Appointments', params: { startDate: range.begin.iso8601, endDate: range.end.iso8601 })
+
+    handle_response(response, as_class: Aeon::Appointment, not_found: [])
+  end
+
   def appointments_for(username:, context: 'both', pending_only: true)
     response = get("Users/#{CGI.escape(username)}/appointments", params: { context: context, pendingOnly: pending_only })
 

--- a/app/views/aeon_mailer/repeated_requests.html.erb
+++ b/app/views/aeon_mailer/repeated_requests.html.erb
@@ -1,0 +1,30 @@
+Here is a list of upcoming requests that reuse the same item:
+
+<ul>
+  <% @request_groups.sort_by { |request_group| request_group.map { |r| r.appointment.start_time }.min }.each do |request_group| %>
+    <li>
+      <%= request_group.first.title %><br>
+
+      <% if request_group.first.call_number.present? %>
+        Call Number: <%= request_group.first.call_number %><br>
+      <% end %>
+
+      <% if request_group.first.item_volume.present? %>
+        Volume: <%= request_group.first.item_volume %><br>
+      <% end %>
+
+      <% if request_group.first.item_number.present? %>
+        Barcode: <%= request_group.first.item_number %><br><br>
+      <% end %>
+      Appointments:
+      <ul>
+        <% request_group.each do |request| %>
+          <li>
+            Date: <%= I18n.l(request.appointment.start_time, format: :date_only) %><br>
+            Username: <%= request.username %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ul>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,6 @@
 every 1.day, roles: :production_cron  do
   rake 'data_removal:remove_old_requests'
 end
+every 1.day, at: '7:00am', roles: :production_cron  do
+  rake 'aeon:check_for_upcoming_requests_for_the_same_item'
+end

--- a/lib/tasks/aeon.rake
+++ b/lib/tasks/aeon.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+namespace :aeon do
+  task check_for_upcoming_requests_for_the_same_item: :environment do
+    CheckForUpcomingAeonRequestsForTheSameItemJob.perform_later
+  end
+end


### PR DESCRIPTION
Maybe plausible?

SPEC staff report it would be nice to know if a given item is going to be reused soon, and maybe should be held in the reading room instead of being reshelved (or sent to off-site storage).

As best I can figure, we can get the requests for upcoming appointments and then figure out which ones are plausibly the same (based on barcode, or callnumber/volume). To reduce noise, I think we can filter the re-used requests to make sure one is probably in the reading room now/soon (so staff can immediately put a note with it). I'm not sure there's an easy way to mark that we already sent a notice for an item though..

Instead of an email, there might be a world where we create a request note to indicate some duplication, but we'd need to make sure staff can see it... so maybe email is a good start 🤷 