### PR TITLE
Update the full date format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,7 +97,7 @@ en:
   time:
     formats:
       short: "%Y-%m-%d %l.%M%P"
-      full: "%B %-d, %Y %l:%M %P"
+      full: "%b %-d, %Y %l:%M %P"
       formal: "%A, %b %-d %Y at %l:%M%P"
       time_today: 'Today at %-l:%M%P'
       time_tomorrow: 'Tomorrow at %-l:%M%P'

--- a/spec/components/aeon/request_group_component_spec.rb
+++ b/spec/components/aeon/request_group_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Aeon::RequestGroupComponent, type: :component do
     it 'renders information about each request' do
       expect(page).to have_css 'h2', text: 'Donald E. Knuth papers', count: 1
       expect(page).to have_css '.rgi-id', text: 'The Art of Computer Programming', count: 2
-      expect(page).to have_text 'Mar 11, 2024', count: 2
+      expect(page).to have_text 'Mar 11, 2024'
       expect(page).to have_css '.card-header', text: 'SC0097', count: 1
       expect(page).to have_text 'Box 1'
       expect(page).to have_text 'Box 2'


### PR DESCRIPTION
Per Darcy, all the date added/modified should use the 3-letter abbreviation.