### PR TITLE
update saved for later sidebar

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -982,6 +982,10 @@ main:not(:has(#requests li, turbo-frame[busy])) .no-requests {
   animation: slideUp 0.5s ease-out forwards;
 }
 
+#saved_for_later_aeon_requests_sidebar .request.flash-on-add::before {
+  inset: 2px 0px;
+}
+
 .request.flash-on-add::before {
   content: '';
   position: absolute;
@@ -1004,12 +1008,6 @@ main:not(:has(#requests li, turbo-frame[busy])) .no-requests {
   &:has(.dropdown-toggle.show) {
     z-index: 5;
   }
-
-  --bs-list-group-item-padding-x: 0;
-  margin-inline-start: -1rem;
-  margin-inline-end: -1rem;
-  padding-inline-start: 1rem;
-  padding-inline-end: 1rem;
 }
 
 @keyframes slideUp {

--- a/app/components/aeon/request_group_brief_component.html.erb
+++ b/app/components/aeon/request_group_brief_component.html.erb
@@ -1,14 +1,16 @@
 <%= tag.div id: request_group.dom_id, class: classes.join(' '), data: do %>
   <div class="card-body">
     <div class="metadata">
-      <div class="mb-2 text-dark-emphasis reading-room"><%= requests.first.reading_room&.name %></div>
+      <div class="mb-2 text- text-uppercase reading-room fw-semibold text-lagunita-dark fs-14">
+        <%= requests.first.reading_room&.name %>
+      </div>
       <h2 class="h4"><%= title %></h2>
       <div class="d-flex gap-sm-3 flex-sm-row flex-wrap flex-column">
-        <% if base_callnumber.present? %>
+        <% if base_callnumber.present? && request_group.multi_item_selector? %>
           <div>Call number: <%= base_callnumber %></div>
         <% end %>
       </div>
-      <ul class="list-group list-group-flush">
+      <ul class="list-group list-group-flush mt-2">
         <%= render Aeon::RequestGroupBriefListItemComponent.with_collection(requests, after_request_item_component: @after_request_item_component) %>
       </ul>
     </div>

--- a/app/components/aeon/request_group_brief_list_item_component.html.erb
+++ b/app/components/aeon/request_group_brief_list_item_component.html.erb
@@ -1,5 +1,5 @@
-<li id="<%= dom_id(request, :sidebar) %>" data-transaction-number="<%= request.transaction_number %>" class="<%= classes.join(' ') %>">
-  <div class="d-flex flex-row align-items-center justify-content-between">
+<%= tag.li id: dom_id(request, :sidebar), data: { transaction_number: request.transaction_number }, class: classes.join(" ") do %>
+  <div class="d-flex align-items-center flex-row justify-content-between">
     <div class="d-flex column-gap-3 text-break flex-wrap">
       <%= render Aeon::RequestItemIdentifierComponent.new(request:) %>
     </div>
@@ -7,4 +7,4 @@
       <%= render @after_request_item_component.new(request:) if @after_request_item_component %>
     </turbo-frame>
   </div>
-</li>
+<% end %>

--- a/app/components/aeon/request_group_brief_list_item_component.rb
+++ b/app/components/aeon/request_group_brief_list_item_component.rb
@@ -9,7 +9,7 @@ module Aeon
 
     def initialize(request: [], after_request_item_component: nil, additional_classes: [])
       @after_request_item_component = after_request_item_component
-      @classes = %w[request list-group-item] + Array(additional_classes)
+      @classes = %w[request list-group-item border-0 border-top px-0 py-1] + Array(additional_classes)
       @request = request
     end
   end


### PR DESCRIPTION
closes #4268 
Before:
<img width="487" height="812" alt="Screenshot 2026-07-29 at 4 50 31 PM" src="https://github.com/user-attachments/assets/5ac4ba30-1a39-4cfc-9709-e58e40eecbe4" />


After:

<img width="519" height="818" alt="Screenshot 2026-07-29 at 5 01 56 PM" src="https://github.com/user-attachments/assets/166dc7e5-5841-4c9c-ba38-30066d9d4ece" />


Figma:
<img width="522" height="722" alt="Screenshot 2026-07-29 at 4 19 49 PM" src="https://github.com/user-attachments/assets/4c1c0f6f-dc9c-41a9-a6c0-38329734f1f7" />
