### PR TITLE
Get all the location details for a hold.

### DIFF
--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -337,15 +337,14 @@ class FolioGraphqlClient
                                         enumeration
                                         volume
                                         permanentLocation {
-                                          code
+                                          #{location_fields}
                                         }
                                         effectiveLocation {
                                           #{location_fields}
                                         }
                                         holdingsRecord {
                                           effectiveLocation {
-                                            id
-                                            code
+                                            #{location_fields}
                                           }
                                         }
                                       }


### PR DESCRIPTION
We need the permanent / holdings location data to get the location details (e.g. restricted service points, etc).