### PR TITLE
Only use the first word as the fine status.

### DIFF
--- a/app/components/folio/fine_component.html.erb
+++ b/app/components/folio/fine_component.html.erb
@@ -12,7 +12,7 @@
       <%= render Folio::CheckedOutActionsComponent.new(checkout: fine) %>
     <% else %>
       <%= render Folio::FineActionsComponent.new(fine:) %>
-      <%= render Folio::FineStatusPillComponent.new(status: fine.status) if fine.closed? %>
+      <%= render Folio::FineStatusPillComponent.new(fine: fine) %>
     <% end %>
   <% end %>
   <% c.with_body(classes: 'bg-white') do %>

--- a/app/components/folio/fine_status_pill_component.rb
+++ b/app/components/folio/fine_status_pill_component.rb
@@ -3,11 +3,17 @@
 module Folio
   # Render a pill with correct value/color combination based on fee status
   class FineStatusPillComponent < ViewComponent::Base
-    attr_reader :status
+    attr_reader :fine
 
-    def initialize(status:)
-      @status = status
+    delegate :status, to: :fine
+
+    def initialize(fine:)
+      @fine = fine
       super()
+    end
+
+    def render?
+      fine.closed?
     end
 
     def status_classes

--- a/app/components/folio/fine_status_pill_component.rb
+++ b/app/components/folio/fine_status_pill_component.rb
@@ -5,8 +5,6 @@ module Folio
   class FineStatusPillComponent < ViewComponent::Base
     attr_reader :fine
 
-    delegate :status, to: :fine
-
     def initialize(fine:)
       @fine = fine
       super()
@@ -17,20 +15,20 @@ module Folio
     end
 
     def status_classes
-      case fine_status
+      case status.upcase
       when 'PAID'
-        %w[fine-status bg-green text-green]
+        %w[fine-status bg-green text-green text-uppercase]
       else
-        %w[fine-status bg-stanford-20-black text-black]
+        %w[fine-status bg-stanford-20-black text-black text-uppercase]
       end
     end
 
-    def fine_status
-      status.gsub('fully', '').strip.upcase
+    def status
+      fine.status.split(' ', 2).first
     end
 
     def call
-      render PillComponent.new(classes: status_classes).with_content(fine_status)
+      render PillComponent.new(classes: status_classes).with_content(status)
     end
   end
 end


### PR DESCRIPTION
FOLIO has some pretty wordy fine labels:

```
"Outstanding",
            "Paid partially",
            "Paid fully",
            "Waived partially",
            "Waived fully",
            "Transferred partially",
            "Transferred fully",
            "Refunded partially",
            "Refunded fully",
            "Credited fully",
            "Credited partially",
            "Cancelled item returned",
            "Cancelled item renewed",
            "Cancelled item declared lost",
            "Cancelled as error",
            "Suspended claim returned"
```

The first word is probably enough detail, per Darcy.