### PR TITLE
Update patron request confirmation page styles

### DIFF
--- a/app/assets/stylesheets/colors.css
+++ b/app/assets/stylesheets/colors.css
@@ -71,6 +71,11 @@ input[type="radio"] {
   --bs-alert-color: var(--bs-alert-border-color);
 }
 
+/* Restore the upstream bootstrap warning alert color. */
+.alert-warning {
+  --bs-alert-color: var(--bs-alert-border-color);
+}
+
 /* Restore disabled primary button styling from upstream bootstrap. */
 .btn-primary {
   --bs-btn-disabled-color: #fff;

--- a/app/assets/stylesheets/utility.css
+++ b/app/assets/stylesheets/utility.css
@@ -136,7 +136,7 @@ label.btn-close {
   margin: -0.5rem !important;
 }
 
-.p-n1 {
+.m-n1 {
   margin-left: -0.25rem;
   margin-right: -0.25rem;
 }

--- a/app/assets/stylesheets/utility.css
+++ b/app/assets/stylesheets/utility.css
@@ -136,6 +136,11 @@ label.btn-close {
   margin: -0.5rem !important;
 }
 
+.p-n1 {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
 /* Override bootstrap tabs to give them a more visible decoration */
 .nav-tabs .nav-link:not(.active):hover {
   background-color: var(--bs-nav-tabs-link-hover-bg);

--- a/app/assets/stylesheets/utility.css
+++ b/app/assets/stylesheets/utility.css
@@ -148,7 +148,7 @@ label.btn-close {
     margin-bottom: 0 !important;
   }
 
-  .border-first-child-top-0:last-child {
+  .border-first-child-top-0:first-child {
     border-top: none !important;
   }
 

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -50,7 +50,6 @@
               <% end %>
 
               <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
-                <hr>
                 <div class="mb-3">
                   <span class="fw-semibold">Item(s) requested:</span>
                 </div>
@@ -62,7 +61,6 @@
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
-                  <hr>
                   <div class="mb-3">
                     <span class="fw-semibold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
                   </div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -53,7 +53,7 @@
                 </div>
                 <ul class="list-unstyled">
                   <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
-                    <li class="request border-top border-first-child-top-0 fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                    <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                   <% end %>
                 </ul>
                 <% if @patron_request.needed_date %>
@@ -64,18 +64,21 @@
                 <% end %>
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
+                <% both_pickup_sections = available_items.any? && unavailable_items.any? %>
+                <% pickup_section_classes = "mb-2#{' bg-light p-1 m-n1' if both_pickup_sections}" %>
+                <% pickup_item_classes = "request border-top fw-semibold text-pretty py-2#{' border-first-child-top-0' if both_pickup_sections}" %>
                 <% if available_items.any? %>
-                  <div class="bg-light mb-2 p-1 m-n1">
+                  <div class="<%= pickup_section_classes %>">
                     <div><dt>Pickup after:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
                   </div>
                   <ul class="list-unstyled">
                     <% available_items.each do |avail_item| %>
-                      <li class="request border-top border-first-child-top-0 fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                      <li class="<%= pickup_item_classes %>"><%= callnumber_label(avail_item) %></li>
                     <% end %>
                   </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                  <div class="bg-light mb-2 p-1 m-n1">
+                  <div class="<%= pickup_section_classes %>">
                     <div><dt>Pickup after:</dt><dd>Notified by email</dd></div>
                     <% if @patron_request.fulfillment_type %>
                       <div>
@@ -94,7 +97,7 @@
                   </div>
                   <ul class="list-unstyled">
                     <% unavailable_items.each do |avail_item| %>
-                      <li class="request border-top border-first-child-top-0 fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                      <li class="<%= pickup_item_classes %>"><%= callnumber_label(avail_item) %></li>
                     <% end %>
                   </ul>
                 <% end %>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -64,7 +64,7 @@
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
-                  <div class="bg-light mb-2 p-1 p-n1">
+                  <div class="bg-light mb-2 p-1 m-n1">
                     <div><dt>Pickup after:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
                   </div>
                   <ul class="list-unstyled">
@@ -74,7 +74,7 @@
                   </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                  <div class="bg-light mb-2 p-1 p-n1">
+                  <div class="bg-light mb-2 p-1 m-n1">
                     <div><dt>Pickup after:</dt><dd>Notified by email</dd></div>
                     <% if @patron_request.fulfillment_type %>
                       <div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -13,25 +13,19 @@
         <hr>
 
         <% @patron_request.patron_request_items.map(&:folio_item).select(&:bound_with_child_holdings_record).each do |item| %>
-            <div class="alert alert-warning d-flex align-items-center gap-3">
-                <i class="bi bi-exclamation-triangle-fill me-2 text-warning fs-1"></i>
-
-                <div>
-                    <div class="fw-bold mb-2">Important!</div>
-
-                    <p>
-                        <% if @patron_request.patron_request_items.one? %>
-                            This item
-                        <% else %>
-                            The item <i><%= @patron_request.item_title %></i> (<%= item.bound_with_child_holdings_record.call_number %>)
-                        <% end %> is bound with other items and is shelved under the title <i><%= item.instance.title %></i> (<%= item.callnumber %>).
-                    </p>
-
-                    <p class="mb-0 fw-bold">
-                        Be advised that all subsequent correspondence will reference this title. The item you requested will be included with it.
-                    </p>
-                </div>
-            </div>
+          <%= render AlertComponent.new(type: :warning) do %>
+            <div class="fw-semibold mb-2">Important!</div>
+            <p>
+              <% if @patron_request.patron_request_items.one? %>
+                This item
+              <% else %>
+                The item <i><%= @patron_request.item_title %></i> (<%= item.bound_with_child_holdings_record.call_number %>)
+              <% end %> is bound with other items and is shelved under the title <i><%= item.instance.title %></i> (<%= item.callnumber %>).
+            </p>
+            <p class="mb-0 fw-semibold">
+              Be advised that all subsequent correspondence will reference this title. The item you requested will be included with it.
+            </p>
+          <% end %>
         <% end %>
 
         <h2 class="my-4">Request confirmation</h2>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -54,7 +54,7 @@
                 </div>
                 <ul class="list-unstyled">
                   <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
-                    <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                    <li class="request border-top border-first-child-top-0 fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                   <% end %>
                 </ul>
                 <% if @patron_request.needed_date %>
@@ -66,17 +66,17 @@
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
-                  <div class="bg-light mb-3 p-1">
+                  <div class="bg-light mb-2 p-1">
                     <div><dt>Pickup after:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
                   </div>
                   <ul class="list-unstyled">
                     <% available_items.each do |avail_item| %>
-                      <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                      <li class="request border-top border-first-child-top-0 fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                     <% end %>
                   </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                  <div class="bg-light mb-3 p-1">
+                  <div class="bg-light mb-2 p-1">
                     <div><dt>Pickup after:</dt><dd>Notified by email</dd></div>
                     <% if @patron_request.fulfillment_type %>
                       <div>
@@ -95,7 +95,7 @@
                   </div>
                   <ul class="list-unstyled">
                     <% unavailable_items.each do |avail_item| %>
-                      <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                      <li class="request border-top border-first-child-top-0 fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                     <% end %>
                   </ul>
                 <% end %>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -26,7 +26,7 @@
           <% end %>
         <% end %>
 
-        <div class="border rounded p-3 mb-2">
+        <div class="border rounded p-3 pb-0 mb-2">
           <h2 class="h3">Details</h2>
           <% if @patron_request.request_type == 'scan' %>
             <p class="text-cardinal">We'll email you when your files are ready.</p>
@@ -51,35 +51,34 @@
 
               <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
                 <hr>
-                <div class="mb-2">
+                <div class="mb-3">
                   <span class="fw-semibold">Item(s) requested:</span>
                 </div>
                 <ul class="list-unstyled">
                   <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
-                    <li><%= callnumber_label(avail_item) %></li>
+                    <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                   <% end %>
                 </ul>
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
                   <hr>
-                  <div class="mb-2">
+                  <div class="mb-3">
                     <span class="fw-semibold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
                   </div>
                   <ul class="list-unstyled">
                     <% available_items.each do |avail_item| %>
-                      <li><%= callnumber_label(avail_item) %></li>
+                      <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                     <% end %>
                   </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                  <hr>
-                  <div class="mb-2">
+                  <div class="mb-3">
                     <span class="fw-semibold">Pickup after:</span> Notified by email
                   </div>
                   <ul class="list-unstyled">
                     <% unavailable_items.each do |avail_item| %>
-                      <li><%= callnumber_label(avail_item) %></li>
+                      <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                     <% end %>
                   </ul>
                 <% end %>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -3,13 +3,6 @@
   <div class="confirmation col-12 col-lg-8">
     <h1>We received your <%= @patron_request.request_type == 'scan' ? 'digital scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
     <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
-    <div>
-      <% if @patron_request.mediateable? %>
-        A librarian will review and approve your request for restricted-use materials, or contact you.
-        Approvals typically happen 1-3 business days before your planned visit date.
-      <% end %>
-    </div>
-
         <% @patron_request.patron_request_items.map(&:folio_item).select(&:bound_with_child_holdings_record).each do |item| %>
           <%= render AlertComponent.new(type: :warning) do %>
             <div class="fw-semibold mb-2">Important!</div>
@@ -30,7 +23,12 @@
           <h2 class="h3">Details</h2>
           <% if @patron_request.request_type == 'scan' %>
             <p class="text-cardinal">We'll email you when your files are ready.</p>
-          <% elsif !@patron_request.mediateable? && !@patron_request.aeon_page? %>
+          <% elsif @patron_request.mediateable? %>
+            <p class="text-cardinal">
+              A librarian will review and approve your request for restricted-use materials, or contact you.
+              Approvals typically happen 1-3 business days before your planned visit date.
+            </p>
+          <% elsif !@patron_request.aeon_page? %>
             <p class="text-cardinal">We'll email you when your <%= @patron_request.patron_request_items.one? ? 'item is' : 'items are' %> ready.</p>
           <% end %>
 
@@ -49,7 +47,7 @@
               <% end %>
 
               <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
-                <div class="mb-3">
+                <div class="mb-2">
                   <span class="fw-semibold">Item(s) requested:</span>
                 </div>
                 <ul class="list-unstyled">

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -28,6 +28,12 @@
 
         <div class="border rounded p-3 mb-2">
           <h2 class="h3">Details</h2>
+          <% if @patron_request.request_type == 'scan' %>
+            <p class="text-cardinal">We'll email you when your files are ready.</p>
+          <% elsif !@patron_request.mediateable? && !@patron_request.aeon_page? %>
+            <p class="text-cardinal">We'll email you when your <%= @patron_request.patron_request_items.one? ? 'item is' : 'items are' %> ready.</p>
+          <% end %>
+
           <dl class="dl-inline">
             <div><dt>Title:</dt><dd><%= @patron_request.item_title %></dd></div>
             <% if @patron_request.request_type == 'scan' %>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -1,9 +1,9 @@
 <%# locals: (mailer: false) %>
-<h1 class="fw-semibold fs-1">We received your <%= @patron_request.request_type == 'scan' ? 'scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
-
-<div class="row mt-4">
-    <div class="col-7">
-        <div class="lead">
+<div class="row">
+  <div class="confirmation col-12 col-lg-8">
+    <h1>We received your <%= @patron_request.request_type == 'scan' ? 'digital scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
+    <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
+    <div class="lead">
             <%= yield %>
 
             <% if @patron_request.patron.present? %>
@@ -120,47 +120,12 @@
                 <div>
                     <dt>Processing method:</dt>
                     <dd>
-                        <%= @patron_request.fulfillment_type == 'hold' ? 'Wait for a Stanford copy to become available' : 'Expedite a copy from a partner library' %>
+                      <%= @patron_request.fulfillment_type == 'hold' ? 'Wait for a Stanford copy to become available' : 'Expedite a copy from a partner library' %>
                     </dd>
                 </div>
             <% end %>
             </dl>
         <% end %>
     </div>
-    <div class="offset-1 col-4">
-        <div class="card">
-            <div class="card-body">
-                <h2 class="h3 fw-semibold">Library resources</h2>
-                <% if mailer || !use_requests_redesign? %>
-                    <div class="bg-light p-2">
-                        <h3 class="h4">
-                            <a href="https://mylibrary.stanford.edu"><i class="bi bi-box-arrow-up-right"></i> Log in to My Account</a>
-                        </h3>
-                        <p class="mb-0">
-                        Access information regarding items currently checked out, monitor requests,
-                        and/or outstanding fines.
-                        </p>
-                    </div>
-                <% end %>
-                <h3 class="h4 fw-semibold mt-3">Get help</h3>
-                    <ul class="list-unstyled">
-                        <li><i class="bi bi-envelope-fill"></i> <%= mail_to(@patron_request.contact_info[:email], @patron_request.contact_info[:email]) %></li>
-                        <li><i class="bi bi-telephone-fill"></i> Call <%= @patron_request.contact_info[:phone] %></li>
-                    </ul>
-                <h3 class="h4 fw-semibold mt-3">Library policies and information</h3>
-                <ul class="list-unstyled">
-                    <li>
-                        <a href="https://library.stanford.edu/services/borrow-and-request" target="_blank">
-                            <i class="bi bi-box-arrow-up-right"></i> Borrow and request
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://library.stanford.edu/borrowdirect" target="_blank">
-                            <i class="bi bi-box-arrow-up-right"></i> Borrow Direct
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </div>
+    <%= render 'contact_aside' %>
 </div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -45,7 +45,7 @@
               <% end %>
             <% else %>
               <% if @patron_request.pickup_service_point %>
-                <div><dt><%= @patron_request.location_label %>:</dt><dd><%= @patron_request.pickup_service_point.name %></dd></div>
+                <div class="mb-3"><dt><%= @patron_request.location_label %>:</dt><dd><%= @patron_request.pickup_service_point.name %></dd></div>
               <% end %>
 
               <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
@@ -57,11 +57,17 @@
                     <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
                   <% end %>
                 </ul>
+                <% if @patron_request.needed_date %>
+                  <div>
+                    <dt><% if @patron_request.mediateable? %>I plan to visit on:<% else %>Not needed after:<% end %></dt>
+                    <dd><%= l @patron_request.needed_date, format: :short %></dd>
+                  </div>
+                <% end %>
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
-                  <div class="mb-3">
-                    <span class="fw-semibold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
+                  <div class="bg-light mb-3 p-1">
+                    <div><dt>Pickup after:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
                   </div>
                   <ul class="list-unstyled">
                     <% available_items.each do |avail_item| %>
@@ -70,8 +76,22 @@
                   </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                  <div class="mb-3">
-                    <span class="fw-semibold">Pickup after:</span> Notified by email
+                  <div class="bg-light mb-3 p-1">
+                    <div><dt>Pickup after:</dt><dd>Notified by email</dd></div>
+                    <% if @patron_request.fulfillment_type %>
+                      <div>
+                        <dt>Processing method:</dt>
+                        <dd>
+                          <%= @patron_request.fulfillment_type == 'hold' ? 'Wait for a Stanford copy to become available' : 'Expedite a copy from a partner library' %>
+                        </dd>
+                      </div>
+                    <% end %>
+                    <% if @patron_request.needed_date %>
+                      <div>
+                        <dt>Not needed after:</dt>
+                        <dd><%= l @patron_request.needed_date, format: :short %></dd>
+                      </div>
+                    <% end %>
                   </div>
                   <ul class="list-unstyled">
                     <% unavailable_items.each do |avail_item| %>
@@ -79,26 +99,6 @@
                     <% end %>
                   </ul>
                 <% end %>
-              <% end %>
-              <% if @patron_request.needed_date %>
-                <div>
-                  <dt>
-                    <% if @patron_request.mediateable? %>
-                      I plan to visit on:
-                    <% else %>Not needed after:<% end %>
-                  </dt>
-                  <dd>
-                    <%= l @patron_request.needed_date, format: :short %>
-                  </dd>
-                </div>
-              <% end %>
-              <% if @patron_request.fulfillment_type %>
-                <div>
-                  <dt>Processing method:</dt>
-                  <dd>
-                    <%= @patron_request.fulfillment_type == 'hold' ? 'Wait for a Stanford copy to become available' : 'Expedite a copy from a partner library' %>
-                  </dd>
-                </div>
               <% end %>
             <% end %>
           </dl>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -66,7 +66,7 @@
               <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
-                  <div class="bg-light mb-2 p-1">
+                  <div class="bg-light mb-2 p-1 p-n1">
                     <div><dt>Pickup after:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
                   </div>
                   <ul class="list-unstyled">
@@ -76,7 +76,7 @@
                   </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                  <div class="bg-light mb-2 p-1">
+                  <div class="bg-light mb-2 p-1 p-n1">
                     <div><dt>Pickup after:</dt><dd>Notified by email</dd></div>
                     <% if @patron_request.fulfillment_type %>
                       <div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -10,8 +10,6 @@
       <% end %>
     </div>
 
-        <hr>
-
         <% @patron_request.patron_request_items.map(&:folio_item).select(&:bound_with_child_holdings_record).each do |item| %>
           <%= render AlertComponent.new(type: :warning) do %>
             <div class="fw-semibold mb-2">Important!</div>
@@ -28,84 +26,81 @@
           <% end %>
         <% end %>
 
-        <h2 class="my-4">Request confirmation</h2>
-        <dl class="dl-inline">
+        <div class="border rounded p-3 mb-2">
+          <h2 class="h3">Details</h2>
+          <dl class="dl-inline">
             <div><dt>Title:</dt><dd><%= @patron_request.item_title %></dd></div>
-        <% if @patron_request.request_type == 'scan' %>
-            <div><dt>Pages:</dt><dd><%= @patron_request.scan_page_range %></dd></div>
-            <div><dt>Chapter/article:</dt><dd><%= @patron_request.scan_title %></dd></div>
-            <div><dt>Authors:</dt><dd><%= @patron_request.scan_authors %></dd></div>
+            <% if @patron_request.request_type == 'scan' %>
+              <div><dt>Pages:</dt><dd><%= @patron_request.scan_page_range %></dd></div>
+              <div><dt>Chapter/article:</dt><dd><%= @patron_request.scan_title %></dd></div>
+              <div><dt>Authors:</dt><dd><%= @patron_request.scan_authors %></dd></div>
 
-            <% if @patron_request.estimated_delivery %>
+              <% if @patron_request.estimated_delivery %>
                 <div><dt>Earliest expected delivery:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
-            <% end %>
-        <% else %>
-            <% if @patron_request.pickup_service_point %>
-            <div><dt><%= @patron_request.location_label %>:</dt><dd><%= @patron_request.pickup_service_point.name %></dd></div>
-            <% end %>
-        <% end %>
-        </dl>
+              <% end %>
+            <% else %>
+              <% if @patron_request.pickup_service_point %>
+                <div><dt><%= @patron_request.location_label %>:</dt><dd><%= @patron_request.pickup_service_point.name %></dd></div>
+              <% end %>
 
-        <% unless @patron_request.request_type == 'scan' %>
-            <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
+              <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
                 <hr>
                 <div class="mb-2">
-                    <span class="fw-bold">Item(s) requested:</span>
+                  <span class="fw-bold">Item(s) requested:</span>
                 </div>
                 <ul class="list-unstyled">
-                    <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
-                        <li><%= callnumber_label(avail_item) %></li>
-                    <% end %>
+                  <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
+                    <li><%= callnumber_label(avail_item) %></li>
+                  <% end %>
                 </ul>
-            <% else %>
+              <% else %>
                 <% available_items, unavailable_items = @patron_request.patron_request_items.map(&:folio_item).partition(&:available?) %>
                 <% if available_items.any? %>
-                    <hr>
-                    <div class="mb-2">
-                        <span class="fw-bold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
-                    </div>
-                    <ul class="list-unstyled">
-                        <% available_items.each do |avail_item| %>
-                            <li><%= callnumber_label(avail_item) %></li>
-                        <% end %>
-                    </ul>
+                  <hr>
+                  <div class="mb-2">
+                    <span class="fw-bold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
+                  </div>
+                  <ul class="list-unstyled">
+                    <% available_items.each do |avail_item| %>
+                      <li><%= callnumber_label(avail_item) %></li>
+                    <% end %>
+                  </ul>
                 <% end %>
                 <% if unavailable_items.any? %>
-                    <hr>
-                    <div class="mb-2">
-                        <span class="fw-bold">Pickup after:</span> Notified by email
-                    </div>
-                    <ul class="list-unstyled">
-                        <% unavailable_items.each do |avail_item| %>
-                            <li><%= callnumber_label(avail_item) %></li>
-                        <% end %>
-                    </ul>
+                  <hr>
+                  <div class="mb-2">
+                    <span class="fw-bold">Pickup after:</span> Notified by email
+                  </div>
+                  <ul class="list-unstyled">
+                    <% unavailable_items.each do |avail_item| %>
+                      <li><%= callnumber_label(avail_item) %></li>
+                    <% end %>
+                  </ul>
                 <% end %>
-            <% end %>
-
-            <dl class="dl-inline">
-            <% if @patron_request.needed_date %>
+              <% end %>
+              <% if @patron_request.needed_date %>
                 <div>
-                    <dt>
-                        <% if @patron_request.mediateable? %>
-                            I plan to visit on:
-                        <% else %>Not needed after:<% end %>
-                    </dt>
-                    <dd>
-                        <%= l @patron_request.needed_date, format: :short %>
-                    </dd>
+                  <dt>
+                    <% if @patron_request.mediateable? %>
+                      I plan to visit on:
+                    <% else %>Not needed after:<% end %>
+                  </dt>
+                  <dd>
+                    <%= l @patron_request.needed_date, format: :short %>
+                  </dd>
                 </div>
-            <% end %>
-            <% if @patron_request.fulfillment_type %>
+              <% end %>
+              <% if @patron_request.fulfillment_type %>
                 <div>
-                    <dt>Processing method:</dt>
-                    <dd>
-                      <%= @patron_request.fulfillment_type == 'hold' ? 'Wait for a Stanford copy to become available' : 'Expedite a copy from a partner library' %>
-                    </dd>
+                  <dt>Processing method:</dt>
+                  <dd>
+                    <%= @patron_request.fulfillment_type == 'hold' ? 'Wait for a Stanford copy to become available' : 'Expedite a copy from a partner library' %>
+                  </dd>
                 </div>
+              <% end %>
             <% end %>
-            </dl>
-        <% end %>
-    </div>
-    <%= render 'contact_aside' %>
+          </dl>
+        </div>
+  </div>
+  <%= render 'contact_aside' %>
 </div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -107,5 +107,5 @@
           </dl>
         </div>
   </div>
-  <%= render 'contact_aside' %>
+  <%= render 'patron_requests/contact_aside' unless mailer %>
 </div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -3,19 +3,12 @@
   <div class="confirmation col-12 col-lg-8">
     <h1>We received your <%= @patron_request.request_type == 'scan' ? 'digital scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
     <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
-    <div class="lead">
-            <%= yield %>
-
-            <% if @patron_request.request_type == 'scan' %>
-                We'll notify you by email once your scan request is ready. Remember to download the PDF within 30 days of notification.
-            <% else %>
-                <% if @patron_request.mediateable? %>
-                    A librarian will review and approve your request for restricted-use materials, or contact you.
-                    Approvals typically happen 1-3 business days before your planned visit date.
-                <% end %>
-                You will receive an email when the <%= @patron_request.patron_request_items.one? ?  'item is' : 'items are' %> ready.
-            <% end %>
-        </div>
+    <div>
+      <% if @patron_request.mediateable? %>
+        A librarian will review and approve your request for restricted-use materials, or contact you.
+        Approvals typically happen 1-3 business days before your planned visit date.
+      <% end %>
+    </div>
 
         <hr>
 

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="confirmation col-12 col-lg-8">
     <h1>We received your <%= @patron_request.request_type == 'scan' ? 'digital scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
-    <%= render RecordHeaderCardComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
+    <%= render RecordHeaderComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
         <% @patron_request.patron_request_items.map(&:folio_item).select(&:bound_with_child_holdings_record).each do |item| %>
           <%= render AlertComponent.new(type: :warning) do %>
             <div class="fw-semibold mb-2">Important!</div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -6,13 +6,6 @@
     <div class="lead">
             <%= yield %>
 
-            <% if @patron_request.patron.present? %>
-                <% if @patron_request.mediateable? %>
-                    Once approved, you can view the status of your request in
-                <% else %>
-                    You can also check the status of your request any time at
-                <% end %><%= link_to ' My Account', use_requests_redesign? ? unified_requests_url : 'https://mylibrary.stanford.edu' %>.
-            <% end %>
             <% if @patron_request.request_type == 'scan' %>
                 We'll notify you by email once your scan request is ready. Remember to download the PDF within 30 days of notification.
             <% else %>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -52,7 +52,7 @@
               <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
                 <hr>
                 <div class="mb-2">
-                  <span class="fw-bold">Item(s) requested:</span>
+                  <span class="fw-semibold">Item(s) requested:</span>
                 </div>
                 <ul class="list-unstyled">
                   <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
@@ -64,7 +64,7 @@
                 <% if available_items.any? %>
                   <hr>
                   <div class="mb-2">
-                    <span class="fw-bold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
+                    <span class="fw-semibold">Pickup after:</span> <%= @patron_request.estimated_delivery %>
                   </div>
                   <ul class="list-unstyled">
                     <% available_items.each do |avail_item| %>
@@ -75,7 +75,7 @@
                 <% if unavailable_items.any? %>
                   <hr>
                   <div class="mb-2">
-                    <span class="fw-bold">Pickup after:</span> Notified by email
+                    <span class="fw-semibold">Pickup after:</span> Notified by email
                   </div>
                   <ul class="list-unstyled">
                     <% unavailable_items.each do |avail_item| %>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -35,7 +35,6 @@
           <% end %>
 
           <dl class="dl-inline">
-            <div><dt>Title:</dt><dd><%= @patron_request.item_title %></dd></div>
             <% if @patron_request.request_type == 'scan' %>
               <div><dt>Pages:</dt><dd><%= @patron_request.scan_page_range %></dd></div>
               <div><dt>Chapter/article:</dt><dd><%= @patron_request.scan_title %></dd></div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -33,6 +33,7 @@
           <% end %>
 
           <dl class="dl-inline">
+            <% if mailer %><div><dt>Title:</dt><dd><%= @patron_request.item_title %></dd></div><% end %>
             <% if @patron_request.request_type == 'scan' %>
               <div><dt>Pages:</dt><dd><%= @patron_request.scan_page_range %></dd></div>
               <div><dt>Chapter/article:</dt><dd><%= @patron_request.scan_title %></dd></div>

--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -47,15 +47,18 @@
                 <div class="mb-3"><dt><%= @patron_request.location_label %>:</dt><dd><%= @patron_request.pickup_service_point.name %></dd></div>
               <% end %>
 
+              <% show_callnumbers = mailer || @patron_request.patron_request_items.many? %>
               <% if @patron_request.mediateable? || @patron_request.aeon_page? %>
-                <div class="mb-2">
-                  <span class="fw-semibold">Item(s) requested:</span>
-                </div>
-                <ul class="list-unstyled">
-                  <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
-                    <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
-                  <% end %>
-                </ul>
+                <% if show_callnumbers %>
+                  <div class="mb-2">
+                    <span class="fw-semibold">Item(s) requested:</span>
+                  </div>
+                  <ul class="list-unstyled">
+                    <% @patron_request.patron_request_items.map(&:folio_item).each do |avail_item| %>
+                      <li class="request border-top fw-semibold text-pretty py-2"><%= callnumber_label(avail_item) %></li>
+                    <% end %>
+                  </ul>
+                <% end %>
                 <% if @patron_request.needed_date %>
                   <div>
                     <dt><% if @patron_request.mediateable? %>I plan to visit on:<% else %>Not needed after:<% end %></dt>
@@ -71,11 +74,13 @@
                   <div class="<%= pickup_section_classes %>">
                     <div><dt>Pickup after:</dt><dd><%= @patron_request.estimated_delivery %></dd></div>
                   </div>
-                  <ul class="list-unstyled">
-                    <% available_items.each do |avail_item| %>
-                      <li class="<%= pickup_item_classes %>"><%= callnumber_label(avail_item) %></li>
-                    <% end %>
-                  </ul>
+                  <% if show_callnumbers %>
+                    <ul class="list-unstyled">
+                      <% available_items.each do |avail_item| %>
+                        <li class="<%= pickup_item_classes %>"><%= callnumber_label(avail_item) %></li>
+                      <% end %>
+                    </ul>
+                  <% end %>
                 <% end %>
                 <% if unavailable_items.any? %>
                   <div class="<%= pickup_section_classes %>">
@@ -95,11 +100,13 @@
                       </div>
                     <% end %>
                   </div>
-                  <ul class="list-unstyled">
-                    <% unavailable_items.each do |avail_item| %>
-                      <li class="<%= pickup_item_classes %>"><%= callnumber_label(avail_item) %></li>
-                    <% end %>
-                  </ul>
+                  <% if show_callnumbers %>
+                    <ul class="list-unstyled">
+                      <% unavailable_items.each do |avail_item| %>
+                        <li class="<%= pickup_item_classes %>"><%= callnumber_label(avail_item) %></li>
+                      <% end %>
+                    </ul>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/patron_requests/show.html.erb
+++ b/app/views/patron_requests/show.html.erb
@@ -5,11 +5,7 @@
   <%= render 'messages', messages: @patron_request.active_messages %>
 <% end %>
 
-<%= render 'confirmation_screen' do %>
-  <% if @patron_request.patron.email %>
-    Expect a confirmation email shortly at <span class="fw-semibold"><%= @patron_request.patron.email %></span>.
-  <% end %>
-<% end %>
+<%= render 'confirmation_screen' %>
 
 <% if can? :debug, @patron_request %>
   <hr>

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -456,6 +456,9 @@ RSpec.describe 'Creating a request', :js do
         expect(page).to have_text 'We received your pickup request'
       end.to change(PatronRequest, :count).by(1)
 
+      # With only a single type of item, we don't need the background styles to break up the sections.
+      expect(page).to have_no_css('.bg-light.p-1')
+
       expect(PatronRequest.last).to have_attributes(patron_request_items: contain_exactly(have_attributes(item_id: '12345678')))
     end
 
@@ -491,6 +494,9 @@ RSpec.describe 'Creating a request', :js do
         end
         expect(page).to have_text 'We received your pickup request'
       end.to change(PatronRequest, :count).by(1)
+
+      # With multiple types of items (available/unavailable), we should use the background styles to break up the sections.
+      expect(page).to have_css('.bg-light.p-1')
 
       expect(PatronRequest.last).to have_attributes(fulfillment_type: 'hold',
                                                     patron_request_items: contain_exactly(have_attributes(item_id: '12345678'),

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Creating a request', :js do
           perform_enqueued_jobs do
             click_on 'Submit request'
           end
-          expect(page).to have_text 'We received your scan request'
+          expect(page).to have_text 'We received your digital scan request'
         end.to change(PatronRequest, :count).by(1)
 
         expect(PatronRequest.last).to have_attributes(
@@ -230,7 +230,7 @@ RSpec.describe 'Creating a request', :js do
         perform_enqueued_jobs do
           click_on 'Submit request'
         end
-        expect(page).to have_text 'We received your scan request'
+        expect(page).to have_text 'We received your digital scan request'
       end
     end
 
@@ -541,7 +541,7 @@ RSpec.describe 'Creating a request', :js do
         perform_enqueued_jobs do
           click_on 'Submit request'
         end
-        expect(page).to have_text 'We received your scan request'
+        expect(page).to have_text 'We received your digital scan request'
       end.to change(PatronRequest, :count).by(1)
 
       expect(PatronRequest.last).to have_attributes(

--- a/spec/features/create_patron_request_spec.rb
+++ b/spec/features/create_patron_request_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe 'Creating a request', :js do
         expect(page).to have_text 'We received your pickup request'
       end.to change(PatronRequest, :count).by(1)
 
+      # Single items omit the call number because it's shown in the record header component
+      expect(page).to have_no_css('li.request', text: 'ABC 123')
+
       expect(PatronRequest.last).to have_attributes(
         patron_id: user.patron_key,
         instance_hrid: 'a1234',
@@ -497,6 +500,10 @@ RSpec.describe 'Creating a request', :js do
 
       # With multiple types of items (available/unavailable), we should use the background styles to break up the sections.
       expect(page).to have_css('.bg-light.p-1')
+
+      # With multiple callnumbers, we list them all
+      expect(page).to have_css('li.request', text: 'ABC 123')
+      expect(page).to have_css('li.request', text: 'ABC 321')
 
       expect(PatronRequest.last).to have_attributes(fulfillment_type: 'hold',
                                                     patron_request_items: contain_exactly(have_attributes(item_id: '12345678'),

--- a/spec/mailers/patron_request_mailer_spec.rb
+++ b/spec/mailers/patron_request_mailer_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe PatronRequestMailer do
       expect(mail.body).to include('We received your pickup request!')
       expect(mail.body).to include('<dt>Title:</dt><dd>Item Title</dd>')
       expect(mail.body).to include('In library use only')
+      expect(mail.body).to include('ABC 123')
     end
   end
 

--- a/spec/mailers/patron_request_mailer_spec.rb
+++ b/spec/mailers/patron_request_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PatronRequestMailer do
       expect(mail.subject).to eq('Item Title - Stanford University Libraries request confirmation')
       expect(mail.to).to eq(['test@example.com'])
       expect(mail.from).to eq(['scan-and-deliver@stanford.edu'])
-      expect(mail.body).to include('We received your scan request!')
+      expect(mail.body).to include('We received your digital scan request!')
       expect(mail.body).to include('<dt>Title:</dt><dd>Item Title</dd>')
     end
   end


### PR DESCRIPTION
Part of #4201

TODO:
Unclear if Darcy wanted the `bg-light` style she suggested always or only in the case where there's both available & unavailable items.

<img width="764" height="454" alt="Screenshot 2026-07-29 at 4 26 09 PM" src="https://github.com/user-attachments/assets/38d65a13-c3ad-410b-985c-287b01bdabaa" />
<img width="765" height="476" alt="Screenshot 2026-07-29 at 4 25 42 PM" src="https://github.com/user-attachments/assets/c5d54eee-5266-4381-8ecc-0c60b09dd4be" />
<img width="763" height="986" alt="Screenshot 2026-07-29 at 4 25 27 PM" src="https://github.com/user-attachments/assets/260c2888-ca82-44fb-8a56-453abfc1bd65" />
