### PR TITLE
unified request view style fixes

### DIFF
--- a/app/components/aeon/request_group_item_component.html.erb
+++ b/app/components/aeon/request_group_item_component.html.erb
@@ -15,8 +15,5 @@
       </turbo-frame>
     </div>
 
-    <div class="rgi-footer pt-2 fs-14 text-body-secondary d-flex gap-sm-3 flex-sm-row flex-column">
-      <div>Request #<%= transaction_number %></div>
-      <div>Date added/modified: <%= l(transaction_date, format: :full) %></div>
-    </div>
+    <%= render RequestRgiFooter.new(request_id: transaction_number, date: transaction_date) %>
 <% end %>

--- a/app/components/folio/ill_request_component.html.erb
+++ b/app/components/folio/ill_request_component.html.erb
@@ -53,11 +53,7 @@
             </button>
           <% end %>
         </div>
-
-        <div class="rgi-footer pt-2 fs-14 text-body-secondary d-flex gap-sm-3 flex-sm-row flex-column">
-          <div>Request #<%= request.id %></div>
-          <span class="text-body-secondary small">Date added/modified: <span class="text-nowrap"><%= l(request.placed_date, format: :full) %></span></span>
-        </div>
+        <%= render RequestRgiFooter.new(request_id: request.id, date: request.placed_date) %>
       </div>
     </div>
   <% end %>

--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -29,9 +29,7 @@
       <%= render Folio::RequestDeleteButtonComponent.new(request:) %>
     <% end %>
   </div>
-  <div class="rgi-footer d-flex justify-content-start gap-2">
-    <span class="text-body-secondary small">Date added/modified: <span class="text-nowrap"><%= l(request.placed_date, format: :full) %></span></span>
-  </div>
+  <%= render RequestRgiFooter.new(date: request.placed_date) %>
   <% if request.proxy_request? %>
     <div class="py-2">
       <%= render Folio::ProxyIndicatorComponent.new(proxy: proxy_borrower, verb: 'Requested') %>

--- a/app/components/mediated_request_component.html.erb
+++ b/app/components/mediated_request_component.html.erb
@@ -54,10 +54,7 @@
         <% end %>
       </div>
 
-      <div class="rgi-footer pt-2 fs-14 text-body-secondary d-flex gap-sm-3 flex-sm-row flex-column">
-        <div>Request #<%= request.id %></div>
-        <span class="text-body-secondary small">Date added/modified: <span class="text-nowrap"><%= l(request.updated_at, format: :full) %></span></span>
-      </div>
+      <%= render RequestRgiFooter.new(request_id: request.id, date: request.updated_at) %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/mediated_request_component.html.erb
+++ b/app/components/mediated_request_component.html.erb
@@ -17,7 +17,7 @@
     <div class="request-grid bg-white p-2">
       <div class="rgi-id d-flex align-items-center">
         <% if request.requires_needed_date? %>
-          <span class="fw-semibold">Planned visit date:</span> <%= l(request.needed_date, format: :short) %>
+          <span class="fw-semibold me-1">Planned visit date:</span><%= l(request.needed_date, format: :short) %>
         <% end %>
       </div>
       <div class="request-fulfillment">

--- a/app/components/request_rgi_footer.html.erb
+++ b/app/components/request_rgi_footer.html.erb
@@ -1,0 +1,4 @@
+<div class="rgi-footer pt-2 fs-14 text-body-secondary d-flex gap-sm-3 flex-sm-row flex-column text-body-secondary small">
+  <% if request_id %><div>Request #<%= request_id %></div><% end %>
+  <span>Date added/modified: <span class="text-nowrap"><%= l(date, format: :full) %></span></span>
+</div>

--- a/app/components/request_rgi_footer.rb
+++ b/app/components/request_rgi_footer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Render a form
+class RequestRgiFooter < ViewComponent::Base
+  attr_reader :request_id, :date
+
+  def initialize(date:, request_id: nil)
+    @request_id = request_id
+    @date = date
+  end
+end


### PR DESCRIPTION
This PR fixes the following two issues
- There is no space between planned visit date and the date
- The footer had misalignment across three request types (see screenshot). The date isn't the correct font-size (figma has it as 14px) this cleans it up and places the html it in one place. 

Before:
<img width="846" height="216" alt="Screenshot 2026-07-30 at 12 48 26 PM" src="https://github.com/user-attachments/assets/45009cf5-001c-40bc-9e69-a732c87f7e8e" />


After:
<img width="856" height="443" alt="Screenshot 2026-07-30 at 12 43 35 PM" src="https://github.com/user-attachments/assets/0feb589a-4acb-4f13-a994-4bdc022949f0" />

Figma
<img width="631" height="176" alt="Screenshot 2026-07-30 at 12 50 14 PM" src="https://github.com/user-attachments/assets/87755a3f-15e5-4dbe-b907-56cc2089aae9" />

