### PR TITLE
Use the alert component for the shared computer warning

### DIFF
--- a/app/assets/stylesheets/colors.css
+++ b/app/assets/stylesheets/colors.css
@@ -65,6 +65,11 @@ input[type="radio"] {
   color: rgb(88, 21, 28);
 }
 
+/* Restore the upstream bootstrap warning alert color. */
+.alert-warning {
+  --bs-alert-color: var(--bs-alert-border-color);
+}
+
 /* Restore disabled primary button styling from upstream bootstrap. */
 .btn-primary {
   --bs-btn-disabled-color: #fff;

--- a/app/views/fines/_shared_computer_alert.html.erb
+++ b/app/views/fines/_shared_computer_alert.html.erb
@@ -2,9 +2,9 @@
 <% if fines.sum(&:owed).positive? %>
   <div>
     <% if patron_or_group.can_pay_fines? %>
-        <div class="alert alert-warning" role="alert">
-            <b>Shared computer users: </b>Due to security risks, you should not use a shared computer to make a payment.
-        </div>
+      <%= render AlertComponent.new(type: :warning) do %>
+        <b>Shared computer users: </b>Due to security risks, you should not use a shared computer to make a payment.
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -1,5 +1,5 @@
-<%= render 'fines/shared_computer_alert' %>
 <div class="col-lg-9">
+  <%= render 'fines/shared_computer_alert' %>
   <div class="d-sm-flex mb-4">
     <h1 class="mt-2 me-3">Fees and fines</h1>
     <ul class="nav nav-tabs">


### PR DESCRIPTION
I need to bring in the `alert-warning` color for https://github.com/sul-dlss/sul-requests/pull/4274, but this shared computer warning throws an AXE color contrast error because it's using the old style. I'm hoping this fixes it.

<img width="924" height="380" alt="Screenshot 2026-07-30 at 4 32 49 PM" src="https://github.com/user-attachments/assets/a6c05f22-8f0e-4230-8f77-d699cbd64792" />
