### PR TITLE
Don't render an empty ul if there are no requests.

### DIFF
--- a/app/components/system/grouped_requests_layout_component.html.erb
+++ b/app/components/system/grouped_requests_layout_component.html.erb
@@ -22,8 +22,8 @@
   <% c.with_body(data: ({ controller: 'show-more'} if show_more?)) do %>
     <%= body %>
 
-    <%= tag.ul id: "#{id}_list", class: 'list-group list-group-flush gap-2', data: { sortable_target: ('subgroup' if sortable?), show_more_target: ('list' if show_more?) } do %>
-      <% if requests? %>
+    <% if requests? %>
+      <%= tag.ul id: "#{id}_list", class: 'list-group list-group-flush gap-2', data: { sortable_target: ('subgroup' if sortable?), show_more_target: ('list' if show_more?) } do %>
         <% requests.each do |request| %>
           <%= request %>
         <% end %>

--- a/app/components/system/grouped_requests_layout_component.rb
+++ b/app/components/system/grouped_requests_layout_component.rb
@@ -38,7 +38,7 @@ module System
     end
 
     def show_more?
-      @show_more
+      @show_more && requests?
     end
   end
 end


### PR DESCRIPTION
Empty ul elements aren't great for accessibility. I'm not totally convinced this case exists in the real world, but easy enough to bump the condition up.