### PR TITLE
Call number cleanup

### DIFF
--- a/app/components/folio/request_component.html.erb
+++ b/app/components/folio/request_component.html.erb
@@ -3,7 +3,7 @@
     <% if request.vol_enum_chron.present? %>
       <%= request.vol_enum_chron %>
     <% elsif request.call_number %>
-      <span class="fw-normal">Call number: </span><%= request.call_number %>
+      <span class="fw-normal me-1">Call number:</span><%= request.call_number %>
     <% end %>
   <% end %>
 

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -69,10 +69,6 @@ module Folio
       status.start_with?('Open')
     end
 
-    def item_call_key
-      item&.dig('effectiveCallNumberComponents', 'callNumber')
-    end
-
     def contact_info
       location&.contact_info
     end


### PR DESCRIPTION
item_call_key isn't being called by anything. It is also redundant since we define the same thing in Folio::Record https://github.com/sul-dlss/sul-requests/blob/73d570e83f667182c0bac5f3f597052369a075f9/app/models/concerns/folio/folio_record.rb#L29

Before:
<img width="663" height="93" alt="Screenshot 2026-07-31 at 3 07 19 PM" src="https://github.com/user-attachments/assets/998c75b7-8a4e-4ad0-9d6a-bdb4a2e5a39b" />
After:
<img width="666" height="97" alt="Screenshot 2026-07-31 at 3 07 29 PM" src="https://github.com/user-attachments/assets/4d191605-2d56-4a4d-a057-2b3c36ac55a8" />
