### PR TITLE
Align the confirmation aside with the record header

### DIFF
--- a/app/views/patron_requests/_confirmation_screen.html.erb
+++ b/app/views/patron_requests/_confirmation_screen.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (mailer: false) %>
 <div class="row">
+  <h1>We received your <%= @patron_request.request_type == 'scan' ? 'digital scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
   <div class="confirmation col-12 col-lg-8">
-    <h1>We received your <%= @patron_request.request_type == 'scan' ? 'digital scan' : (@patron_request.mediateable? || @patron_request.aeon_page?) ? '' : 'pickup' %> request!</h1>
     <%= render RecordHeaderComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
         <% @patron_request.patron_request_items.map(&:folio_item).select(&:bound_with_child_holdings_record).each do |item| %>
           <%= render AlertComponent.new(type: :warning) do %>

--- a/app/views/patron_requests/_contact_aside.html.erb
+++ b/app/views/patron_requests/_contact_aside.html.erb
@@ -1,5 +1,5 @@
 
-<aside class="col-3 d-none d-lg-block">
+<aside class="col-3 d-none d-lg-block mt-4">
   <% if @patron_request.ead_doc %>
     <h2>Contact information</h2>
     <div>

--- a/app/views/patron_requests/show.html+aeon.erb
+++ b/app/views/patron_requests/show.html+aeon.erb
@@ -1,13 +1,13 @@
 <%= flash_column_classes 'col-12 col-lg-8' %>
 <div class="row">
+  <% if @patron_request.request_type == 'scan' %>
+    <h1>We received your digitization request!</h1>
+  <% elsif @patron_request.request_type == 'activity' %>
+    <h1>We received your activities request!</h1>
+  <% else %>
+    <h1>We received your reading room access request!</h1>
+  <% end %>
   <div class="confirmation col-12 col-lg-8">
-    <% if @patron_request.request_type == 'scan' %>
-      <h1>We received your digitization request!</h1>
-    <% elsif @patron_request.request_type == 'activity' %>
-      <h1>We received your activities request!</h1>
-    <% else %>
-      <h1>We received your reading room access request!</h1>
-    <% end %>
     <%= render RecordHeaderComponent.new(record: @patron_request.bib_record, classes: 'bg-light mt-4 mb-4 p-4 rounded-0', title_classes: ['h3']) %>
     <div data-controller="aeon-confirmation-poll" data-aeon-confirmation-poll-attempts-value="0">
       <turbo-frame id="aeon-confirmation" data-aeon-confirmation-poll-target="frame">


### PR DESCRIPTION
Closes #4201 

I'm being a bit lazy here. If we refactored the `mt-4` out of the record header, there is likely a better solution. I think this seems fine for the moment.

<img width="1186" height="310" alt="Screenshot 2026-07-31 at 2 27 04 PM" src="https://github.com/user-attachments/assets/daac2d44-2037-42d8-aaeb-b9eae249e77f" />

<img width="1177" height="378" alt="Screenshot 2026-07-31 at 2 27 51 PM" src="https://github.com/user-attachments/assets/8ab070b2-28a1-4d2c-8376-5ed7e148b68f" />
