### PR TITLE
Fix appointment banner when selecting a day-only appointment.

### DIFF
--- a/app/javascript/controllers/appointment_controller.js
+++ b/app/javascript/controllers/appointment_controller.js
@@ -6,6 +6,14 @@ export default class extends Controller {
     availabilityRoute: String
   }
 
+  handleChange() {
+    if (this.hasAvailabilityTarget) {
+      this.refreshAvailability();
+    } else {
+      this.updateBanner();
+    }
+  }
+
   filterDurationFields() {
     const data = this.fieldsetTarget.dataset;
     const maxDuration = data.maxSlot;

--- a/app/views/aeon_appointments/_form.html.erb
+++ b/app/views/aeon_appointments/_form.html.erb
@@ -25,7 +25,7 @@
       <div class="d-flex align-items-center gap-3">
         <%= render DatePickerComponent.new(:date, form: f,
               schedule: Aeon::AppointmentSchedule.new(reading_room: @appointment.reading_room, appointment_id: @appointment.id, existing_appointments: existing_appointments),
-              data: { action: 'change->appointment#refreshAvailability', 'date-picker-marked-value': existing_appointments }) %>
+              data: { action: 'change->appointment#handleChange', 'date-picker-marked-value': existing_appointments }) %>
         <%= turbo_frame_tag 'earliest_appointment', src: available_aeon_reading_room_url(@appointment.reading_room_id, date: Date.today) %>
       </div>
       <% if f.object.errors[:date].any? %>

--- a/spec/features/aeon_appointment_spec.rb
+++ b/spec/features/aeon_appointment_spec.rb
@@ -119,14 +119,15 @@ RSpec.describe 'Appointments', :js do
         expect(page).to have_text 'Current'
         expect(page).to have_text appointment_start_time.strftime('%b %-d, %Y')
         expect(page).to have_no_text appointment_start_time.strftime('%l:%M %p')
-        expect(page).to have_text 'New'
-        expect(page).to have_text 'Select date'
+        expect(page).to have_text 'New Select date', normalize_ws: true
         expect(page).to have_text '1 item will move to the new appointment.'
 
         click_on appointment_start_time.strftime('%b %-d, %Y')
         click_on 'Next month'
 
         first('td[role="gridcell"]:not(:has(button:disabled))').click
+
+        expect(page).to have_no_text 'New Select date', normalize_ws: true
 
         click_on 'Save'
       end


### PR DESCRIPTION
Fixes #4320 

https://github.com/sul-dlss/sul-requests/pull/4051) and https://github.com/sul-dlss/sul-requests/pull/4086 didn't play nice together. `handleChange` isn't very stimulus-y, but a better quick fix eludes me. 