### PR TITLE
Include icons helper in the mailer

### DIFF
--- a/app/mailers/patron_request_mailer.rb
+++ b/app/mailers/patron_request_mailer.rb
@@ -6,6 +6,7 @@
 ###
 class PatronRequestMailer < ApplicationMailer
   helper :requests
+  helper :icons
   helper_method :use_requests_redesign?
 
   def confirmation_email(patron_request)

--- a/spec/mailers/patron_request_mailer_spec.rb
+++ b/spec/mailers/patron_request_mailer_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe PatronRequestMailer do
       expect(mail.body).to include('In library use only')
       expect(mail.body).to include('ABC 123')
     end
+
+    context 'when the bib record has a document_type that triggers icon rendering' do
+      before do
+        allow(request.bib_record).to receive_messages(document_type: 'Book', document_formats: ['Book'])
+      end
+
+      it 'renders the format indicator without raising for the missing helper' do
+        expect { mail.body }.not_to raise_error
+        expect(mail.body).to include('Book')
+      end
+    end
   end
 
   context 'scan request_type' do


### PR DESCRIPTION
Closes #4329

We should look harder at the exact format of the mail we want to send in the future, but not throwing an error seems like a good first start.