### PR TITLE
requests header cleanup

### DIFF
--- a/app/assets/stylesheets/utility.css
+++ b/app/assets/stylesheets/utility.css
@@ -114,7 +114,7 @@ label.btn-close {
 
 .rounded-pill {
   padding-top: 4px;
-  padding-bottom: 2px;
+  padding-bottom: 4px;
   padding-left: 12px;
   padding-right: 12px;
 }

--- a/app/components/system/grouped_requests_layout_component.rb
+++ b/app/components/system/grouped_requests_layout_component.rb
@@ -7,7 +7,7 @@ module System
       pill: ->(content:) { render PillComponent.new(classes: %w[bg-lagunita-dark text-white]).with_content(content) }
     }
     renders_one :details, lambda { |content|
-      tag.span content, class: 'ms-2 ps-1 text-nowrap text-lagunita-dark'
+      tag.span content, class: 'ms-2 text-nowrap text-lagunita-dark align-middle'
     }
 
     renders_one :status_message


### PR DESCRIPTION
For some reason we are aligning the pills near the bottom. I can't see anything in the figma that indicates we should be doing that.

Before:
<img width="165" height="56" alt="Screenshot 2026-08-03 at 4 57 38 PM" src="https://github.com/user-attachments/assets/214ec406-8ab6-4d7a-bcd7-86e0b6feb874" />
After:
<img width="152" height="60" alt="Screenshot 2026-08-03 at 5 01 27 PM" src="https://github.com/user-attachments/assets/1fa0ec50-a19a-4484-808e-8a3ee9b00429" />


Figma:
<img width="179" height="73" alt="Screenshot 2026-08-03 at 5 00 21 PM" src="https://github.com/user-attachments/assets/032091f3-74f9-436f-a4d6-9a61d63c1f2b" />

Also the detail text isn't aligned properly

Before:
<img width="396" height="64" alt="Screenshot 2026-08-03 at 5 07 33 PM" src="https://github.com/user-attachments/assets/3716c418-7962-4f2f-ace9-35e2325d0014" />
<img width="371" height="59" alt="Screenshot 2026-08-03 at 5 08 55 PM" src="https://github.com/user-attachments/assets/65007880-6e96-467c-9a21-649899a8bb36" />


After:
<img width="430" height="71" alt="Screenshot 2026-08-03 at 5 07 49 PM" src="https://github.com/user-attachments/assets/e9509d50-1384-4b6d-87f2-63068382e0f6" />
<img width="393" height="80" alt="Screenshot 2026-08-03 at 5 09 23 PM" src="https://github.com/user-attachments/assets/7ed00054-0acf-4106-8a9a-3a279d889a92" />


Figma:


<img width="388" height="69" alt="Screenshot 2026-08-03 at 5 08 08 PM" src="https://github.com/user-attachments/assets/40ed6fa0-53fc-431e-9bfe-7a85e91e2a9b" />
