### PR TITLE
fix title sort on checkouts

### DIFF
--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -127,17 +127,21 @@ module Folio
       SHORT_TERM_LOAN_PERIODS.include?(loan_policy_interval)
     end
 
+    def title_no_punctuation
+      title&.gsub(/[^\w\s]/, '')
+    end
+
     # rubocop:disable Metrics/MethodLength
     def sort_key(key)
       sort_key = case key
                  when :status
-                   [status_sort_key, title, author, shelf_key]
+                   [status_sort_key, title_no_punctuation, author, shelf_key]
                  when :due_date
-                   [due_date_sort_value, title, author, shelf_key]
+                   [due_date_sort_value, title_no_punctuation, author, shelf_key]
                  when :title
-                   [title, author, shelf_key]
+                   [title_no_punctuation, author, shelf_key]
                  when :author
-                   [author, title, shelf_key]
+                   [author, title_no_punctuation, shelf_key]
                  when :call_number
                    [shelf_key]
                  end

--- a/spec/factories/mylibrary_patrons.rb
+++ b/spec/factories/mylibrary_patrons.rb
@@ -256,7 +256,7 @@ FactoryBot.define do
                'effectiveLocation' => { 'code' => 'ART-STACKS', 'library' => { 'code' => 'ART' } },
                'permanentLocation' => { 'code' => 'ART-STACKS' } } },
            'loanDate' => '2023-06-03T06:08:45.521+00:00',
-           'dueDate' => '2020-09-27T06:59:59.000+00:00',
+           'dueDate' => '2020-10-27T06:59:59.000+00:00',
            'overdue' => false,
            'details' =>
            { 'renewalCount' => nil,
@@ -268,7 +268,7 @@ FactoryBot.define do
          { 'id' => 'e8d0dd5c-2b69-420f-bd91-075eebbe8eba',
            'item' =>
            { 'title' =>
-             'See this sound',
+             '"See" this sound',
              'author' => 'Daniels, Dieter; Naumann, Sandra; Thoben, Jan',
              'instanceId' => 'abdb8f6a-d3c3-5f7e-921c-0cfc4835f3bc',
              'itemId' => '95acc0f1-d699-5723-a89b-3329279a05d5',

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -132,6 +132,9 @@ RSpec.describe 'Checkout Page' do
     within '#checkouts' do
       expect(page).to have_css('.dropdown-toggle', text: 'Sort by due date')
       click_on 'Sort by due date'
+      due_date_order = page.all('ul.checkouts-list li').map { |li| li.find('h2').text }
+
+      expect(due_date_order).to eq ['Blue-collar Broadway', '"See" this sound', 'Music, sound, language, theater']
 
       within '[data-sortable-target="sortMenu"] .dropdown-menu' do
         click_on 'title'
@@ -140,9 +143,8 @@ RSpec.describe 'Checkout Page' do
       expect(page).to have_css('.dropdown-toggle', text: 'Sort by title')
       expect(page).to have_css('.active[data-sortable-sort-param="title"]', visible: :all)
 
-      within(first('ul.checkouts-list li')) do
-        expect(page).to have_text(/Blue-collar Broadway/)
-      end
+      title_order = page.all('ul.checkouts-list li').map { |li| li.find('h2').text }
+      expect(title_order).to eq ['Blue-collar Broadway', 'Music, sound, language, theater', '"See" this sound']
     end
   end
 

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Proxy User' do
       expect(page).to have_css('.checkouts-list li', count: 2)
 
       expect(page).to have_text('Music, sound, language, theater')
-      expect(page).to have_text('See this sound')
+      expect(page).to have_text('"See" this sound')
 
       expect(page).to have_no_text('Blue-collar Broadway')
     end


### PR DESCRIPTION
The sort is using the quotes to put titles first that shouldn't be first
Before:
<img width="707" height="959" alt="Screenshot 2026-08-05 at 3 11 10 PM" src="https://github.com/user-attachments/assets/3081cf97-924a-42d8-a7dc-1da7cab4df85" />

After:
<img width="741" height="842" alt="Screenshot 2026-08-05 at 3 11 40 PM" src="https://github.com/user-attachments/assets/71a5128a-7d26-43a6-ab8e-03dd0df9a755" />
