### PR TITLE
use call_number fields everywhere

### DIFF
--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -63,9 +63,7 @@ class FolioGraphqlClient
                 effectiveLocation {
                   code
                 }
-                effectiveCallNumberComponents {
-                  callNumber
-                }
+                #{call_number_fields}
                 instance {
                   title
                 }
@@ -441,9 +439,7 @@ class FolioGraphqlClient
                                           name
                                         }
                                         effectiveShelvingOrder
-                                        effectiveCallNumberComponents {
-                                          callNumber
-                                        }
+                                        #{call_number_fields}
                                         permanentLoanTypeId
                                         temporaryLoanTypeId
                                         materialTypeId


### PR DESCRIPTION
I don't know if there is more to. I would assume so because the location of "SUL" seems not great but that seems separate/needs design.
https://stanfordlib.slack.com/archives/C0BC9PRQHEH/p1785958212037889

But we should be calling the same fields every time we need a call number. This normalizes calling of the call number.

Before:

<img width="691" height="455" alt="Screenshot 2026-08-05 at 5 21 31 PM" src="https://github.com/user-attachments/assets/b10b7b66-ac92-4c14-8b07-a2e668d6e9c6" />

After:
<img width="981" height="654" alt="Screenshot 2026-08-05 at 5 19 00 PM" src="https://github.com/user-attachments/assets/1d9efd48-5080-4059-8dbe-56c3d60958c5" />

