### PR TITLE
add SUL-ILLIAD to ILL_LOCATION_CODES

### DIFF
--- a/app/models/folio/record_location.rb
+++ b/app/models/folio/record_location.rb
@@ -4,7 +4,7 @@ module Folio
   # Determines the presentable library or location for a checkout or request record
   class RecordLocation
     # TODO: Add FOLIO ILL code once we know what it is
-    ILL_LOCATION_CODES = %w[SUL-BORROW-DIRECT].freeze
+    ILL_LOCATION_CODES = %w[SUL-BORROW-DIRECT SUL-ILLIAD].freeze
 
     def initialize(item)
       @item = item


### PR DESCRIPTION
I don't know if this is actually correct in terms of visual but it is correct in terms of logic. 

- Removes searchworks link that shouldn't be showing up because the record is not visible in searchworks
- Changes library name from SUL to Illiad

Before:
<img width="453" height="141" alt="image" src="https://github.com/user-attachments/assets/afb1f8fb-a623-4550-9bf1-88561936ed8d" />


After:
<img width="289" height="116" alt="Screenshot 2026-08-05 at 5 41 14 PM" src="https://github.com/user-attachments/assets/b0f2f356-3812-4db2-88aa-1a4edb0e1f30" />


