### PR TITLE
Include "in progress" activities on the home page card

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -2,4 +2,10 @@
 
 # Helpers for the home page redesign views.
 module HomeHelper
+  def activities_card_label(in_progress:, upcoming:)
+    return t('dashboard.activities.label_html', count: upcoming) if in_progress.zero?
+    return t('dashboard.activities.in_progress_label_html', count: in_progress) if upcoming.zero?
+
+    t('dashboard.activities.in_progress_with_upcoming_label_html', in_progress:, upcoming:)
+  end
 end

--- a/app/models/aeon/activity.rb
+++ b/app/models/aeon/activity.rb
@@ -45,6 +45,12 @@ module Aeon
       status == 'Completed'
     end
 
+    def in_progress?
+      return false unless start_time && stop_time
+
+      (start_time..stop_time).cover?(Time.zone.now)
+    end
+
     def requests=(requests)
       @requests = requests.submitted.sort_by(&:default_sort_key)
       @grouped_requests = nil

--- a/app/models/aeon/scheduled_finders.rb
+++ b/app/models/aeon/scheduled_finders.rb
@@ -5,14 +5,23 @@ module Aeon
   # respond to `start_time`). Includers must be Enumerable and accept an
   # array of items in their initializer.
   module ScheduledFinders
-    # Upcoming items that start within `within`, sorted by start time; if none
-    # fall in that range, falls back to the next `fallback` upcoming items.
+    # Items that start within `within`, plus items already in progress, sorted
+    # by start time; if none fall in that range, falls back to the next
+    # `fallback` items. An item is in progress until its stop time passes.
     def upcoming(within:, fallback:)
       now = Time.zone.now
-      future = select { |item| item.start_time && item.start_time >= now }.sort_by(&:start_time)
+      future = select { |item| unfinished?(item, now) }.sort_by(&:start_time)
       cutoff = within.from_now
       in_window = future.take_while { |item| item.start_time <= cutoff }
       in_window.any? ? in_window : future.first(fallback)
+    end
+
+    private
+
+    def unfinished?(item, now)
+      return false unless item.start_time
+
+      item.start_time >= now || (item.stop_time.present? && item.stop_time >= now)
     end
   end
 end

--- a/app/models/home/dashboard.rb
+++ b/app/models/home/dashboard.rb
@@ -88,9 +88,22 @@ module Home
       aeon.activities.any?
     end
 
+    def activities_in_progress_count
+      @activities_in_progress_count ||= upcoming_activities&.count(&:in_progress?) || 0
+    end
+
+    def activities_upcoming_count
+      @activities_upcoming_count ||= (upcoming_activities&.count || 0) - activities_in_progress_count
+    end
+
+    # The next activity to start. An activity already in progress is reported by
+    # the card body instead, because its start date has passed.
+    def next_activity
+      @next_activity ||= upcoming_activities&.reject(&:in_progress?)&.first
+    end
+
     def next_activity_date
-      first_activity = upcoming_activities&.first
-      @next_activity_date ||= first_activity&.start_time&.to_date
+      next_activity&.start_time&.to_date
     end
 
     def upcoming_activities

--- a/app/views/home/show_aeon.html.erb
+++ b/app/views/home/show_aeon.html.erb
@@ -40,7 +40,7 @@
           id: 'aeon-activities',
           title: 'Activities',
           icon_class: 'bi-person-video3',
-          label: t('dashboard.activities.label_html', count: @dashboard.upcoming_activities.count),
+          label: activities_card_label(in_progress: @dashboard.activities_in_progress_count, upcoming: @dashboard.activities_upcoming_count),
           path: @dashboard.upcoming_activities.count.positive? ? aeon_activities_path : aeon_activities_path(past: 'true'),
           link_label: @dashboard.upcoming_activities.count.zero? ? 'View past activities' : nil) do |c| %>
           <% c.with_status_next_up(date: @dashboard.next_activity_date) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,3 +331,5 @@ en:
         zero: 'No upcoming activities'
         one: '<span class="fw-semibold fs-5">1</span> upcoming activity'
         other: '<span class="fw-semibold fs-5">%{count}</span> upcoming activities'
+      in_progress_label_html: '<span class="fw-semibold fs-5">%{count}</span> in progress'
+      in_progress_with_upcoming_label_html: '<span class="fw-semibold fs-5">%{in_progress}</span> in progress, <span class="fw-semibold fs-5">%{upcoming}</span> upcoming'

--- a/spec/component_previews/home/card_view/summary_card_component_preview.rb
+++ b/spec/component_previews/home/card_view/summary_card_component_preview.rb
@@ -107,31 +107,29 @@ module Home
         )
       end
 
+      # No activity is upcoming, so the card sends the user to the past ones.
       def activities_empty
-        render Home::SummaryCardComponent.new(
-          title: 'Activities',
-          icon: 'bi-person-video3',
-          count: 0,
-          item_label: 'upcoming activity',
-          empty_label: 'No upcoming activities',
-          path: '#',
-          empty_path: '#',
-          empty_link_label: 'View past activities'
-        )
+        render activities_card(in_progress: 0, upcoming: 0, link_label: 'View past activities')
       end
 
+      # One activity, still to start. The card reports the date it starts.
       def activities_with_next_up
-        render Home::SummaryCardComponent.new(
-          title: 'Activities',
-          icon: 'bi-person-video3',
-          count: 4,
-          item_label: 'upcoming activity',
-          empty_label: 'No upcoming activities',
-          path: '#',
-          empty_path: '#',
-          empty_link_label: 'View past activities',
-          next_up_date: Date.new(2026, 6, 18)
-        )
+        render activities_card(in_progress: 0, upcoming: 1) do |c|
+          c.with_status_next_up(date: Date.new(2026, 6, 18))
+        end
+      end
+
+      # One activity, already started. Nothing is waiting to start, so no date shows.
+      def activities_in_progress
+        render activities_card(in_progress: 1, upcoming: 0)
+      end
+
+      # One activity in progress and one still to start. The body counts both kinds.
+      # The date belongs to the one still to start.
+      def activities_in_progress_with_another_upcoming
+        render activities_card(in_progress: 1, upcoming: 1) do |c|
+          c.with_status_next_up(date: Date.new(2026, 6, 18))
+        end
       end
 
       def appointments_empty
@@ -161,6 +159,19 @@ module Home
           secondary_label: 'item',
           secondary_label_suffix: 'scheduled',
           next_up_date: Date.new(2026, 6, 18)
+        )
+      end
+
+      private
+
+      def activities_card(in_progress:, upcoming:, link_label: nil)
+        Home::SummaryCardComponent.new(
+          id: 'aeon-activities',
+          title: 'Activities',
+          icon_class: 'bi-person-video3',
+          label: ApplicationController.helpers.activities_card_label(in_progress:, upcoming:),
+          path: '#',
+          link_label:
         )
       end
     end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -107,5 +107,74 @@ RSpec.describe 'Home Page' do
         expect(page).to have_css('.card', text: 'Activities')
       end
     end
+
+    context 'with an activity that has not started yet' do
+      let(:patron) { Folio::NullPatron.new }
+
+      before do
+        activity = build(:aeon_activity, start_time: 2.days.from_now, stop_time: 4.days.from_now)
+        allow(aeon_user).to receive(:activities).and_return(Aeon::ActivityFinders.new([activity]))
+      end
+
+      it 'shows the start date as the next one up' do
+        visit root_path
+
+        expect(page).to have_css('.card', text: '1 upcoming activity')
+        expect(page).to have_css('.card', text: "Next up: #{2.days.from_now.strftime('%b %-d, %Y')}")
+      end
+    end
+
+    context 'with an activity already in progress' do
+      let(:patron) { Folio::NullPatron.new }
+
+      before do
+        activity = build(:aeon_activity, start_time: 1.day.ago, stop_time: 3.days.from_now)
+        allow(aeon_user).to receive(:activities).and_return(Aeon::ActivityFinders.new([activity]))
+      end
+
+      it 'counts the activity as in progress' do
+        visit root_path
+
+        expect(page).to have_css('.card', text: '1 in progress')
+      end
+
+      it 'shows no next up date, because nothing is waiting to start' do
+        visit root_path
+
+        within('#aeon-activities') { expect(page).to have_no_text('Next up') }
+      end
+
+      it 'links to the current activities, not the past ones' do
+        visit root_path
+
+        within('#aeon-activities') do
+          expect(page).to have_link('View details', href: aeon_activities_path)
+        end
+      end
+    end
+
+    context 'with one activity in progress and another still to start' do
+      let(:patron) { Folio::NullPatron.new }
+
+      before do
+        activities = [
+          build(:aeon_activity, id: 1, start_time: 1.day.ago, stop_time: 3.days.from_now),
+          build(:aeon_activity, id: 2, start_time: 2.days.from_now, stop_time: 4.days.from_now)
+        ]
+        allow(aeon_user).to receive(:activities).and_return(Aeon::ActivityFinders.new(activities))
+      end
+
+      it 'counts each kind separately' do
+        visit root_path
+
+        expect(page).to have_css('.card', text: '1 in progress, 1 upcoming')
+      end
+
+      it 'shows the start date of the one still to start' do
+        visit root_path
+
+        expect(page).to have_css('.card', text: "Next up: #{2.days.from_now.strftime('%b %-d, %Y')}")
+      end
+    end
   end
 end

--- a/spec/models/aeon/activity_finders_spec.rb
+++ b/spec/models/aeon/activity_finders_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe Aeon::ActivityFinders do
     let(:tomorrow) { build(:aeon_activity, id: 12, start_time: now + 1.day) }
     let(:far_future) { build(:aeon_activity, id: 13, start_time: now + 30.days) }
     let(:no_start) { build(:aeon_activity, id: 14, start_time: nil) }
+    let(:in_progress) { build(:aeon_activity, id: 15, start_time: now - 1.day, stop_time: now + 1.day) }
+    let(:ended) { build(:aeon_activity, id: 16, start_time: now - 3.days, stop_time: now - 1.day) }
+
+    it 'includes an activity that has started but not ended, before the ones still to start' do
+      finders = described_class.new([tomorrow, in_progress, soon])
+
+      expect(finders.upcoming(within: 7.days, fallback: 1).map(&:id)).to eq [15, 11, 12]
+    end
+
+    it 'excludes an activity whose stop_time has passed' do
+      finders = described_class.new([ended, soon])
+
+      expect(finders.upcoming(within: 7.days, fallback: 1).map(&:id)).to eq [11]
+    end
 
     it 'returns future activities within the window sorted by start_time' do
       finders = described_class.new([tomorrow, past, soon, far_future, no_start])

--- a/spec/models/aeon/activity_spec.rb
+++ b/spec/models/aeon/activity_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Aeon::Activity do
+  let(:now) { Time.zone.now }
+
+  describe '#in_progress?' do
+    it 'is true when now falls between the start and the stop' do
+      activity = build(:aeon_activity, start_time: now - 1.day, stop_time: now + 1.day)
+
+      expect(activity).to be_in_progress
+    end
+
+    it 'is false before the start' do
+      activity = build(:aeon_activity, start_time: now + 1.hour, stop_time: now + 2.hours)
+
+      expect(activity).not_to be_in_progress
+    end
+
+    it 'is false after the stop' do
+      activity = build(:aeon_activity, start_time: now - 2.days, stop_time: now - 1.day)
+
+      expect(activity).not_to be_in_progress
+    end
+
+    it 'is false without a stop_time' do
+      activity = build(:aeon_activity, start_time: now - 1.day, stop_time: nil)
+
+      expect(activity).not_to be_in_progress
+    end
+
+    it 'is false without a start_time' do
+      activity = build(:aeon_activity, start_time: nil, stop_time: now + 1.day)
+
+      expect(activity).not_to be_in_progress
+    end
+  end
+end


### PR DESCRIPTION
Closes #4358 

I guessed on our desired language/behavior here, Darcy hasn't seen it yet.

<img width="722" height="191" alt="Screenshot 2026-08-21 at 3 45 13 PM" src="https://github.com/user-attachments/assets/87e490e0-1892-4d14-9961-561fd47659dd" />
