### PR TITLE
Aeon edit policies are day-granularity only

### DIFF
--- a/app/models/aeon/appointment.rb
+++ b/app/models/aeon/appointment.rb
@@ -83,7 +83,7 @@ module Aeon
     def editable?
       return true unless start_time
 
-      start_time.after?(edit_policy.days.from_now)
+      start_time.after?(edit_policy.days.from_now.beginning_of_day)
     end
 
     def item_limit


### PR DESCRIPTION
... so don't worry about the current time when figuring out if we're in-range or not.